### PR TITLE
[cli] [core] [nextjs] Add file extension property to ScaffoldTemplate

### DIFF
--- a/packages/cli/src/scripts/scaffold.test.ts
+++ b/packages/cli/src/scripts/scaffold.test.ts
@@ -19,6 +19,7 @@ describe('scaffold command', () => {
       templates: [
         {
           name: ComponentTemplateType.DEFAULT,
+          fileExtension: 'tsx',
           generateTemplate: (componentName: string) => {
             return componentName;
           },
@@ -26,6 +27,7 @@ describe('scaffold command', () => {
         },
         {
           name: ComponentTemplateType.BYOC,
+          fileExtension: 'tsx',
           generateTemplate: (componentName: string) => {
             return `${ComponentTemplateType.BYOC} ${componentName}`;
           },
@@ -33,6 +35,7 @@ describe('scaffold command', () => {
         },
         {
           name: 'customTemplate',
+          fileExtension: 'tsx',
           generateTemplate: (componentName: string) => {
             return 'customTemplate ' + componentName;
           },
@@ -88,13 +91,13 @@ dashes, or underscores. It can also contain slashes to indicate a subfolder`
     const argv = {
       componentName: 'ValidComponentName',
     };
-    const expectedOutputFilePath = path.join('src/components', 'ValidComponentName.tsx');
+    const expectedOutputFFolderPath = 'src/components';
 
     handler(argv);
 
     expect(
       scaffoldComponentStub.calledOnceWith(
-        expectedOutputFilePath,
+        expectedOutputFFolderPath,
         'ValidComponentName',
         ComponentTemplateType.DEFAULT,
         mockConfig.scaffold.templates
@@ -107,13 +110,13 @@ dashes, or underscores. It can also contain slashes to indicate a subfolder`
       componentName: 'ValidComponentName',
       byoc: true,
     };
-    const expectedOutputFilePath = path.join('src/components', 'ValidComponentName.tsx');
+    const expectedOutputFFolderPath = 'src/components';
 
     handler(argv);
 
     expect(
       scaffoldComponentStub.calledOnceWith(
-        expectedOutputFilePath,
+        expectedOutputFFolderPath,
         'ValidComponentName',
         ComponentTemplateType.BYOC,
         mockConfig.scaffold.templates
@@ -127,13 +130,13 @@ dashes, or underscores. It can also contain slashes to indicate a subfolder`
       templateName: 'customTemplate',
       byoc: true,
     };
-    const expectedOutputFilePath = path.join('src/components', 'ValidComponentName.tsx');
+    const expectedOutputFFolderPath = 'src/components';
 
     handler(argv);
 
     expect(
       scaffoldComponentStub.calledOnceWith(
-        expectedOutputFilePath,
+        expectedOutputFFolderPath,
         'ValidComponentName',
         argv.templateName,
         mockConfig.scaffold.templates
@@ -148,7 +151,7 @@ dashes, or underscores. It can also contain slashes to indicate a subfolder`
       templateName: 'template',
       byoc: true,
     };
-    const expectedOutputFilePath = path.join('path/to', 'ValidComponentName.tsx');
+    const expectedOutputFilePath = 'path/to/';
     handler(argv);
     expect(
       scaffoldComponentStub.calledOnceWith(

--- a/packages/cli/src/scripts/scaffold.ts
+++ b/packages/cli/src/scripts/scaffold.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { scaffoldComponent } from '@sitecore-content-sdk/core/tools';
 import loadCliConfig from '../utils/load-config';
 import { Argv } from 'yargs';
@@ -92,10 +91,9 @@ dashes, or underscores. It can also contain slashes to indicate a subfolder`);
 
   const componentPath = regExResult[1];
   const componentName = regExResult[2];
-  const filename = `${componentName}.tsx`;
-  const outputFilePath = path.join(componentPath || 'src/components', filename);
+  const outputFolder = componentPath || 'src/components';
   const templateName =
     argv.templateName ?? (argv.byoc ? ComponentTemplateType.BYOC : ComponentTemplateType.DEFAULT);
 
-  scaffoldComponent(outputFilePath, componentName, templateName, cliConfig.scaffold.templates);
+  scaffoldComponent(outputFolder, componentName, templateName, cliConfig.scaffold.templates);
 }

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -225,6 +225,10 @@ export type ScaffoldTemplate = {
    */
   name: string;
   /**
+   * File extension for the generated component.
+   */
+  fileExtension: string;
+  /**
    * Function to generate the component file contents based on the component name.
    * @param componentName - The name of the component.
    * @returns The generated content as a string.

--- a/packages/core/src/tools/scaffold.test.ts
+++ b/packages/core/src/tools/scaffold.test.ts
@@ -93,32 +93,40 @@ describe('scaffold', () => {
     const templates = [
       {
         name: 'default',
+        fileExtension: 'tsx',
         generateTemplate: sinon.stub().returns('default template content'),
         getNextSteps: sinon.stub().returns(['Step 1', 'Step 2']),
       },
       {
         name: 'byoc',
+        fileExtension: 'tsx',
         generateTemplate: sinon.stub().returns('byoc template content'),
         getNextSteps: sinon.stub().returns(['BYOC Step 1', 'BYOC Step 2']),
       },
       {
         name: 'customTemplate',
+        fileExtension: 'tsx',
         generateTemplate: sinon.stub().returns('custom template content'),
         getNextSteps: sinon.stub().returns(['custom Step 1', 'custom Step 2']),
       },
     ];
 
     it('should scaffold component with default template', () => {
-      const outputFilePath = 'output/path';
+      const outputFolderPath = 'output/path';
       const componentName = 'MyComponent';
       const templateName = 'default';
       const template = templates.filter((t) => t.name === 'default')[0];
-      existsStub.withArgs(outputFilePath).returns(false);
-      scaffoldComponent(outputFilePath, componentName, templateName, templates);
+      existsStub.withArgs(outputFolderPath).returns(false);
+      scaffoldComponent(outputFolderPath, componentName, templateName, templates);
 
       expect(template.generateTemplate.calledWith(componentName)).to.be.true;
-      expect(writeFileStub.calledWith(outputFilePath, template.generateTemplate(), 'utf8')).to.be
-        .true;
+      expect(
+        writeFileStub.calledWith(
+          path.join(outputFolderPath, `${componentName}.${template.fileExtension}`),
+          template.generateTemplate(),
+          'utf8'
+        )
+      ).to.be.true;
       expect(consoleLogStub.calledWithMatch(`Scaffolding of ${componentName} complete.`)).to.be
         .true;
       expect(consoleLogStub.calledWithMatch(template.getNextSteps()[0])).to.be.true;
@@ -126,17 +134,22 @@ describe('scaffold', () => {
     });
 
     it('should scaffold component with byoc template', () => {
-      const outputFilePath = 'output/path';
+      const outputFolderPath = 'output/path';
       const componentName = 'MyByocComponent';
       const templateName = 'byoc';
       const template = templates.filter((t) => t.name === 'byoc')[0];
-      existsStub.withArgs(outputFilePath).returns(false);
+      existsStub.withArgs(outputFolderPath).returns(false);
 
-      scaffoldComponent(outputFilePath, componentName, templateName, templates);
+      scaffoldComponent(outputFolderPath, componentName, templateName, templates);
 
       expect(template.generateTemplate.calledWith(componentName)).to.be.true;
-      expect(writeFileStub.calledWith(outputFilePath, template.generateTemplate(), 'utf8')).to.be
-        .true;
+      expect(
+        writeFileStub.calledWith(
+          path.join(outputFolderPath, `${componentName}.${template.fileExtension}`),
+          template.generateTemplate(),
+          'utf8'
+        )
+      ).to.be.true;
       expect(consoleLogStub.calledWithMatch(`Scaffolding of ${componentName} complete.`)).to.be.be
         .true;
       expect(consoleLogStub.calledWithMatch(template.getNextSteps()[0])).to.be.true;
@@ -144,17 +157,22 @@ describe('scaffold', () => {
     });
 
     it('should scaffold component with custom template', () => {
-      const outputFilePath = 'output/path';
+      const outputFolderPath = 'output/path';
       const componentName = 'MyCustomComponent';
       const templateName = 'customTemplate';
       const template = templates.filter((t) => t.name === templateName)[0];
-      existsStub.withArgs(outputFilePath).returns(false);
+      existsStub.withArgs(outputFolderPath).returns(false);
 
-      scaffoldComponent(outputFilePath, componentName, templateName, templates);
+      scaffoldComponent(outputFolderPath, componentName, templateName, templates);
 
       expect(template.generateTemplate.calledWith(componentName)).to.be.true;
-      expect(writeFileStub.calledWith(outputFilePath, template.generateTemplate(), 'utf8')).to.be
-        .true;
+      expect(
+        writeFileStub.calledWith(
+          path.join(outputFolderPath, `${componentName}.${template.fileExtension}`),
+          template.generateTemplate(),
+          'utf8'
+        )
+      ).to.be.true;
       expect(consoleLogStub.calledWithMatch(`Scaffolding of ${componentName} complete.`)).to.be.be
         .true;
       expect(consoleLogStub.calledWithMatch(template.getNextSteps()[0])).to.be.true;

--- a/packages/core/src/tools/scaffold.ts
+++ b/packages/core/src/tools/scaffold.ts
@@ -37,14 +37,14 @@ export function scaffoldFile(filePath: string, fileContent: string): string | nu
 
 /**
  * Scaffolds a new component based on the provided template.
- * @param {string} outputFilePath - The file path where the component will be created.
+ * @param {string} outputFolderPath - The file path where the component will be created.
  * @param {string} componentName - The name of the component to be created.
  * @param {string} templateName - The name of the template to use for scaffolding. If not provided, defaults to 'byoc' if `byoc` is true, otherwise 'default'.
  * @param {ScaffoldTemplate[]} templates - An array of template objects, each containing a name, a template function, and a getNextSteps function.
  * @throws Will throw an error if the specified template is not found.
  */
 export function scaffoldComponent(
-  outputFilePath: string,
+  outputFolderPath: string,
   componentName: string,
   templateName: string,
   templates: ScaffoldTemplate[]
@@ -55,6 +55,7 @@ export function scaffoldComponent(
     throw new Error(`Template ${templateName} not found.`);
   }
 
+  const outputFilePath = path.join(outputFolderPath, `${componentName}.${template.fileExtension}`);
   const componentOutputPath = scaffoldFile(
     outputFilePath,
     template.generateTemplate(componentName)

--- a/packages/nextjs/src/config/define-cli-config.ts
+++ b/packages/nextjs/src/config/define-cli-config.ts
@@ -2,11 +2,10 @@ import {
   defineCliConfig as defineCliConfigCore,
   SitecoreCliConfigInput,
   SitecoreCliConfig,
-  ComponentTemplateType,
 } from '@sitecore-content-sdk/core/config';
 
-import * as byocTemplate from '../tools/templating/byoc-component';
-import * as defaultTemplate from '../tools/templating/default-component';
+import { byocTemplate } from '../tools/templating/byoc-component';
+import { defaultTemplate } from '../tools/templating/default-component';
 
 /**
  * Accepts a `SitecoreCliConfigInput` object and returns the Sitecore Content SDK CLI configuration from the specified file,
@@ -32,16 +31,5 @@ function addDefaultScaffoldTemplates(cliConfig: SitecoreCliConfigInput) {
     cliConfig.scaffold.templates = [];
   }
 
-  cliConfig.scaffold.templates.unshift(
-    {
-      name: ComponentTemplateType.DEFAULT,
-      generateTemplate: defaultTemplate.generateTemplate,
-      getNextSteps: defaultTemplate.getNextSteps,
-    },
-    {
-      name: ComponentTemplateType.BYOC,
-      generateTemplate: byocTemplate.generateTemplate,
-      getNextSteps: byocTemplate.getNextSteps,
-    }
-  );
+  cliConfig.scaffold.templates.unshift(defaultTemplate, byocTemplate);
 }

--- a/packages/nextjs/src/tools/templating/byoc-component.test.ts
+++ b/packages/nextjs/src/tools/templating/byoc-component.test.ts
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
-import { generateTemplate, getNextSteps } from './byoc-component';
+import { byocTemplate } from './byoc-component';
 import chalk from 'chalk';
 
 describe('byoc-component', () => {
   describe('generateTemplate', () => {
     it('should generate a template with the given component name', () => {
       const componentName = 'TestComponent';
-      const template = generateTemplate(componentName);
+      const template = byocTemplate.generateTemplate(componentName);
       expect(template).to.include(`interface ${componentName}Props`);
       expect(template).to.include(`<p>${componentName} Component</p>`);
       expect(template).to.include(`FEAAS.External.registerComponent(${componentName}`);
@@ -15,7 +15,7 @@ describe('byoc-component', () => {
 
   describe('getNextSteps', () => {
     it('should return an array with a step to modify component registration', () => {
-      const nextSteps = getNextSteps('');
+      const nextSteps = byocTemplate.getNextSteps && byocTemplate.getNextSteps('');
       expect(nextSteps)
         .to.be.an('array')
         .that.includes(
@@ -25,7 +25,7 @@ describe('byoc-component', () => {
 
     it('should return an array with next steps if componentOutputPath is provided', () => {
       const componentOutputPath = 'src/components/TestComponent.tsx';
-      const nextSteps = getNextSteps(componentOutputPath);
+      const nextSteps = byocTemplate.getNextSteps && byocTemplate.getNextSteps(componentOutputPath);
       expect(nextSteps)
         .to.be.an('array')
         .that.includes(

--- a/packages/nextjs/src/tools/templating/byoc-component.ts
+++ b/packages/nextjs/src/tools/templating/byoc-component.ts
@@ -1,11 +1,13 @@
 import chalk from 'chalk';
+import { ScaffoldTemplate, ComponentTemplateType } from '@sitecore-content-sdk/core/config';
+import { COMPONENT_FILE_EXTENSION } from './utils';
 
 /**
  * Next.js BYOC component boilerplate
  * @param {string} componentName - the component name
  * @returns component generated template
  */
-export const generateTemplate = (componentName: string): string => {
+const generateTemplate = (componentName: string): string => {
   return `import React from 'react';
 import * as FEAAS from '@sitecore-feaas/clientside/react';
 
@@ -53,7 +55,7 @@ FEAAS.External.registerComponent(${componentName}, {
  * @param {string} componentOutputPath - The file path where the component file is generated.
  * @returns {string[]} An array of strings, each representing a next step.
  */
-export const getNextSteps = (componentOutputPath: string): string[] => {
+const getNextSteps = (componentOutputPath: string): string[] => {
   const nextSteps = [];
 
   nextSteps.push(
@@ -65,4 +67,11 @@ export const getNextSteps = (componentOutputPath: string): string[] => {
   }
 
   return nextSteps;
+};
+
+export const byocTemplate: ScaffoldTemplate = {
+  name: ComponentTemplateType.BYOC,
+  fileExtension: COMPONENT_FILE_EXTENSION,
+  generateTemplate,
+  getNextSteps,
 };

--- a/packages/nextjs/src/tools/templating/default-component.test.ts
+++ b/packages/nextjs/src/tools/templating/default-component.test.ts
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
-import { generateTemplate, getNextSteps } from './default-component';
+import { defaultTemplate } from './default-component';
 import chalk from 'chalk';
 
 describe('default-component', () => {
   describe('generateTemplate', () => {
     it('should generate a template with the given component name', () => {
       const componentName = 'TestComponent';
-      const template = generateTemplate(componentName);
+      const template = defaultTemplate.generateTemplate(componentName);
       expect(template).to.include(`interface ${componentName}Props`);
       expect(template).to.include(`<p>${componentName} Component</p>`);
     });
@@ -14,13 +14,14 @@ describe('default-component', () => {
 
   describe('getNextSteps', () => {
     it('should return an empty array if no componentOutputPath is provided', () => {
-      const nextSteps = getNextSteps('');
+      const nextSteps = defaultTemplate.getNextSteps && defaultTemplate.getNextSteps('');
       expect(nextSteps).to.be.an('array').that.is.empty;
     });
 
     it('should return an array with next steps if componentOutputPath is provided', () => {
       const componentOutputPath = 'src/components/TestComponent.tsx';
-      const nextSteps = getNextSteps(componentOutputPath);
+      const nextSteps =
+        defaultTemplate.getNextSteps && defaultTemplate.getNextSteps(componentOutputPath);
       expect(nextSteps)
         .to.be.an('array')
         .that.includes(`* Implement the React component in ${chalk.green(componentOutputPath)}`);

--- a/packages/nextjs/src/tools/templating/default-component.ts
+++ b/packages/nextjs/src/tools/templating/default-component.ts
@@ -1,11 +1,13 @@
 import chalk from 'chalk';
+import { ScaffoldTemplate, ComponentTemplateType } from '@sitecore-content-sdk/core/config';
+import { COMPONENT_FILE_EXTENSION } from './utils';
 
 /**
  * Next.js component boilerplate
  * @param {string} componentName - the component name
  * @returns component generated template
  */
-export const generateTemplate = (componentName: string): string => {
+const generateTemplate = (componentName: string): string => {
   return `import React from 'react';
 import { ComponentParams, ComponentRendering } from '@sitecore-content-sdk/nextjs';
 
@@ -33,7 +35,7 @@ export const Default = (props: ${componentName}Props): JSX.Element => {
  * @param {string} componentOutputPath - The file path where the component file is generated.
  * @returns {string[]} An array of strings, each representing a next step.
  */
-export const getNextSteps = (componentOutputPath: string): string[] => {
+const getNextSteps = (componentOutputPath: string): string[] => {
   const nextSteps = [];
 
   if (componentOutputPath) {
@@ -41,4 +43,11 @@ export const getNextSteps = (componentOutputPath: string): string[] => {
   }
 
   return nextSteps;
+};
+
+export const defaultTemplate: ScaffoldTemplate = {
+  name: ComponentTemplateType.DEFAULT,
+  fileExtension: COMPONENT_FILE_EXTENSION,
+  generateTemplate,
+  getNextSteps,
 };

--- a/packages/nextjs/src/tools/templating/utils.ts
+++ b/packages/nextjs/src/tools/templating/utils.ts
@@ -1,6 +1,11 @@
 import chokidar from 'chokidar';
 
 /**
+ * The file extension for nextjs components
+ */
+export const COMPONENT_FILE_EXTENSION = 'tsx';
+
+/**
  * Run watch mode, watching on @var paths
  * @param {string[]} paths paths to watch by chokidar
  * @param {Function<void>} cb callback to run on file change


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removed hardcoded '.tsx' file extension when scaffolding a component, file extension is now a property of the ScaffoldTemplate type and can be provided along with the generateTemplate function. This will make scaffolding functionality generic and not tied to specific framework

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added/Updated
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
