### PR TITLE
[cli] Load config function now loads .env from the config file folder path if config parameter is passed

### DIFF
--- a/packages/cli/src/utils/load-config.ts
+++ b/packages/cli/src/utils/load-config.ts
@@ -1,6 +1,7 @@
 import { SitecoreCliConfig } from '@sitecore-content-sdk/core/types/config';
 import path from 'path';
 import fs from 'fs';
+import processEnv from './process-env';
 
 const tsx = require('tsx/cjs/api');
 
@@ -16,6 +17,14 @@ export default function loadCliConfig(configFile?: string): SitecoreCliConfig {
     configFile = './sitecore.cli.config.ts';
     if (!fs.existsSync(path.resolve(process.cwd(), configFile))) {
       configFile = './sitecore.cli.config.js';
+    }
+  } else {
+    // configuration file/filepath has been provided
+    // the env variables have been already loaded from the current working directory, however the current command may be running outside of a context of a project
+    // if so try loading the env vars from the directory of the provided config file
+    const configFileDirectory = path.dirname(path.resolve(process.cwd(), configFile));
+    if (process.cwd() !== configFileDirectory) {
+      processEnv(configFileDirectory);
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If configuration file/filepath has been provided with the  `--config` parameter, it is likely that the cli is running outside of the context of the app folder - so we may need to load the .env from the folder where the cli config is located.
This will make it possible to run scaffold command outside of the app folder, with the caveat that .env and the cli.config should be in the same location.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
