### PR TITLE
[nextjs] Fix chokidar import being fetched when importing config

### DIFF
--- a/packages/nextjs/src/tools/templating/byoc-component.ts
+++ b/packages/nextjs/src/tools/templating/byoc-component.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { ScaffoldTemplate, ComponentTemplateType } from '@sitecore-content-sdk/core/config';
-import { COMPONENT_FILE_EXTENSION } from './utils';
+import { COMPONENT_FILE_EXTENSION } from './constants';
 
 /**
  * Next.js BYOC component boilerplate

--- a/packages/nextjs/src/tools/templating/constants.ts
+++ b/packages/nextjs/src/tools/templating/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * The file extension for nextjs components
+ */
+export const COMPONENT_FILE_EXTENSION = 'tsx';

--- a/packages/nextjs/src/tools/templating/default-component.ts
+++ b/packages/nextjs/src/tools/templating/default-component.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { ScaffoldTemplate, ComponentTemplateType } from '@sitecore-content-sdk/core/config';
-import { COMPONENT_FILE_EXTENSION } from './utils';
+import { COMPONENT_FILE_EXTENSION } from './constants';
 
 /**
  * Next.js component boilerplate

--- a/packages/nextjs/src/tools/templating/utils.ts
+++ b/packages/nextjs/src/tools/templating/utils.ts
@@ -1,11 +1,6 @@
 import chokidar from 'chokidar';
 
 /**
- * The file extension for nextjs components
- */
-export const COMPONENT_FILE_EXTENSION = 'tsx';
-
-/**
  * Run watch mode, watching on @var paths
  * @param {string[]} paths paths to watch by chokidar
  * @param {Function<void>} cb callback to run on file change


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
App would fail when building and importing config:
You will get several errors:

```
Module not found: Can't resolve 'fs'

[Module Not Found](https://nextjs.org/docs/messages/module-not-found) 

Import trace for requested module:
../../packages/nextjs/node_modules/chokidar/index.js
../../packages/nextjs/dist/cjs/tools/templating/utils.js     
../../packages/nextjs/dist/cjs/tools/templating/byoc-component.js
../../packages/nextjs/dist/cjs/config/define-cli-config.js   
../../packages/nextjs/dist/cjs/config/index.js
../../packages/nextjs/config.js
./sitecore.config.ts
./src/Bootstrap.tsx
./src/pages/_app.tsx
```

This happens cause tools/templating/byoc-component file imports `/utils` and that imports chokidar, breaking the app early.
This fixes the problem.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
