### PR TITLE
[v2] Don't throw error when siteName is empty at deploy

### DIFF
--- a/packages/core/src/config/define-config.ts
+++ b/packages/core/src/config/define-config.ts
@@ -103,9 +103,6 @@ const validateConfig = (config: SitecoreConfigInput) => {
       );
     }
   }
-  if (!config.defaultSite) {
-    throw new Error('Configuration error: defaultSite value should be defined in sitecore.config');
-  }
 };
 
 /**

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -64,6 +64,7 @@ export type SitecoreConfigInput = {
   defaultLanguage: string;
   /**
    * Your default site name. When using the multisite feature this variable defines the fallback site.
+   * @default empty string
    */
   defaultSite?: string;
   /**


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR removes a forceful check for siteName being not empty in sitecore.config during deploy. Previously, this caused XM Cloud deployments to fail, as Deploy process does not set SITECORE_SITE_NAME and there is no site yet during deploy.

## Testing Details
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
