### PR TITLE
[Nextjs] Fix for custom error pages not rendering

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/404.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/404.tsx
@@ -36,7 +36,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
 
   return {
     props: {
-      layoutData: resultErrorPages?.serverErrorPage?.rendered || null,
+      layout: resultErrorPages?.notFoundPage?.rendered || null,
     },
   };
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/500.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/500.tsx
@@ -51,7 +51,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
 
   return {
     props: {
-      layoutData: resultErrorPages?.serverErrorPage?.rendered || null,
+      layout: resultErrorPages?.serverErrorPage?.rendered || null,
     },
   };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
In this PR we fixed the issue of custom error pages not showing in NextJs template. Previously 404 and 500 custom error pages were not displayed properly and would only show the default ones by NextJs. This is now addressed and the custom error pages are shown.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
