### PR TITLE
[core] Fix edge url trailing for styles as well

### DIFF
--- a/packages/core/src/client/graphql-edge-proxy.ts
+++ b/packages/core/src/client/graphql-edge-proxy.ts
@@ -1,7 +1,5 @@
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
-
-const normalizeUrl = (url: string) => (url.endsWith('/') ? url.slice(0, -1) : url);
-
+import { normalizeUrl } from '../utils/normalize-url';
 /**
  * Generates a URL for accessing Sitecore Edge Platform Content using the provided endpoint and context ID.
  * @param {string} sitecoreEdgeContextId - The unique context id.

--- a/packages/core/src/editing/design-library.test.ts
+++ b/packages/core/src/editing/design-library.test.ts
@@ -174,6 +174,14 @@ describe('component library utils', () => {
       );
     });
 
+    it('should handle trailing slash in sitecoreEdgeUrl', () => {
+      const customUrlWithSlash = 'https://custom-designlibrary.com/';
+      const scriptLink = getDesignLibraryScriptLink(customUrlWithSlash);
+      expect(scriptLink).to.equal(
+        'https://custom-designlibrary.com/v1/files/designlibrary/lib/rh-lib-script.js'
+      );
+    });
+
     it('should return the correct script link when a custom URL is provided', () => {
       const customUrl = 'https://custom-designlibrary.com';
       const scriptLink = getDesignLibraryScriptLink(customUrl);

--- a/packages/core/src/editing/design-library.ts
+++ b/packages/core/src/editing/design-library.ts
@@ -1,5 +1,6 @@
 import { ComponentRendering, Field, GenericFieldValue } from '../layout/models';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
+import { normalizeUrl } from '../utils/normalize-url';
 
 /**
  * Event to be sent when report status to design library
@@ -151,5 +152,5 @@ export function getDesignLibraryStatusEvent(
  * @returns The full URL to the design library script.
  */
 export function getDesignLibraryScriptLink(sitecoreEdgeUrl = SITECORE_EDGE_URL_DEFAULT): string {
-  return `${sitecoreEdgeUrl}/v1/files/designlibrary/lib/rh-lib-script.js`;
+  return `${normalizeUrl(sitecoreEdgeUrl)}/v1/files/designlibrary/lib/rh-lib-script.js`;
 }

--- a/packages/core/src/layout/content-styles.test.ts
+++ b/packages/core/src/layout/content-styles.test.ts
@@ -13,13 +13,43 @@ import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 describe('content-styles', () => {
   const truthyValue = { value: '<div class="test bar"><p class="foo ck-content">bar</p></div>' };
   const falsyValue = { value: '<div class="test bar"><p class="foo">ck-content</p></div>' };
-  const sitecoreEdgeContextId = ' 7qwerty';
+  const sitecoreEdgeContextId = '{7qwerty}';
 
   describe('getContentStylesheetLink', () => {
     it('should return null when route data is empty', () => {
       expect(
         getContentStylesheetLink({ sitecore: { context: {}, route: null } }, sitecoreEdgeContextId)
       ).to.be.null;
+    });
+
+    it('should handle trailing slash in sitecoreEdgeUrl', () => {
+      const layoutData: LayoutServiceData = {
+        sitecore: {
+          context: {},
+          route: {
+            name: 'route',
+            placeholders: {
+              car: [
+                {
+                  componentName: 'foo',
+                  fields: { car: falsyValue },
+                  placeholders: {
+                    bar: [{ componentName: 'cow', fields: { dog: truthyValue } }],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const sitecoreEdgeUrl = 'https://foo.bar/';
+      expect(
+        getContentStylesheetLink(layoutData, sitecoreEdgeContextId, sitecoreEdgeUrl)
+      ).to.deep.equal({
+        href: `https://foo.bar/v1/files/pages/styles/content-styles.css?sitecoreContextId=${sitecoreEdgeContextId}`,
+        rel: 'stylesheet',
+      });
     });
 
     it('should set "loadStyles: false" when layout does not have a ck-content class', () => {

--- a/packages/core/src/layout/content-styles.ts
+++ b/packages/core/src/layout/content-styles.ts
@@ -1,6 +1,7 @@
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 import { ComponentRendering, Field, Item, LayoutServiceData, RouteData } from './index';
 import { HTMLLink } from '../models';
+import { normalizeUrl } from '../utils/normalize-url';
 
 /**
  * Regular expression to check if the content styles are used in the field value
@@ -39,7 +40,9 @@ export const getContentStylesheetUrl = (
   sitecoreEdgeContextId: string,
   sitecoreEdgeUrl = SITECORE_EDGE_URL_DEFAULT
 ): string =>
-  `${sitecoreEdgeUrl}/v1/files/pages/styles/content-styles.css?sitecoreContextId=${sitecoreEdgeContextId}`;
+  `${normalizeUrl(
+    sitecoreEdgeUrl
+  )}/v1/files/pages/styles/content-styles.css?sitecoreContextId=${sitecoreEdgeContextId}`;
 
 export const traversePlaceholder = (components: Array<ComponentRendering>, config: Config) => {
   if (config.loadStyles) return;

--- a/packages/core/src/layout/themes.test.ts
+++ b/packages/core/src/layout/themes.test.ts
@@ -77,6 +77,29 @@ describe('themes', () => {
       ]);
     });
 
+    it('should handle trailing slash in sitecoreEdgeUrl when generating links', () => {
+      const sitecoreEdgeUrlWithSlash = 'https://edge-platform.sitecorecloud.io/';
+      expect(
+        getDesignLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'test',
+            fields: {
+              LibraryId: {
+                value: 'bar',
+              },
+            },
+          }),
+          sitecoreEdgeContextId,
+          sitecoreEdgeUrlWithSlash
+        )
+      ).to.deep.equal([
+        {
+          href: getStylesheetUrl('bar', sitecoreEdgeContextId, sitecoreEdgeUrlWithSlash),
+          rel: 'stylesheet',
+        },
+      ]);
+    });
+
     it('should return links using LibraryId field', () => {
       expect(
         getDesignLibraryStylesheetLinks(

--- a/packages/core/src/layout/themes.ts
+++ b/packages/core/src/layout/themes.ts
@@ -1,6 +1,7 @@
 import { ComponentRendering, LayoutServiceData, RouteData, getFieldValue } from '.';
 import { HTMLLink } from '../models';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
+import { normalizeUrl } from '../utils/normalize-url';
 
 /**
  * Pattern for library ids
@@ -37,7 +38,9 @@ export const getStylesheetUrl = (
   sitecoreEdgeContextId: string,
   sitecoreEdgeUrl = SITECORE_EDGE_URL_DEFAULT
 ) => {
-  return `${sitecoreEdgeUrl}/v1/files/components/styles/${id}.css?sitecoreContextId=${sitecoreEdgeContextId}`;
+  return `${normalizeUrl(
+    sitecoreEdgeUrl
+  )}/v1/files/components/styles/${id}.css?sitecoreContextId=${sitecoreEdgeContextId}`;
 };
 
 /**

--- a/packages/core/src/utils/normalize-url.ts
+++ b/packages/core/src/utils/normalize-url.ts
@@ -1,0 +1,1 @@
+export const normalizeUrl = (url: string) => (url.endsWith('/') ? url.slice(0, -1) : url);


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Ensures styles and component library URLs are correct when sitecoreEdgeUrl has trailing slash.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
