### PR TITLE
[nextjs-sample] Fix sitecore.config not initialing when running CLI in global mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ Our versioning strategy is as follows:
 - Major: may include breaking changes in core packages (e.g. major architectural changes, major features)
 
 ## Unreleased
+
+### Bug Fixes
+
+- Ensure sitecore.config always uses local .env values, for the sake of global Content SDK CLI ([#60](https://github.com/Sitecore/content-sdk/pull/60))

--- a/packages/cli/src/utils/load-config.test.ts
+++ b/packages/cli/src/utils/load-config.test.ts
@@ -89,7 +89,10 @@ describe('loadCliConfig', () => {
     tsxRequireStub.throws(new Error(errorMessage));
 
     expect(() => loadCliConfig(invalidConfig)).to.throw(
-      `Error while trying to load the cli configuration from ${invalidConfig}. Error message: ${errorMessage}`
+      `Error while trying to load the cli configuration from ${path.resolve(
+        process.cwd(),
+        invalidConfig
+      )}. Error message: ${errorMessage}`
     );
   });
 });

--- a/packages/cli/src/utils/load-config.ts
+++ b/packages/cli/src/utils/load-config.ts
@@ -33,9 +33,10 @@ export default function loadCliConfig(configFile?: string): SitecoreCliConfig {
   try {
     cliConfig = tsx.require(path.resolve(process.cwd(), configFile), __filename);
   } catch (e) {
-    throw `Error while trying to load the cli configuration from ${configFile}. Error message: ${
-      (e as Error).message
-    }`;
+    throw `Error while trying to load the cli configuration from ${path.resolve(
+      process.cwd(),
+      configFile
+    )}. Error message: ${(e as Error).message}`;
   }
 
   return cliConfig.default;

--- a/packages/create-sitecore-jss/src/templates/nextjs/sitecore.config.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/sitecore.config.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { defineConfig } from '@sitecore-content-sdk/nextjs/config';
 /**
  * @type {import('@sitecore-content-sdk/nextjs/config').SitecoreConfig}


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Ensures sitecore.config uses local .env always, when retrieving values.

## Testing Details
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
