### PR TITLE
[cli] Process env variables in both cli global and local mode by default.

### DIFF
--- a/packages/cli/src/bin/sitecore-tools.ts
+++ b/packages/cli/src/bin/sitecore-tools.ts
@@ -14,19 +14,21 @@ resolve('@sitecore-content-sdk/cli', { basedir: process.cwd() }, (error, project
     // library from a package.json. Instead, include it from a relative
     // path to this script file (which is likely a globally installed
     // npm package).
-    // Not erroring here because we might use this in future for scaffolding.
+    // Not erroring here because cli can be used in global mode.
     cli = require('../cli').default;
     console.warn(
       'Sitecore Content SDK CLI is running in global mode because it was not installed in the local node_modules folder.'
     );
   } else {
     // No error implies a projectLocalCli, which will load whatever
-    // version of jss-cli you have installed in a local package.json
+    // version of content sdk cli you have installed in a local package.json
     cli = require(projectLocalCli as string).default;
-
-    // Since we are in context of a project, load its environment variables
-    processEnv(process.cwd());
   }
+
+  // load environment variables from current working directory
+  // if the current working directory is not an app project root .env file will be missing and nothing will be loaded
+  // in that case loading environment variables will be handled by the actual cli command
+  processEnv(process.cwd());
 
   cli(commands);
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Load environment variables from current directory in both cli local and global mode by default when cli is invoked. This will fix cli commands throwing error when cli is invoked in global mode.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) test build/scaffold command work in cli global mode 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
