### PR TITLE
[react] Extend withDatasourceCheck logic to handle empty datasource in DesignLibrary mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ Our versioning strategy is as follows:
 - Major: may include breaking changes in core packages (e.g. major architectural changes, major features)
 
 ## Unreleased
+
+### 🐛 Bug Fixes
+
+* `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))

--- a/packages/react/src/enhancers/withDatasourceCheck.test.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.test.tsx
@@ -6,10 +6,11 @@ import { spy } from 'sinon';
 
 import { withDatasourceCheck, WithDatasourceCheckProps } from '../enhancers/withDatasourceCheck';
 import { SitecoreContextReactContext } from '../components/SitecoreContext';
+import { RenderingType } from '@sitecore-content-sdk/core/layout';
 
-const mockContext = (editing: boolean) => {
+const mockContext = (editing: boolean, renderingType?: RenderingType) => {
   return {
-    context: { pageEditing: editing },
+    context: { pageEditing: editing, renderingType },
     setContext: spy(),
   };
 };
@@ -92,6 +93,25 @@ describe('withDatasourceCheck', () => {
     );
 
     expect(wrapper.container.innerHTML).to.contain('Better than yours');
+  });
+
+  it('should return wrapped component if rendered in DesignLibrary', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '',
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false, RenderingType.Component)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
+    expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
   });
 
   it('should return wrapped component if datasource present in normal mode', () => {

--- a/packages/react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.tsx
@@ -1,5 +1,5 @@
 ﻿import React from 'react';
-import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
+import { ComponentRendering, RenderingType } from '@sitecore-content-sdk/core/layout';
 import { useSitecoreContext } from './withSitecoreContext';
 
 export const DefaultEditingError = (): JSX.Element => (
@@ -35,7 +35,10 @@ export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
       const { sitecoreContext } = useSitecoreContext();
       const EditingError = options?.editingErrorComponent ?? DefaultEditingError;
 
-      return props.rendering?.dataSource ? (
+      // If the component is rendered in DesignLibrary, we don't need to check for datasource
+      const isDesignLibrary = sitecoreContext?.renderingType === RenderingType.Component;
+
+      return isDesignLibrary || props.rendering?.dataSource ? (
         <Component {...props} />
       ) : sitecoreContext.pageEditing ? (
         <EditingError />


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Components rendered within the Design Library don’t require a datasource and are initialized with an empty one by default. We need to handle this case explicitly to avoid unnecessary validation errors.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
