### PR TITLE
[react][nextjs] Fix EditingScripts component being rendered twice. Fix 'dataSourceId' query parameter name in editing render middleware. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ Our versioning strategy is as follows:
 
 * `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))
 * `[cli]` Process env variables in both cli global and local mode by default. ([#61](https://github.com/Sitecore/content-sdk/pull/61))
+* `[react]` `[nextjs]` Do not render EditingScripts component in DesignLibrary component. Fix 'dataSourceId' query parameter name in editing render middleware. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,4 @@ Our versioning strategy is as follows:
 
 * `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))
 * `[cli]` Process env variables in both cli global and local mode by default. ([#61](https://github.com/Sitecore/content-sdk/pull/61))
-* `[react]` `[nextjs]` Do not render EditingScripts component in DesignLibrary component. Fix 'dataSourceId' query parameter name in editing render middleware. 
+* `[react]``[nextjs]` Do not render EditingScripts component in DesignLibrary component. Fix 'dataSourceId' query parameter name in editing render middleware. ([#64](https://github.com/Sitecore/content-sdk/pull/64))

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -379,7 +379,7 @@ describe('EditingRenderMiddleware', () => {
       sc_version: 'latest',
       secret: secret,
       sc_renderingId: '123',
-      sc_datasourceId: '456',
+      dataSourceId: '456',
       sc_uid: '789',
     };
 
@@ -399,7 +399,7 @@ describe('EditingRenderMiddleware', () => {
         language: query.sc_lang,
         site: query.sc_site,
         mode: 'library',
-        dataSourceId: query.sc_datasourceId,
+        dataSourceId: query.dataSourceId,
         version: query.sc_version,
       });
 

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -171,7 +171,7 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
           language: query.sc_lang,
           site: query.sc_site,
           mode: 'library',
-          dataSourceId: query.sc_datasourceId,
+          dataSourceId: query.dataSourceId,
           version: query.sc_version,
         } as DesignLibraryRenderPreviewData,
         {

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -14,7 +14,6 @@ import {
   DesignLibraryStatus,
   ComponentUpdateEventArgs,
   getDesignLibraryStatusEvent,
-  getDesignLibraryScriptLink,
 } from '@sitecore-content-sdk/core/editing';
 
 describe('<DesignLibrary />', () => {
@@ -88,7 +87,6 @@ describe('<DesignLibrary />', () => {
       { container: document.body }
     );
 
-    expect(rendered.baseElement.innerHTML).to.contain(`${getDesignLibraryScriptLink()}?cb=`);
     expect(rendered.baseElement.innerHTML).to.contain(
       [
         '<main><div id="editing-component">',
@@ -116,7 +114,6 @@ describe('<DesignLibrary />', () => {
       { container: document.body }
     );
 
-    expect(rendered.baseElement.innerHTML).to.contain(`${getDesignLibraryScriptLink()}?cb=`);
     expect(rendered.baseElement.innerHTML).to.contain(
       [
         '<main><div id="editing-component">',
@@ -142,7 +139,6 @@ describe('<DesignLibrary />', () => {
       { container: document.body }
     );
 
-    expect(rendered.baseElement.innerHTML).to.contain(`${getDesignLibraryScriptLink()}?cb=`);
     expect(rendered.baseElement.innerHTML).to.contain(
       [
         '<main><div id="editing-component">',
@@ -177,7 +173,6 @@ describe('<DesignLibrary />', () => {
       { container: document.body }
     );
 
-    expect(rendered.baseElement.innerHTML).to.contain(`${getDesignLibraryScriptLink()}?cb=`);
     expect(rendered.baseElement.innerHTML).to.contain(
       [
         '<main><div id="editing-component">',

--- a/packages/react/src/components/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary.tsx
@@ -11,7 +11,6 @@ import {
   getDesignLibraryStatusEvent,
   addComponentUpdateHandler,
 } from '@sitecore-content-sdk/core/editing';
-import { EditingScripts } from './EditingScripts';
 
 export const DesignLibrary = (layoutData: LayoutServiceData): JSX.Element => {
   const { route } = layoutData.sitecore;
@@ -59,7 +58,6 @@ export const DesignLibrary = (layoutData: LayoutServiceData): JSX.Element => {
 
   return (
     <>
-      <EditingScripts />
       <main>
         <div id={EDITING_COMPONENT_ID}>
           {route && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes two minor bugs:
- EditingScripts component rendered twice in case of Design Library request - fixed by removing EditingScripts from DesignLibrary component
- incorrect name of the `dataSourceId` query parameter in case of DesignLibrary request, causing component with datasource to not render properly. 

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added/Adjusted
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
