### PR TITLE
[nextjs] Render "unoptimized" Next Image in component rendering mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[nextjs]` Render "unoptimized" Next Image in component rendering mode ([#66](https://github.com/Sitecore/content-sdk/pull/66))
 * `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))
 * `[cli]` Process env variables in both cli global and local mode by default. ([#61](https://github.com/Sitecore/content-sdk/pull/61))
 * `[react]` `[nextjs]` Do not render EditingScripts component in DesignLibrary component. Fix 'dataSourceId' query parameter name in editing render middleware. ([#64](https://github.com/Sitecore/content-sdk/pull/64))

--- a/packages/nextjs/src/components/NextImage.test.tsx
+++ b/packages/nextjs/src/components/NextImage.test.tsx
@@ -10,6 +10,7 @@ import {
   LayoutServicePageState,
   SitecoreContextReactContext,
 } from '@sitecore-content-sdk/react';
+import { RenderingType } from '@sitecore-content-sdk/core/layout';
 import { ImageLoader } from 'next/image';
 import { spy, match } from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -553,6 +554,22 @@ describe('<NextImage />', () => {
         ...testContextProps,
         context: {
           pageState: LayoutServicePageState.Preview,
+        },
+      };
+      const rendered = render(
+        <SitecoreContextReactContext.Provider value={testEditingContext}>
+          <NextImage loader={mockLoader} {...props} />
+        </SitecoreContextReactContext.Provider>
+      ).container.querySelector('img');
+      expect(rendered?.getAttribute('data-unoptimized')).to.equal('true');
+    });
+
+    it('should render unoptimized image in component rendering type', () => {
+      const testEditingContext = {
+        ...testContextProps,
+        context: {
+          ...testContextProps.context,
+          renderingType: RenderingType.Component,
         },
       };
       const rendered = render(

--- a/packages/nextjs/src/components/NextImage.tsx
+++ b/packages/nextjs/src/components/NextImage.tsx
@@ -7,11 +7,15 @@ import {
   ImageFieldValue,
   withFieldMetadata,
   SitecoreContextReactContext,
+  DefaultEmptyFieldEditingComponentImage,
+  withEmptyFieldEditingComponent,
 } from '@sitecore-content-sdk/react';
 import Image, { ImageProps as NextImageProperties } from 'next/image';
-import { withEmptyFieldEditingComponent } from '@sitecore-content-sdk/react';
-import { DefaultEmptyFieldEditingComponentImage } from '@sitecore-content-sdk/react';
-import { isFieldValueEmpty, LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
+import {
+  isFieldValueEmpty,
+  LayoutServicePageState,
+  RenderingType,
+} from '@sitecore-content-sdk/core/layout';
 
 type NextImageProps = ImageProps & Partial<NextImageProperties>;
 export const NextImage: React.FC<NextImageProps> = withFieldMetadata<NextImageProps>(
@@ -38,9 +42,10 @@ export const NextImage: React.FC<NextImageProps> = withFieldMetadata<NextImagePr
         return null;
       }
 
-      // disable image optimization for Edit and Preview, but preserve original value if true
+      // disable image optimization for Edit / Preview / Component rendering, but preserve original value if true
       const unoptimized =
         otherProps.unoptimized ||
+        sitecoreContext.context?.renderingType === RenderingType.Component ||
         sitecoreContext.context?.pageState !== LayoutServicePageState.Normal;
 
       const attrs = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
We should avoid rendering optimized Next.js images in the Design Library, as image sources may vary and are not guaranteed to be listed in the remotePatterns configuration.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
