### PR TITLE
[core] Introduce ContentClient abstraction

### DIFF
--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -1,10 +1,8 @@
 /* eslint-disable dot-notation */
 import { expect } from 'chai';
 import sinon from 'sinon';
-// import debug from '../debug';
 import { ContentClient } from './content-client';
 import { GraphQLRequestClient } from '../graphql-request-client';
-import 'mocha';
 
 describe('content-client', () => {
   describe('constructor', () => {
@@ -26,7 +24,6 @@ describe('content-client', () => {
       expect(client.graphqlClient['headers']).to.deep.equal({
         Authorization: 'Bearer test-token',
       });
-      // expect(client.graphqlClient['debug']).to.deep.equal(debug.content);
     });
   });
 

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -1,0 +1,142 @@
+/* eslint-disable dot-notation */
+import { expect } from 'chai';
+import sinon from 'sinon';
+// import debug from '../debug';
+import { ContentClient } from './content-client';
+import { GraphQLRequestClient } from '../graphql-request-client';
+import 'mocha';
+
+describe('content-client', () => {
+  describe('constructor', () => {
+    it('should initialize endpoint and graphqlClient', () => {
+      const options = {
+        url: 'https://example.com',
+        tenant: 'test-tenant',
+        environment: 'test-env',
+        preview: true,
+        token: 'test-token',
+      };
+
+      const client = new ContentClient(options);
+
+      expect(client.endpoint).to.equal(
+        'https://example.com/api/graphql/v1/test-tenant/test-env?preview=true'
+      );
+      expect(client.graphqlClient).to.be.instanceOf(GraphQLRequestClient);
+      expect(client.graphqlClient['headers']).to.deep.equal({
+        Authorization: 'Bearer test-token',
+      });
+      // expect(client.graphqlClient['debug']).to.deep.equal(debug.content);
+    });
+  });
+
+  describe('createClient', () => {
+    it('should throw an error if tenant is not provided', () => {
+      expect(() =>
+        ContentClient.createClient({
+          token: 'test-token',
+        })
+      ).to.throw(
+        'Tenant is required to be provided as an argument or as a SITECORE_CS_TENANT environment variable'
+      );
+    });
+
+    it('should throw an error if token is not provided', () => {
+      expect(() =>
+        ContentClient.createClient({
+          tenant: 'test-tenant',
+        })
+      ).to.throw(
+        'Token is required to be provided as an argument or as a SITECORE_CS_TOKEN environment variable'
+      );
+    });
+
+    it('should create a ContentClient instance with default values', () => {
+      const client = ContentClient.createClient({
+        tenant: 'test-tenant',
+        token: 'test-token',
+      });
+
+      expect(client).to.be.instanceOf(ContentClient);
+      expect(client.endpoint).to.equal(
+        'https://cs-graphqlapi-staging.sitecore-staging.cloud/api/graphql/v1/test-tenant/main?preview=false'
+      );
+    });
+
+    it('should create a ContentClient instance with custom values', () => {
+      const client = ContentClient.createClient({
+        url: 'https://custom-url.com',
+        tenant: 'test-tenant',
+        environment: 'test-env',
+        preview: true,
+        token: 'test-token',
+      });
+
+      expect(client.endpoint).to.equal(
+        'https://custom-url.com/api/graphql/v1/test-tenant/test-env?preview=true'
+      );
+    });
+
+    it('should create a ContentClient instance with environment variables', () => {
+      process.env.SITECORE_CS_URL = 'https://example.com';
+      process.env.SITECORE_CS_TENANT = 'test-tenant';
+      process.env.SITECORE_CS_ENVIRONMENT = 'test-env';
+      process.env.SITECORE_CS_PREVIEW = 'false';
+      process.env.SITECORE_CS_TOKEN = 'test-token';
+
+      expect(ContentClient.createClient().endpoint).to.equal(
+        'https://example.com/api/graphql/v1/test-tenant/test-env?preview=false'
+      );
+
+      process.env.SITECORE_CS_PREVIEW = 'true';
+
+      expect(ContentClient.createClient().endpoint).to.equal(
+        'https://example.com/api/graphql/v1/test-tenant/test-env?preview=true'
+      );
+    });
+  });
+
+  describe('get', () => {
+    let client: ContentClient;
+    let requestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      client = new ContentClient({
+        url: 'https://example.com',
+        tenant: 'test-tenant',
+        environment: 'test-env',
+        preview: true,
+        token: 'test-token',
+      });
+
+      requestStub = sinon.stub(client.graphqlClient, 'request');
+    });
+
+    it('should call graphqlClient with correct arguments', async () => {
+      const query = '{ testQuery }';
+      const variables = { key: 'value' };
+      const options = { headers: { 'Custom-Header': 'value' } };
+
+      requestStub.resolves({ data: 'test-data' });
+
+      const result = await client.get<{ data: string }>(query, variables, options);
+
+      expect(requestStub.calledOnce).to.be.true;
+      expect(requestStub.calledWith(query, variables, options)).to.be.true;
+      expect(result).to.deep.equal({ data: 'test-data' });
+    });
+
+    it('should handle errors thrown by graphqlClient', async () => {
+      const query = '{ testQuery }';
+      const error = new Error('Test error');
+
+      requestStub.rejects(error);
+
+      try {
+        await client.get(query);
+      } catch (err) {
+        expect(err).to.equal(error);
+      }
+    });
+  });
+});

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -65,7 +65,7 @@ export class ContentClient {
       url: url || process.env.SITECORE_CS_URL,
       tenant: tenant || process.env.SITECORE_CS_TENANT || '',
       environment: environment || process.env.SITECORE_CS_ENVIRONMENT || 'main',
-      preview: preview || process?.env?.SITECORE_CS_PREVIEW === 'true',
+      preview: preview || process.env.SITECORE_CS_PREVIEW === 'true',
       token: token || process.env.SITECORE_CS_TOKEN || '',
     };
 

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -1,0 +1,103 @@
+import { DocumentNode } from 'graphql';
+import { GraphQLRequestClient } from '../graphql-request-client';
+import { getContentUrl } from './utils';
+import { FetchOptions } from '../models';
+import debug from '../debug';
+
+/**
+ * Interface representing the options for the ContentClient.
+ */
+export interface ContentClientOptions {
+  /** The base URL for the Content API. */
+  url?: string;
+  /** The tenant name. */
+  tenant: string;
+  /** The environment name. */
+  environment: string;
+  /** Indicates if preview mode is enabled. */
+  preview: boolean;
+  /** The authentication token. */
+  token: string;
+}
+
+/**
+ * Class representing a client for interacting with the Content API.
+ */
+export class ContentClient {
+  endpoint: string;
+  graphqlClient: GraphQLRequestClient;
+
+  constructor({ url, tenant, environment, preview, token }: ContentClientOptions) {
+    this.endpoint = getContentUrl({
+      environment,
+      preview,
+      tenant,
+      url,
+    });
+
+    this.graphqlClient = new GraphQLRequestClient(this.endpoint, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      debugger: debug.content,
+    });
+  }
+
+  /**
+   * Factory method for creating a ContentClient instance. This method allows you to create a client with the values populated from environment variables or provided as arguments.
+   * @param {Partial<ContentClientOptions>} [options] - client configuration options
+   * @param {string} [options.url] - Content base graphql endpoint url. If not provided, it will be read from the SITECORE_CS_URL environment variable. Otherwise, it defaults to https://cs-graphqlapi-staging.sitecore-staging.cloud.
+   * @param {string} [options.tenant] - Tenant name. If not provided, it will be read from the SITECORE_CS_TENANT environment variable
+   * @param {string} [options.environment] - Environment name. If not provided, it will be read from the SITECORE_CS_ENVIRONMENT environment variable. Otherwise, it defaults to 'main'
+   * @param {boolean} [options.preview] - Indicates if preview mode is enabled. If not provided, it will be read from the SITECORE_CS_PREVIEW environment variable. Otherwise, it defaults to true
+   * @param {string} [options.token] - Token for authentication. If not provided, it will be read from the SITECORE_CS_TOKEN environment variable.
+   * @returns {ContentClient} ContentClient instance
+   * @throws {Error} If tenant or token is not provided
+   */
+  static createClient({
+    url,
+    tenant,
+    environment,
+    preview,
+    token,
+  }: Partial<ContentClientOptions> = {}): ContentClient {
+    const options = {
+      url: url || process.env.SITECORE_CS_URL,
+      tenant: tenant || process.env.SITECORE_CS_TENANT || '',
+      environment: environment || process.env.SITECORE_CS_ENVIRONMENT || 'main',
+      preview: preview || process?.env?.SITECORE_CS_PREVIEW === 'true',
+      token: token || process.env.SITECORE_CS_TOKEN || '',
+    };
+
+    if (!options.tenant) {
+      throw new Error(
+        'Tenant is required to be provided as an argument or as a SITECORE_CS_TENANT environment variable'
+      );
+    }
+
+    if (!options.token) {
+      throw new Error(
+        'Token is required to be provided as an argument or as a SITECORE_CS_TOKEN environment variable'
+      );
+    }
+
+    return new ContentClient(options);
+  }
+
+  /**
+   * Execute graphql request
+   * @param {string | DocumentNode} query graphql query
+   * @param {object} variables variables for the query
+   * @param {FetchOptions} options options for configuring the request
+   * @returns {T} response data
+   */
+  async get<T>(
+    query: string | DocumentNode,
+    variables: Record<string, unknown> = {},
+    options: FetchOptions = {}
+  ): Promise<T> {
+    debug.content('fetching content data');
+
+    return this.graphqlClient.request<T>(query, variables, options);
+  }
+}

--- a/packages/core/src/content/index.ts
+++ b/packages/core/src/content/index.ts
@@ -1,1 +1,2 @@
-export default {};
+export { ContentClient, ContentClientOptions } from './content-client';
+export { getContentUrl } from './utils';

--- a/packages/core/src/content/utils.test.ts
+++ b/packages/core/src/content/utils.test.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import { getContentUrl } from './utils';
+
+describe('utils', () => {
+  describe('getContentUrl', () => {
+    const tenant = 'my-tenant';
+    const environment = 'my-environment';
+
+    it('should return the correct endpoint url with default url', () => {
+      const url = getContentUrl({
+        tenant,
+        environment,
+        preview: true,
+      });
+
+      expect(url).to.equal(
+        `https://cs-graphqlapi-staging.sitecore-staging.cloud/api/graphql/v1/${tenant}/${environment}?preview=true`
+      );
+    });
+
+    it('should return the correct endpoint url with custom url', () => {
+      const url = getContentUrl({
+        url: 'https://my-custom-url.com',
+        tenant,
+        environment,
+        preview: false,
+      });
+
+      expect(url).to.equal(
+        `https://my-custom-url.com/api/graphql/v1/${tenant}/${environment}?preview=false`
+      );
+    });
+
+    it('should return the correct endpoint url with custom url and trailing slash', () => {
+      const url = getContentUrl({
+        url: 'https://my-custom-url.com/',
+        tenant,
+        environment,
+        preview: false,
+      });
+
+      expect(url).to.equal(
+        `https://my-custom-url.com/api/graphql/v1/${tenant}/${environment}?preview=false`
+      );
+    });
+  });
+});

--- a/packages/core/src/content/utils.ts
+++ b/packages/core/src/content/utils.ts
@@ -1,0 +1,24 @@
+import { normalizeUrl } from '../utils/normalize-url';
+
+/**
+ * Get the Content graphql endpoint url
+ * @param {object} params Parameters
+ * @param {string} [params.url] Content base graphql endpoint url
+ * @param {string} params.tenant Tenant name
+ * @param {string} params.environment Environment name
+ * @param {boolean} params.preview Indicates if preview mode is enabled
+ * @returns {string} Content graphql endpoint url
+ */
+export function getContentUrl({
+  url = 'https://cs-graphqlapi-staging.sitecore-staging.cloud',
+  tenant,
+  environment,
+  preview,
+}: {
+  url?: string;
+  tenant: string;
+  environment: string;
+  preview: boolean;
+}) {
+  return `${normalizeUrl(url)}/api/graphql/v1/${tenant}/${environment}?preview=${preview}`;
+}

--- a/packages/core/src/debug.ts
+++ b/packages/core/src/debug.ts
@@ -29,6 +29,7 @@ export const enableDebug = (namespaces: string) => debug.enable(namespaces);
  */
 export default {
   common: debug(`${rootNamespace}:common`),
+  content: debug(`${rootNamespace}:content`),
   form: debug(`${rootNamespace}:form`),
   http: debug(`${rootNamespace}:http`),
   layout: debug(`${rootNamespace}:layout`),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated (Will be updated separately once we get all the information about naming)
- [ ] Upgrade guide entry added

## Description / Motivation
* Introduced a new `ContentClient` abstraction for interacting with the Content API.
* Added a static `createClient` method for client initialization, allowing developers to conveniently configure the client using environment variables.
* Implemented a `get` method to perform GraphQL requests and retrieve data from the API.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other - created a .ts script where I executed a single _manyBlog_ query

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
