### PR TITLE
[nextjs] fix for casing issue in redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[nextjs]` Fix for case sensitive redirects (make all redirects case-insensitive) ([#69](https://github.com/Sitecore/content-sdk/pull/69))
 * `[core]` Fix for lookbehind regex. (not supported on ios 16) ([#67](https://github.com/Sitecore/content-sdk/pull/67))
 * `[nextjs]` Render "unoptimized" Next Image in component rendering mode ([#66](https://github.com/Sitecore/content-sdk/pull/66))
 * `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -1798,7 +1798,7 @@ describe('RedirectsMiddleware', () => {
       });
 
 
-      // Tests cases for case-insensitive redirects
+      // Test cases for case-insensitive redirects
       it('should redirect regardless of case in pattern and target', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
         const url = {

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -1797,7 +1797,6 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
-
       // Test cases for case-insensitive redirects
       it('should redirect regardless of case in pattern and target', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
@@ -1810,7 +1809,7 @@ describe('RedirectsMiddleware', () => {
           clone: cloneUrl,
         };
         setupRedirectStub(301);
-      
+
         const { res, req } = createTestRequestResponse({
           response: { url },
           request: {
@@ -1824,7 +1823,7 @@ describe('RedirectsMiddleware', () => {
           },
           status: 301,
         });
-      
+
         const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
           {
             pattern: '/about', // Lowercase pattern
@@ -1836,14 +1835,14 @@ describe('RedirectsMiddleware', () => {
           req,
           res
         );
-      
+
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
           headers: {},
           redirected: undefined,
           status: 301,
           url,
         });
-      
+
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -1737,7 +1737,7 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
-      it('should clean redirect headers and return a 302 redirectt', async () => {
+      it('should clean redirect headers and return a 302 redirect', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
         const url = {
           clone: cloneUrl,
@@ -1790,6 +1790,60 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.headers.has('x-middleware-rewrite')).to.equal(false);
         expect(finalRes.headers.has(REWRITE_HEADER_NAME)).to.equal(false);
 
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes).to.deep.equal(res);
+        expect(finalRes.status).to.equal(res.status);
+      });
+
+
+      // Tests cases for case-insensitive redirects
+      it('should redirect regardless of case in pattern and target', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/found',
+          pathname: '/found',
+          origin: 'http://localhost:3000',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+        setupRedirectStub(301);
+      
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/About', // Mixed case
+              href: 'http://localhost:3000/About',
+              locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+      
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: '/about', // Lowercase pattern
+            target: '/Found', // Mixed case target
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+      
+        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+          headers: {},
+          redirected: undefined,
+          status: 301,
+          url,
+        });
+      
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -314,10 +314,10 @@ export class RedirectsMiddleware extends MiddlewareBase {
       })
       .join('&');
 
-    const newUrl = new URL(`${url.pathname}?${newQueryString}`, url.origin);
+    const newUrl = new URL(`${url.pathname.toLowerCase()}?${newQueryString}`, url.origin);
 
     url.search = newUrl.search;
-    url.pathname = newUrl.pathname;
+    url.pathname = newUrl.pathname.toLowerCase();
     url.href = newUrl.href;
 
     return url;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
With this fix we can now use case-insensitive redirects, which wasn't the case before. Redirects like this /Old -> /New wouldn't work due to case sensitivity preserved and only lower case redirects would be completed. After this fix all redirects should work despite casing.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
