### PR TITLE
[cli] Introduce "project" subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🎉 New Features & Improvements
+
+* `[cli]` Introduce "project" subcommands ([#73](https://github.com/Sitecore/content-sdk/pull/73))
+
 ### 🛠 Breaking Changes
 
 * `[core]` SXA Form can't fire CloudSDK events due to initialization error ([#63](https://github.com/Sitecore/content-sdk/pull/63)):

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -42,17 +42,21 @@ export default async function cli(commands?: {
     }
   }
 
-  appCommands.command({
-    command: '*',
-    handler: (argv) => {
-      if (argv._.length > 0) {
-        console.error(`Command not found: "${argv._[0]}". Use --help to see available commands.`);
-      } else {
-        console.error('No command provided. Use --help to see available commands.');
-      }
-      process.exit(1);
-    },
-  });
+  appCommands
+    .command({
+      command: '*',
+      handler: (argv) => {
+        if (argv._.length > 0) {
+          console.error(`Command not found: "${argv._[0]}"`);
+        } else {
+          console.error('No command provided');
+        }
+        yargs.showHelp();
+        process.exit(1);
+      },
+    })
+    .demandCommand(1, 'You need at least one command before moving on')
+    .strict();
 
   await appCommands.argv;
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -55,7 +55,7 @@ export default async function cli(commands?: {
         process.exit(1);
       },
     })
-    .demandCommand(1, 'You need at least one command before moving on')
+    .demandCommand(1, 'You need to specify a command to run')
     .strict();
 
   await appCommands.argv;

--- a/packages/cli/src/scripts/index.ts
+++ b/packages/cli/src/scripts/index.ts
@@ -1,7 +1,6 @@
 // commands available when running from an app location (with CLI installed to local node_modules)
 // e.g. setup, deploy
 
-import * as build from './build';
-import * as scaffold from './scaffold';
+import * as project from './project';
 
-export { build, scaffold };
+export { project };

--- a/packages/cli/src/scripts/project/build.test.ts
+++ b/packages/cli/src/scripts/project/build.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import * as loadConfigModule from '../utils/load-config';
+import * as loadConfigModule from '../../utils/load-config';
 import { handler } from './build';
 
 describe('build command', () => {

--- a/packages/cli/src/scripts/project/build.ts
+++ b/packages/cli/src/scripts/project/build.ts
@@ -1,7 +1,8 @@
-import loadCliConfig from '../utils/load-config';
+import loadCliConfig from '../../utils/load-config';
+
 export const command = 'build';
 
-export const describe = 'Handles build time automation';
+export const describe = 'Performs build time automation';
 
 export const builder = {
   config: {

--- a/packages/cli/src/scripts/project/component/index.ts
+++ b/packages/cli/src/scripts/project/component/index.ts
@@ -1,0 +1,24 @@
+import { Argv } from 'yargs';
+
+import * as scaffold from './scaffold';
+
+/**
+ * @param {Argv} yargs
+ */
+export function builder(yargs: Argv) {
+  return yargs.command({
+    command: 'component',
+    describe: 'Performs component level operations',
+    builder: (_yargs: Argv) => {
+      _yargs = _yargs
+        .command([scaffold] as any)
+        .strict()
+        .demandCommand(1, 'You need to specify a command to run');
+
+      _yargs = scaffold.builder(_yargs as any);
+
+      return _yargs;
+    },
+    handler: () => {},
+  });
+}

--- a/packages/cli/src/scripts/project/component/scaffold.test.ts
+++ b/packages/cli/src/scripts/project/component/scaffold.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ComponentTemplateType } from '@sitecore-content-sdk/core/config';
-import * as loadConfigModule from '../../../utils/load-config';
-import proxyquire from 'proxyquire';
 import { SitecoreCliConfig } from '@sitecore-content-sdk/core/src/config';
+import proxyquire from 'proxyquire';
+import * as loadConfigModule from '../../../utils/load-config';
 
 describe('scaffold command', () => {
   let loadCliConfigStub: sinon.SinonStub;

--- a/packages/cli/src/scripts/project/component/scaffold.test.ts
+++ b/packages/cli/src/scripts/project/component/scaffold.test.ts
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import path from 'path';
 import { ComponentTemplateType } from '@sitecore-content-sdk/core/config';
-import * as loadConfigModule from '../utils/load-config';
+import * as loadConfigModule from '../../../utils/load-config';
 import proxyquire from 'proxyquire';
 import { SitecoreCliConfig } from '@sitecore-content-sdk/core/src/config';
 
@@ -91,13 +90,13 @@ dashes, or underscores. It can also contain slashes to indicate a subfolder`
     const argv = {
       componentName: 'ValidComponentName',
     };
-    const expectedOutputFFolderPath = 'src/components';
+    const expectedOutputFolderPath = 'src/components';
 
     handler(argv);
 
     expect(
       scaffoldComponentStub.calledOnceWith(
-        expectedOutputFFolderPath,
+        expectedOutputFolderPath,
         'ValidComponentName',
         ComponentTemplateType.DEFAULT,
         mockConfig.scaffold.templates
@@ -110,13 +109,13 @@ dashes, or underscores. It can also contain slashes to indicate a subfolder`
       componentName: 'ValidComponentName',
       byoc: true,
     };
-    const expectedOutputFFolderPath = 'src/components';
+    const expectedOutputFolderPath = 'src/components';
 
     handler(argv);
 
     expect(
       scaffoldComponentStub.calledOnceWith(
-        expectedOutputFFolderPath,
+        expectedOutputFolderPath,
         'ValidComponentName',
         ComponentTemplateType.BYOC,
         mockConfig.scaffold.templates

--- a/packages/cli/src/scripts/project/component/scaffold.ts
+++ b/packages/cli/src/scripts/project/component/scaffold.ts
@@ -1,5 +1,5 @@
 import { scaffoldComponent } from '@sitecore-content-sdk/core/tools';
-import loadCliConfig from '../utils/load-config';
+import loadCliConfig from '../../../utils/load-config';
 import { Argv } from 'yargs';
 import { ComponentTemplateType } from '@sitecore-content-sdk/core/config';
 
@@ -9,7 +9,7 @@ import { ComponentTemplateType } from '@sitecore-content-sdk/core/config';
 export function builder(yargs: Argv<ScaffoldArgs>) {
   return yargs.command<ScaffoldArgs>(
     'scaffold <componentName>',
-    'Scaffolds a new component. Use `sitecore-tools scaffold --help` for available options.',
+    'Scaffolds a new component',
     args,
     handler
   );

--- a/packages/cli/src/scripts/project/index.ts
+++ b/packages/cli/src/scripts/project/index.ts
@@ -1,0 +1,25 @@
+import { Argv } from 'yargs';
+
+import * as build from './build';
+import * as component from './component';
+
+/**
+ * @param {Argv} yargs
+ */
+export function builder(yargs: Argv) {
+  return yargs.command({
+    command: 'project',
+    describe: 'Performs project level operations',
+    builder: (_yargs: Argv) => {
+      _yargs = _yargs
+        .command([build, component] as any)
+        .strict()
+        .demandCommand(1, 'You need to specify a command to run');
+
+      _yargs = component.builder(_yargs as any);
+
+      return _yargs;
+    },
+    handler: () => {},
+  });
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Introduces a simple implementation of subcommands using yargs, enabling the CLI to support commands like
`sitecore-tools project build`
`sitecore-tools project component scaffold`.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added - no unit tests, since subcommand wrapper doesn't produce any logic
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
