### PR TITLE
[core] introducing get locales functionality on content client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
+* `[core]` Introduce get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))
 * `[cli]` Introduce "project" subcommands ([#73](https://github.com/Sitecore/content-sdk/pull/73))
 
 ### 🛠 Breaking Changes

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { ContentClient } from './content-client';
 import { GraphQLRequestClient } from '../graphql-request-client';
+import { GET_LOCALE_QUERY, GET_LOCALES_QUERY } from './locales';
 
 describe('content-client', () => {
   describe('constructor', () => {
@@ -131,6 +132,95 @@ describe('content-client', () => {
 
       try {
         await client.get(query);
+      } catch (err) {
+        expect(err).to.equal(error);
+      }
+    });
+  });
+
+  describe('getLocale', () => {
+    let client: ContentClient;
+    let requestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      client = new ContentClient({
+        url: 'https://example.com',
+        tenant: 'test-tenant',
+        environment: 'test-env',
+        preview: true,
+        token: 'test-token',
+      });
+
+      requestStub = sinon.stub(client.graphqlClient, 'request');
+    });
+
+    it('should retrieve a locale by ID', async () => {
+      const localeId = 'en-us';
+      const mockResponse = { locale: { id: localeId, label: 'English (US)' } };
+
+      requestStub.resolves(mockResponse);
+
+      const result = await client.getLocale(localeId);
+
+      expect(requestStub.calledOnce).to.be.true;
+      expect(requestStub.calledWith(GET_LOCALE_QUERY, { id: localeId })).to.be.true;
+      expect(result).to.deep.equal(mockResponse.locale);
+    });
+
+    it('should handle errors when retrieving a locale by ID', async () => {
+      const localeId = 'en-us';
+      const error = new Error('Failed to fetch locale');
+
+      requestStub.rejects(error);
+
+      try {
+        await client.getLocale(localeId);
+      } catch (err) {
+        expect(err).to.equal(error);
+      }
+    });
+  });
+
+  describe('getLocales', () => {
+    let client: ContentClient;
+    let requestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      client = new ContentClient({
+        url: 'https://example.com',
+        tenant: 'test-tenant',
+        environment: 'test-env',
+        preview: true,
+        token: 'test-token',
+      });
+
+      requestStub = sinon.stub(client.graphqlClient, 'request');
+    });
+
+    it('should retrieve all available locales', async () => {
+      const mockResponse = {
+        manyLocale: [
+          { id: 'en-us', label: 'English (US)' },
+          { id: 'fr-fr', label: 'French (France)' },
+        ],
+      };
+
+      requestStub.resolves(mockResponse);
+
+      const result = await client.getLocales();
+
+      expect(requestStub.calledOnce).to.be.true;
+      expect(requestStub.calledWith(GET_LOCALES_QUERY)).to.be.true;
+      expect(result).to.deep.equal(mockResponse.manyLocale);
+    });
+
+    it('should handle errors when retrieving all locales', async () => {
+      const error = new Error('Failed to fetch locales');
+
+      requestStub.rejects(error);
+
+      try {
+        await client.getLocales();
       } catch (err) {
         expect(err).to.equal(error);
       }

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -6,6 +6,7 @@ import debug from '../debug';
 import {
   GET_LOCALE_QUERY,
   GET_LOCALES_QUERY,
+  Locale,
   LocaleQueryResponse,
   LocalesQueryResponse,
 } from './locales';
@@ -113,7 +114,7 @@ export class ContentClient {
    * @param id - The unique identifier of the locale item.
    * @returns A promise that resolves to the locale information associated with the specified locale ID.
    */
-  async getLocale(id: string) {
+  async getLocale(id: string): Promise<Locale | null> {
     debug.content('Getting locale for id: %s', id);
 
     const response = await this.get<LocaleQueryResponse>(GET_LOCALE_QUERY, { id });

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -6,7 +6,6 @@ import debug from '../debug';
 import {
   GET_LOCALE_QUERY,
   GET_LOCALES_QUERY,
-  Locale,
   LocaleQueryResponse,
   LocalesQueryResponse,
 } from './locales';

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -3,6 +3,12 @@ import { GraphQLRequestClient } from '../graphql-request-client';
 import { getContentUrl } from './utils';
 import { FetchOptions } from '../models';
 import debug from '../debug';
+import {
+  GET_LOCALE_QUERY,
+  GET_LOCALES_QUERY,
+  LocaleQueryResponse,
+  LocalesQueryResponse,
+} from './locales';
 
 /**
  * Interface representing the options for the ContentClient.
@@ -99,5 +105,30 @@ export class ContentClient {
     debug.content('fetching content data');
 
     return this.graphqlClient.request<T>(query, variables, options);
+  }
+
+  /**
+   * Retrieves the locale information for a given locale ID.
+   *
+   * @param id - The unique identifier of the locale item.
+   * @returns A promise that resolves to the locale information associated with the specified locale ID.
+   */
+  async getLocale(id: string) {
+    debug.content('Getting locale for id: %s', id);
+
+    const response = await this.get<LocaleQueryResponse>(GET_LOCALE_QUERY, { id });
+    return response.locale;
+  }
+
+  /**
+   * Retrieves all available locales from the content service.
+   *
+   * @returns A promise that resolves to an array of locales.
+   */
+  async getLocales() {
+    debug.content('Getting all locales');
+
+    const response = await this.get<LocalesQueryResponse>(GET_LOCALES_QUERY);
+    return response.manyLocale;
   }
 }

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -114,7 +114,7 @@ export class ContentClient {
    * @param id - The unique identifier of the locale item.
    * @returns A promise that resolves to the locale information associated with the specified locale ID.
    */
-  async getLocale(id: string): Promise<Locale | null> {
+  async getLocale(id: string) {
     debug.content('Getting locale for id: %s', id);
 
     const response = await this.get<LocaleQueryResponse>(GET_LOCALE_QUERY, { id });

--- a/packages/core/src/content/index.ts
+++ b/packages/core/src/content/index.ts
@@ -1,2 +1,9 @@
 export { ContentClient, ContentClientOptions } from './content-client';
+export {
+  GET_LOCALE_QUERY,
+  GET_LOCALES_QUERY,
+  LocaleQueryResponse,
+  LocalesQueryResponse,
+  Locale,
+} from './locales';
 export { getContentUrl } from './utils';

--- a/packages/core/src/content/locales.ts
+++ b/packages/core/src/content/locales.ts
@@ -31,7 +31,7 @@ export type Locale = {
  * @returns {string} The GraphQL query string.
  */
 export const GET_LOCALE_QUERY = `
-  query ($id: ID!) {
+  query GetLocaleById ($id: ID!) {
     locale(id: $id) {
       id
       label
@@ -45,7 +45,7 @@ export const GET_LOCALE_QUERY = `
  * @returns {string} The GraphQL query string.
  */
 export const GET_LOCALES_QUERY = `
-  query {
+  query GetAllLocales{
     manyLocale {
       id
       label

--- a/packages/core/src/content/locales.ts
+++ b/packages/core/src/content/locales.ts
@@ -1,0 +1,54 @@
+/**
+ * Represents the response structure for a query that retrieves a locale.
+ */
+export interface LocaleQueryResponse {
+  locale: Locale;
+}
+
+/**
+ * Represents the response structure for a query that retrieves multiple locales.
+ */
+export interface LocalesQueryResponse {
+  manyLocale: Locale[];
+}
+
+/**
+ * Represents a locale with an id and a label.
+ *
+ * @typedef Locale
+ * @property {string} id - The unique identifier for the locale.
+ * @property {string} label - The display name or label for the locale.
+ */
+export type Locale = {
+  id: string;
+  label: string;
+};
+
+/**
+ * GraphQL query to retrieve a specific locale by its ID.
+ *
+ * @param {string} id - The unique identifier for the locale.
+ * @returns {string} The GraphQL query string.
+ */
+export const GET_LOCALE_QUERY = `
+  query ($id: ID!) {
+    locale(id: $id) {
+      id
+      label
+    }
+  }
+`;
+
+/**
+ * GraphQL query to retrieve all available locales.
+ *
+ * @returns {string} The GraphQL query string.
+ */
+export const GET_LOCALES_QUERY = `
+  query {
+    manyLocale {
+      id
+      label
+    }
+  }
+`;

--- a/packages/core/src/content/locales.ts
+++ b/packages/core/src/content/locales.ts
@@ -2,7 +2,7 @@
  * Represents the response structure for a query that retrieves a locale.
  */
 export interface LocaleQueryResponse {
-  locale: Locale;
+  locale: Locale | null;
 }
 
 /**
@@ -14,7 +14,6 @@ export interface LocalesQueryResponse {
 
 /**
  * Represents a locale with an id and a label.
- *
  * @typedef Locale
  * @property {string} id - The unique identifier for the locale.
  * @property {string} label - The display name or label for the locale.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR introduces new functionality for querying locale data in the content client. The changes enhance the Content SDK by providing methods to:

- Retrieve specific locale information from Content Services.
- Retrieve all available locales from the Content Services.
- Additionally, we are exporting the necessary GraphQL (GQL) queries and types to support these new methods. These additions aim to improve the flexibility and usability of the Content SDK, enabling developers to access locale-specific data more efficiently.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
