### PR TITLE
[nextjs] Silence sass warnings

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -107,7 +107,9 @@ const nextConfig = {
       '@sass': path.join(process.cwd(), './src/assets', 'sass'),
       '@fontawesome': path.join(process.cwd(), './node_modules', 'font-awesome'),
     }).getImporter(),
-    quietDeps: true,
+    // temporary measure until new versions of bootstrap and font-awesome released
+    quietDeps: true,    
+    silenceDeprecations: ["import"],
   },
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -109,7 +109,7 @@ const nextConfig = {
     }).getImporter(),
     // temporary measure until new versions of bootstrap and font-awesome released
     quietDeps: true,    
-    silenceDeprecations: ["import"],
+    silenceDeprecations: ["import", "legacy-js-api"],
   },
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/assets/sass/components/promo/_promo-shadow.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/assets/sass/components/promo/_promo-shadow.scss
@@ -13,11 +13,11 @@
         float: left;
     }
     >.component-content {
+        padding: 15px;
+        margin: 0 0 30px 0;
         @include respond-to(all-mobile) {
             margin: 0 10px 30px 10px;
         }
-        padding: 15px;
-        margin: 0 0 30px 0;
         &:before, &:after {
             opacity: 0.7;
             box-shadow: 0 17px 10px rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Follow up to nextjs/react upgrades. Silences sass deprecation warnings, until we can new versions of bootstrap and font-awesome are available and can be upgraded to:
- https://github.com/FortAwesome/font-awesome-sass/issues/195
- https://github.com/twbs/bootstrap/issues/29853

After the releases, develompent can continue in https://github.com/Sitecore/content-sdk/tree/bugifx/jss-6129-update-sass

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
