### PR TITLE
[nextjs] Fix `siteName` and `language` being undefined during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Our versioning strategy is as follows:
 * `[core]` Introduce get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#75](https://github.com/Sitecore/content-sdk/pull/75))
 * `[cli]` Introduce "project" subcommands ([#73](https://github.com/Sitecore/content-sdk/pull/73))
 * `[nextjs]` Enhance customizability for Sitecore Client and SDK Middlwares ([#87](https://github.com/Sitecore/content-sdk/pull/87))
-* `[core]` `[next]` `[create-sitecore-jss]` Passing configuration object to `defineConfig` in _sitecore.config_ is now optional. Introduced _sitecore.config.ts.example_ ([#90](https://github.com/Sitecore/content-sdk/pull/90))
+* `[core]` `[next]` `[create-sitecore-jss]` Passing configuration object to `defineConfig` in _sitecore.config_ is now optional. Introduced _sitecore.config.ts.example_ ([#90](https://github.com/Sitecore/content-sdk/pull/90)) ([#93](https://github.com/Sitecore/content-sdk/pull/93))
 
 
 ### 🛠 Breaking Changes

--- a/packages/nextjs/src/config/define-config.test.ts
+++ b/packages/nextjs/src/config/define-config.test.ts
@@ -237,7 +237,7 @@ describe('defineConfig', () => {
       it('should default to undefined', () => {
         defineConfigModule.defineConfig(defaultConfig());
         const resultConfig = defineConfigCoreStub.getCalls()[0].args[0];
-        expect(resultConfig.defaultSite).to.be.undefined;
+        expect(resultConfig.defaultSite).to.equal('');
       });
 
       it('should use the value from the config', () => {
@@ -285,7 +285,7 @@ describe('defineConfig', () => {
           },
         });
         const resultConfig = defineConfigCoreStub.getCalls()[0].args[0];
-        expect(resultConfig.defaultLanguage).to.be.undefined;
+        expect(resultConfig.defaultLanguage).to.equal('en');
       });
 
       it('should use the value from the config', () => {

--- a/packages/nextjs/src/config/define-config.ts
+++ b/packages/nextjs/src/config/define-config.ts
@@ -28,8 +28,8 @@ export const getNextFallbackConfig = (config?: SitecoreConfigInput): SitecoreCon
         apiHost: config?.api?.local?.apiHost || process.env.NEXT_PUBLIC_SITECORE_API_HOST || '',
       },
     },
-    defaultSite: config?.defaultSite || process.env.NEXT_PUBLIC_SITECORE_SITE_NAME,
-    defaultLanguage: config?.defaultLanguage || process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE,
+    defaultSite: config?.defaultSite || process.env.NEXT_PUBLIC_SITECORE_SITE_NAME || '',
+    defaultLanguage: config?.defaultLanguage || process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE || 'en',
     multisite: {
       ...config?.multisite,
       useCookieResolution:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fallback value was not defined therefore `siteName` and `language` were coming out to undefined.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
