### PR TITLE
[core] Fallback "core" values are not respected when framework specific value is empty & validate resolved config instead of base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Our versioning strategy is as follows:
 * `[nextjs]` Component-level `getServerSideProps` and `getStaticProps` methods have been replaced by a single `getComponentServerProps` method for simplicity.
     * In case a separate logic is needed depending on SSR/SSG context, an `isServerSidePropsContext` helper method from `@sitecore-content-sdk/nextjs/utils` can now be used.
 
+### 🐛 Bug Fixes
+
+* `[core]` `[sitecore.config]` Fallback values are not respected when framework specific value is empty & validate resolved config instead of base ([#97](https://github.com/Sitecore/content-sdk/pull/97))
+
 ## 0.2.0
 
 ### 🎉 New Features & Improvements

--- a/packages/core/src/config/define-config.test.ts
+++ b/packages/core/src/config/define-config.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { defineConfig, getFallbackConfig } from './define-config';
+import { deepMerge, defineConfig, getFallbackConfig } from './define-config';
 import { SitecoreConfigInput } from './models';
 import { DefaultRetryStrategy } from '..';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
@@ -185,6 +185,81 @@ describe('define-config', () => {
       expect(fallbackConfig.editingSecret).to.equal('editing-secret-missing');
       expect(fallbackConfig.personalize.edgeTimeout).to.equal(400);
       expect(fallbackConfig.personalize.cdpTimeout).to.equal(400);
+    });
+  });
+
+  describe('deepMerge', () => {
+    it('should fallback to base when override value is empty', () => {
+      expect(
+        deepMerge(
+          {
+            deep: {
+              test: 'base',
+            },
+          },
+          {
+            deep: {
+              test: '',
+            },
+          }
+        )
+      ).to.deep.equal({ deep: { test: 'base' } });
+
+      expect(
+        deepMerge(
+          {
+            deep: {
+              test: 'base',
+            },
+          },
+          {
+            deep: {
+              test: undefined,
+            },
+          }
+        )
+      ).to.deep.equal({ deep: { test: 'base' } });
+    });
+
+    it('should traverse nested objects and merge', () => {
+      class Test {
+        a = true;
+      }
+
+      class BaseTest extends Test {
+        b = true;
+      }
+
+      const base = {
+        deep: {
+          fn: () => {
+            return false;
+          },
+          class: new BaseTest(),
+          array: [4, 5, 6],
+          number: 5,
+          string: '5',
+        },
+        boolean: true,
+      };
+
+      const override = {
+        deep: {
+          fn: () => {
+            return true;
+          },
+          class: new Test(),
+          nullValue: null,
+          array: [1, 2, 3],
+          number: 10,
+          string: '10',
+        },
+        boolean: false,
+      };
+
+      console.log(override);
+
+      expect(deepMerge(base, override)).to.deep.equal(override);
     });
   });
 });

--- a/packages/core/src/config/define-config.ts
+++ b/packages/core/src/config/define-config.ts
@@ -1,6 +1,6 @@
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 import { DefaultRetryStrategy } from '../retries';
-import { SitecoreConfig, SitecoreConfigInput } from './models';
+import { DeepPartial, SitecoreConfig, SitecoreConfigInput } from './models';
 
 /**
  * Provides default initial values for SitecoreConfig
@@ -56,26 +56,51 @@ export const getFallbackConfig = (): SitecoreConfig => ({
 });
 
 /**
- * Merges two SitecoreConfig objects
+ * Deep merge utility that skips undefined or empty string values in the override.
+ * @param {T} base base value
+ * @param {DeepPartial<T>} [override] override value
+ */
+export function deepMerge<T>(base: T, override?: DeepPartial<T>): T {
+  if (!override) return base;
+
+  const result: T = { ...base };
+
+  for (const key in override) {
+    if (!Object.prototype.hasOwnProperty.call(override, key)) continue;
+
+    const typedKey = key as keyof T;
+    const baseValue = base[typedKey];
+    const overrideValue = override[typedKey];
+
+    // Skip undefined and empty string overrides
+    if (overrideValue === undefined || overrideValue === '') {
+      continue;
+    }
+
+    if (
+      typeof overrideValue === 'object' &&
+      overrideValue !== null &&
+      !Array.isArray(overrideValue) &&
+      Object.getPrototypeOf(overrideValue) === Object.prototype
+    ) {
+      result[typedKey] = deepMerge(baseValue, overrideValue);
+    } else {
+      result[typedKey] = overrideValue as T[typeof typedKey];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Resolves sitecore config vased on base config and overrides
  * @param {SitecoreConfig} base base sitecore config object
  * @param {SitecoreConfig} override override sitecore config object
- * @returns merged SitecoreConfig object
+ * @returns resolved SitecoreConfig object
  */
-const deepMerge = (base: SitecoreConfig, override: SitecoreConfigInput) => {
-  const result = {
-    ...base,
-    ...override,
-    api: {
-      edge: { ...base.api?.edge, ...override.api?.edge },
-      local: { ...base.api?.local, ...override.api?.local },
-    },
-    retries: { ...base.retries, ...override.retries },
-    layout: { ...base.layout, ...override.layout },
-    multisite: { ...base.multisite, ...override.multisite },
-    personalize: { ...base.personalize, ...override.personalize },
-    redirects: { ...base.redirects, ...override.redirects },
-    dictionary: { ...base.dictionary, ...override.dictionary },
-  };
+const resolveConfig = (base: SitecoreConfig, override: SitecoreConfigInput): SitecoreConfig => {
+  const result: SitecoreConfig = deepMerge(base, override);
+
   if (Number.isNaN(result.personalize.cdpTimeout) || !result.personalize.cdpTimeout) {
     result.personalize.cdpTimeout = base.personalize.cdpTimeout;
   }
@@ -109,7 +134,10 @@ const validateConfig = (config: SitecoreConfigInput) => {
  * @param {SitecoreConfigInput} config override values to be written over default config settings
  * @returns {SitecoreConfig} full sitecore configuration to use in application
  */
-export const defineConfig = (config: SitecoreConfigInput) => {
-  validateConfig(config);
-  return deepMerge(getFallbackConfig(), config) as SitecoreConfig;
+export const defineConfig = (config: SitecoreConfigInput): SitecoreConfig => {
+  const resolvedConfig = resolveConfig(getFallbackConfig(), config);
+
+  validateConfig(resolvedConfig);
+
+  return resolvedConfig;
 };

--- a/packages/core/src/config/define-config.ts
+++ b/packages/core/src/config/define-config.ts
@@ -93,7 +93,7 @@ export function deepMerge<T>(base: T, override?: DeepPartial<T>): T {
 }
 
 /**
- * Resolves sitecore config vased on base config and overrides
+ * Resolves sitecore config based on base config and overrides
  * @param {SitecoreConfig} base base sitecore config object
  * @param {SitecoreConfig} override override sitecore config object
  * @returns resolved SitecoreConfig object

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -10,6 +10,13 @@ export type DeepRequired<T> = Required<
 >;
 
 /**
+ * Utility type to make all properties in a type optional, recursively.
+ */
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+/**
  * Type to be used as config input in sitecore.config
  */
 export type SitecoreConfigInput = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Pull Request resolves two issues:
1) Framework specific empty values should not override fallback values defined in "core"
2) Config validation should validate resolved (merged) config instead of initially provided

Another problem I've found: currently, it's required to set edge context id in order to don't  get validation error in browser, but this is not right, since we treat client context id as optional, so we need to revisit. I will create a follow up, since it's not related to initial problem

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
