### PR TITLE
[nextjs] [DesignLibrary] Script is requested from production even when a custom Edge URL is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,11 @@ Our versioning strategy is as follows:
     - `WithSitecoreContextOptions` → `WithSitecoreOptions`
     - `WithSitecoreContextProps` → `WithSitecoreProps`
     - `WithSitecoreContextHocProps` → `WithSitecoreHocProps`
-
 * `[nextjs]` Component-level `getServerSideProps` and `getStaticProps` methods have been replaced by a single `getComponentServerProps` method for simplicity.
     * In case a separate logic is needed depending on SSR/SSG context, an `isServerSidePropsContext` helper method from `@sitecore-content-sdk/nextjs/utils` can now be used.
+* `[nextjs]` [DesignLibrary] Script is requested from production even when a custom Edge URL is set ([#98](https://github.com/Sitecore/content-sdk/pull/98)):
+  * The `EditingScripts` component doesn't accept `sitecoreEdgeUrl` property anymore.
+  * The custom Edge URL is now accessed via the `api` property of the `SitecoreProvider` component.
 
 ### 🐛 Bug Fixes
 

--- a/packages/react/src/components/EditingScripts.test.tsx
+++ b/packages/react/src/components/EditingScripts.test.tsx
@@ -190,8 +190,12 @@ describe('<EditingScripts />', () => {
       const stagingEdgeUrl = 'http://edge-staging';
 
       const component = render(
-        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData}>
-          <EditingScripts sitecoreEdgeUrl={stagingEdgeUrl} />
+        <SitecoreProvider
+          componentMap={mockComponentMap}
+          layoutData={layoutData}
+          api={{ edge: { edgeUrl: stagingEdgeUrl, contextPath: 'id' } }}
+        >
+          <EditingScripts />
         </SitecoreProvider>
       );
 

--- a/packages/react/src/components/EditingScripts.test.tsx
+++ b/packages/react/src/components/EditingScripts.test.tsx
@@ -193,7 +193,7 @@ describe('<EditingScripts />', () => {
         <SitecoreProvider
           componentMap={mockComponentMap}
           layoutData={layoutData}
-          api={{ edge: { edgeUrl: stagingEdgeUrl, contextPath: 'id' } }}
+          api={{ edge: { edgeUrl: stagingEdgeUrl, contextId: 'id' } }}
         >
           <EditingScripts />
         </SitecoreProvider>

--- a/packages/react/src/components/EditingScripts.tsx
+++ b/packages/react/src/components/EditingScripts.tsx
@@ -5,25 +5,14 @@ import { getJssPagesClientData } from '@sitecore-content-sdk/core/editing';
 import { getDesignLibraryScriptLink } from '@sitecore-content-sdk/core/editing';
 
 /**
- * Props for the EditingScripts component.
- */
-export type EditingScriptsProps = {
-  /**
-   * Sitecore Edge Platform URL.
-   */
-  sitecoreEdgeUrl?: string;
-};
-
-/**
  * Renders client scripts and data for editing/preview mode for Pages.
  * Renders script required for the Design Library (when RenderingType is `component`).
- * @param {EditingScriptsProps} props - The props for the EditingScripts component.
- * @param {string} props.sitecoreEdgeUrl - Sitecore Edge Platform URL.
  * @returns A JSX element containing the editing scripts or an empty fragment if not in editing/preview mode.
  */
-export const EditingScripts = (props: EditingScriptsProps): JSX.Element => {
+export const EditingScripts = (): JSX.Element => {
   const {
     pageContext: { pageState, clientData, clientScripts, renderingType },
+    api,
   } = useSitecore();
 
   // Don't render anything if not in editing/preview mode and rendering type is not component
@@ -39,7 +28,7 @@ export const EditingScripts = (props: EditingScriptsProps): JSX.Element => {
   // In case of RenderingType.Component - render only the script for Design Libnrary
   if (renderingType === RenderingType.Component) {
     // Add cache buster to the script URL
-    const scriptUrl = `${getDesignLibraryScriptLink(props.sitecoreEdgeUrl)}?cb=${Date.now()}`;
+    const scriptUrl = `${getDesignLibraryScriptLink(api?.edge?.edgeUrl)}?cb=${Date.now()}`;
 
     return (
       <>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
When a custom SITECORE_EDGE_URL is set, the Design Library script is still requested from the production Edge endpoint instead of the custom one.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
