### PR TITLE
[core] Introduce get taxonomy(ies) implementation in the content client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ Our versioning strategy is as follows:
   - A new `RobotsMiddleware` class encapsulates HTTP-level logic for generating `robots.txt` responses in Next.js apps.
   - These additions follow the same extensible architecture as existing features enabling custom behavior via service overrides and improving consistency across endpoints.
 * `[sitecore-jss-cli]` Code extraction feature for XMCloud code generation is added ([#71](https://github.com/Sitecore/jss/pull/71))
-
 * `[all]` XM Cloud Content support
   * `[core]` Introduced /content submodule to interact with XM Cloud Content ([#65](https://github.com/Sitecore/content-sdk/pull/65))
   * `[richtext]` Added new `richtext` package to enable Content SDK to work with TipTap Rich Text editors ([#85](https://github.com/Sitecore/content-sdk/pull/85))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
+* `[core]` Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99))
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.
@@ -32,7 +33,7 @@ Our versioning strategy is as follows:
   - A new `RobotsMiddleware` class encapsulates HTTP-level logic for generating `robots.txt` responses in Next.js apps.
   - These additions follow the same extensible architecture as existing features enabling custom behavior via service overrides and improving consistency across endpoints.
 * `[sitecore-jss-cli]` Code extraction feature for XMCloud code generation is added ([#71](https://github.com/Sitecore/jss/pull/71))
-* `[core]` Introduce get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))
+* `[core]` Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))
 * `[all]` XM Cloud Content support
   * `[core]` Introduced /content submodule to interact with XM Cloud Content ([#65](https://github.com/Sitecore/content-sdk/pull/65))
   * `[richtext]` Added new `richtext` package to enable Content SDK to work with TipTap Rich Text editors ([#85](https://github.com/Sitecore/content-sdk/pull/85))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Our versioning strategy is as follows:
 
 * `[core]` Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
   - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
-  - Support pagination for the above methods by implementing an internal fetchNext method to handle this in each method
+  - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
   - Introduced respective queries and types
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,11 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[core]` 
-  * `[Content - Name TBD] Support`:
-     - Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
-       - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
-       - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
-    - Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))   
+* `[Content - Name TBD] Support`:
+  - Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
+    - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
+    - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
+  - Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))   
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[core]` Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99))
+* `[core]` Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
+  - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
+  - Support pagination for the above methods by implementing an internal fetchNext method to handle this in each method
+  - Introduced respective queries and types
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[core]` Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
-  - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
-  - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
-  - Introduced respective queries and types
+* `[core]` 
+  * `[Content - Name TBD] Support`:
+     - Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
+       - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
+       - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
+    - Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))   
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.
@@ -36,7 +38,7 @@ Our versioning strategy is as follows:
   - A new `RobotsMiddleware` class encapsulates HTTP-level logic for generating `robots.txt` responses in Next.js apps.
   - These additions follow the same extensible architecture as existing features enabling custom behavior via service overrides and improving consistency across endpoints.
 * `[sitecore-jss-cli]` Code extraction feature for XMCloud code generation is added ([#71](https://github.com/Sitecore/jss/pull/71))
-* `[core]` Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))
+
 * `[all]` XM Cloud Content support
   * `[core]` Introduced /content submodule to interact with XM Cloud Content ([#65](https://github.com/Sitecore/content-sdk/pull/65))
   * `[richtext]` Added new `richtext` package to enable Content SDK to work with TipTap Rich Text editors ([#85](https://github.com/Sitecore/content-sdk/pull/85))

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -244,17 +244,11 @@ describe('content-client', () => {
       requestStub = sinon.stub(client.graphqlClient, 'request');
     });
 
-    it('should retrieve all available taxonomies', async () => {
+    it('should retrieve taxonomies with terms and pagination support', async () => {
       const mockResponse = {
         manyTaxonomy: {
           results: [
             {
-              terms: {
-                results: [
-                  { id: 'term1', name: 'Term 1', label: 'First Term' },
-                  { id: 'term2', name: 'Term 2', label: 'Second Term' },
-                ],
-              },
               system: {
                 id: 'tax1',
                 name: 'Taxonomy 1',
@@ -266,36 +260,45 @@ describe('content-client', () => {
                 updatedBy: 'user2',
                 publishStatus: 'published',
               },
+              terms: {
+                results: [{ id: 'term1', name: 'Term 1', label: 'First Term' }],
+                cursor: 'cursor-terms',
+                hasMore: true,
+              },
             },
           ],
+          cursor: 'cursor-taxonomies',
+          hasMore: true,
         },
       };
 
       requestStub.resolves(mockResponse);
 
-      const result = await client.getTaxonomies();
+      const result = await client.getTaxonomies(2, 1);
 
       expect(requestStub.calledOnce).to.be.true;
       expect(requestStub.calledWith(GET_TAXONOMIES_QUERY)).to.be.true;
-      expect(result).to.deep.equal(mockResponse.manyTaxonomy);
+      expect(result.results[0].system.name).to.equal('Taxonomy 1');
+      expect(result.results[0].terms.results[0].name).to.equal('Term 1');
+
+      // Test fetchNext for taxonomies
+      if (result.fetchNext) {
+        requestStub.resolves(mockResponse); // Mock again for fetchNext
+        const nextPage = await result.fetchNext();
+        expect(requestStub.calledTwice).to.be.true;
+        expect(nextPage.results[0].system.name).to.equal('Taxonomy 1');
+      }
     });
 
-    it('should handle null response', async () => {
+    it('should handle empty or null responses', async () => {
       requestStub.resolves({ manyTaxonomy: null });
 
       const result = await client.getTaxonomies();
-      expect(result).to.be.null;
-    });
-
-    it('should handle errors when retrieving taxonomies', async () => {
-      const error = new Error('Failed to fetch taxonomies');
-      requestStub.rejects(error);
-
-      try {
-        await client.getTaxonomies();
-      } catch (err) {
-        expect(err).to.equal(error);
-      }
+      expect(result).to.deep.include({
+        results: [],
+        cursor: undefined,
+        hasMore: false,
+      });
     });
   });
 
@@ -315,16 +318,10 @@ describe('content-client', () => {
       requestStub = sinon.stub(client.graphqlClient, 'request');
     });
 
-    it('should retrieve a taxonomy by ID', async () => {
+    it('should retrieve a taxonomy by ID with paginated terms', async () => {
       const taxonomyId = 'tax1';
       const mockResponse = {
         taxonomy: {
-          terms: {
-            results: [
-              { id: 'term1', name: 'Term 1', label: 'First Term' },
-              { id: 'term2', name: 'Term 2', label: 'Second Term' },
-            ],
-          },
           system: {
             id: taxonomyId,
             name: 'Taxonomy 1',
@@ -336,36 +333,62 @@ describe('content-client', () => {
             updatedBy: 'user2',
             publishStatus: 'published',
           },
+          terms: {
+            results: [{ id: 'term1', name: 'Term 1', label: 'First Term' }],
+            cursor: 'cursor-terms',
+            hasMore: true,
+          },
+        },
+      };
+
+      requestStub.resolves(mockResponse);
+
+      const result = await client.getTaxonomy(taxonomyId, 3);
+      expect(result?.system.id).to.equal(taxonomyId);
+      expect(result?.terms.results[0].name).to.equal('Term 1');
+
+      // Test fetchNext for terms
+      if (result?.terms.fetchNext) {
+        requestStub.resolves(mockResponse); // Mock again for fetchNext
+        const nextTerms = await result.terms.fetchNext();
+        expect(nextTerms.results[0].name).to.equal('Term 1');
+      }
+    });
+
+    it('should retrieve a taxonomy by ID without terms pagination', async () => {
+      const taxonomyId = 'tax2';
+      const mockResponse = {
+        taxonomy: {
+          system: {
+            id: taxonomyId,
+            name: 'Taxonomy 2',
+            version: 1,
+            label: 'Second Taxonomy',
+            createdAt: '2024-02-01',
+            createdBy: 'user3',
+            updatedAt: '2024-02-02',
+            updatedBy: 'user4',
+            publishStatus: 'published',
+          },
+          terms: {
+            results: [{ id: 'term2', name: 'Term 2', label: 'Second Term' }],
+            cursor: null,
+            hasMore: false,
+          },
         },
       };
 
       requestStub.resolves(mockResponse);
 
       const result = await client.getTaxonomy(taxonomyId);
-
-      expect(requestStub.calledOnce).to.be.true;
-      expect(requestStub.calledWith(GET_TAXONOMY_QUERY, { id: taxonomyId })).to.be.true;
-      expect(result).to.deep.equal(mockResponse.taxonomy);
+      expect(result?.system.id).to.equal(taxonomyId);
+      expect(result?.terms.results[0].name).to.equal('Term 2');
     });
 
-    it('should handle null response', async () => {
-      const taxonomyId = 'nonexistent';
+    it('should handle null taxonomy response', async () => {
       requestStub.resolves({ taxonomy: null });
-
-      const result = await client.getTaxonomy(taxonomyId);
+      const result = await client.getTaxonomy('invalid-id');
       expect(result).to.be.null;
-    });
-
-    it('should handle errors when retrieving a taxonomy', async () => {
-      const taxonomyId = 'tax1';
-      const error = new Error('Failed to fetch taxonomy');
-      requestStub.rejects(error);
-
-      try {
-        await client.getTaxonomy(taxonomyId);
-      } catch (err) {
-        expect(err).to.equal(error);
-      }
     });
   });
 });

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -277,6 +277,7 @@ describe('content-client', () => {
 
       expect(requestStub.calledOnce).to.be.true;
       const callArgs = requestStub.getCall(0).args;
+      expect(callArgs[0]).to.equal(GET_TAXONOMIES_QUERY);
       expect(callArgs[1]).to.deep.equal({ pageSize: 2, after: '' });
       expect(result.results[0].system.name).to.equal('Taxonomy 1');
       expect(result.results[0].terms[0].name).to.equal('Term 1');
@@ -317,6 +318,7 @@ describe('content-client', () => {
 
       expect(requestStub.calledOnce).to.be.true;
       const callArgs = requestStub.getCall(0).args;
+      expect(callArgs[0]).to.equal(GET_TAXONOMIES_QUERY);
       expect(callArgs[1]).to.deep.equal({ pageSize: 2, after: 'cursor-taxonomies' });
       expect(result.results[0].system.name).to.equal('Taxonomy 2');
       expect(result.results[0].terms[0].name).to.equal('Term 2');
@@ -383,6 +385,7 @@ describe('content-client', () => {
       });
       expect(requestStub.calledOnce).to.be.true;
       const callArgs = requestStub.getCall(0).args;
+      expect(callArgs[0]).to.equal(GET_TAXONOMY_QUERY); // <-- Ensure correct query is used
       expect(callArgs[1]).to.deep.equal({
         id: taxonomyId,
         termsPageSize: 1,
@@ -419,10 +422,10 @@ describe('content-client', () => {
 
       requestStub.resolves(mockResponse);
 
-      // Now expect undefineds for termsPageSize/termsAfter
       const result = await client.getTaxonomy({ id: taxonomyId });
       expect(requestStub.calledOnce).to.be.true;
       const callArgs = requestStub.getCall(0).args;
+      expect(callArgs[0]).to.equal(GET_TAXONOMY_QUERY); // <-- Ensure correct query is used
       expect(callArgs[1]).to.deep.equal({
         id: taxonomyId,
         termsPageSize: undefined,

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -336,6 +336,74 @@ describe('content-client', () => {
         hasMore: false,
       });
     });
+
+    describe('edge cases: terms.results null/undefined', () => {
+      it('should handle null terms.results in taxonomy', async () => {
+        const mockResponse = {
+          manyTaxonomy: {
+            results: [
+              {
+                system: {
+                  id: 'tax1',
+                  name: 'Taxonomy 1',
+                  version: 1,
+                  label: 'First Taxonomy',
+                  createdAt: '',
+                  createdBy: '',
+                  updatedAt: '',
+                  updatedBy: '',
+                  publishStatus: '',
+                },
+                terms: {
+                  results: null, // simulate null
+                  cursor: null,
+                  hasMore: false,
+                },
+              },
+            ],
+            cursor: 'cursor-taxonomies',
+            hasMore: false,
+          },
+        };
+        requestStub.resolves(mockResponse);
+
+        const result = await client.getTaxonomies({ pageSize: 2, after: '' });
+        expect(result.results[0].terms).to.deep.equal([]);
+      });
+
+      it('should handle undefined terms.results in taxonomy', async () => {
+        const mockResponse = {
+          manyTaxonomy: {
+            results: [
+              {
+                system: {
+                  id: 'tax1',
+                  name: 'Taxonomy 1',
+                  version: 1,
+                  label: 'First Taxonomy',
+                  createdAt: '',
+                  createdBy: '',
+                  updatedAt: '',
+                  updatedBy: '',
+                  publishStatus: '',
+                },
+                terms: {
+                  // results is undefined
+                  cursor: null,
+                  hasMore: false,
+                },
+              },
+            ],
+            cursor: 'cursor-taxonomies',
+            hasMore: false,
+          },
+        };
+        requestStub.resolves(mockResponse);
+
+        const result = await client.getTaxonomies({ pageSize: 2, after: '' });
+        expect(result.results[0].terms).to.deep.equal([]);
+      });
+    });
   });
 
   describe('getTaxonomy', () => {
@@ -385,7 +453,7 @@ describe('content-client', () => {
       });
       expect(requestStub.calledOnce).to.be.true;
       const callArgs = requestStub.getCall(0).args;
-      expect(callArgs[0]).to.equal(GET_TAXONOMY_QUERY); // <-- Ensure correct query is used
+      expect(callArgs[0]).to.equal(GET_TAXONOMY_QUERY);
       expect(callArgs[1]).to.deep.equal({
         id: taxonomyId,
         termsPageSize: 1,
@@ -425,7 +493,7 @@ describe('content-client', () => {
       const result = await client.getTaxonomy({ id: taxonomyId });
       expect(requestStub.calledOnce).to.be.true;
       const callArgs = requestStub.getCall(0).args;
-      expect(callArgs[0]).to.equal(GET_TAXONOMY_QUERY); // <-- Ensure correct query is used
+      expect(callArgs[0]).to.equal(GET_TAXONOMY_QUERY);
       expect(callArgs[1]).to.deep.equal({
         id: taxonomyId,
         termsPageSize: undefined,
@@ -441,6 +509,62 @@ describe('content-client', () => {
       requestStub.resolves({ taxonomy: null });
       const result = await client.getTaxonomy({ id: 'invalid-id' });
       expect(result).to.be.null;
+    });
+
+    describe('edge cases: terms.results null/undefined', () => {
+      it('should handle null terms.results', async () => {
+        const taxonomyId = 'tax1';
+        const mockResponse = {
+          taxonomy: {
+            system: {
+              id: taxonomyId,
+              name: 'Taxonomy 1',
+              version: 1,
+              label: 'First Taxonomy',
+              createdAt: '',
+              createdBy: '',
+              updatedAt: '',
+              updatedBy: '',
+              publishStatus: '',
+            },
+            terms: {
+              results: null,
+              cursor: null,
+              hasMore: false,
+            },
+          },
+        };
+        requestStub.resolves(mockResponse);
+        const result = await client.getTaxonomy({ id: taxonomyId });
+        expect(result?.terms.results).to.deep.equal([]);
+      });
+
+      it('should handle undefined terms.results', async () => {
+        const taxonomyId = 'tax1';
+        const mockResponse = {
+          taxonomy: {
+            system: {
+              id: taxonomyId,
+              name: 'Taxonomy 1',
+              version: 1,
+              label: 'First Taxonomy',
+              createdAt: '',
+              createdBy: '',
+              updatedAt: '',
+              updatedBy: '',
+              publishStatus: '',
+            },
+            terms: {
+              // results missing
+              cursor: null,
+              hasMore: false,
+            },
+          },
+        };
+        requestStub.resolves(mockResponse);
+        const result = await client.getTaxonomy({ id: taxonomyId });
+        expect(result?.terms.results).to.deep.equal([]);
+      });
     });
   });
 });

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import { ContentClient } from './content-client';
 import { GraphQLRequestClient } from '../graphql-request-client';
 import { GET_LOCALE_QUERY, GET_LOCALES_QUERY } from './locales';
+import { GET_TAXONOMIES_QUERY, GET_TAXONOMY_QUERY } from './taxonomies';
 
 describe('content-client', () => {
   describe('constructor', () => {
@@ -221,6 +222,147 @@ describe('content-client', () => {
 
       try {
         await client.getLocales();
+      } catch (err) {
+        expect(err).to.equal(error);
+      }
+    });
+  });
+
+  describe('getTaxonomies', () => {
+    let client: ContentClient;
+    let requestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      client = new ContentClient({
+        url: 'https://example.com',
+        tenant: 'test-tenant',
+        environment: 'test-env',
+        preview: true,
+        token: 'test-token',
+      });
+
+      requestStub = sinon.stub(client.graphqlClient, 'request');
+    });
+
+    it('should retrieve all available taxonomies', async () => {
+      const mockResponse = {
+        manyTaxonomy: {
+          results: [
+            {
+              terms: {
+                results: [
+                  { id: 'term1', name: 'Term 1', label: 'First Term' },
+                  { id: 'term2', name: 'Term 2', label: 'Second Term' },
+                ],
+              },
+              system: {
+                id: 'tax1',
+                name: 'Taxonomy 1',
+                version: 1,
+                label: 'First Taxonomy',
+                createdAt: '2024-01-01',
+                createdBy: 'user1',
+                updatedAt: '2024-01-02',
+                updatedBy: 'user2',
+                publishStatus: 'published',
+              },
+            },
+          ],
+        },
+      };
+
+      requestStub.resolves(mockResponse);
+
+      const result = await client.getTaxonomies();
+
+      expect(requestStub.calledOnce).to.be.true;
+      expect(requestStub.calledWith(GET_TAXONOMIES_QUERY)).to.be.true;
+      expect(result).to.deep.equal(mockResponse.manyTaxonomy);
+    });
+
+    it('should handle null response', async () => {
+      requestStub.resolves({ manyTaxonomy: null });
+
+      const result = await client.getTaxonomies();
+      expect(result).to.be.null;
+    });
+
+    it('should handle errors when retrieving taxonomies', async () => {
+      const error = new Error('Failed to fetch taxonomies');
+      requestStub.rejects(error);
+
+      try {
+        await client.getTaxonomies();
+      } catch (err) {
+        expect(err).to.equal(error);
+      }
+    });
+  });
+
+  describe('getTaxonomy', () => {
+    let client: ContentClient;
+    let requestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      client = new ContentClient({
+        url: 'https://example.com',
+        tenant: 'test-tenant',
+        environment: 'test-env',
+        preview: true,
+        token: 'test-token',
+      });
+
+      requestStub = sinon.stub(client.graphqlClient, 'request');
+    });
+
+    it('should retrieve a taxonomy by ID', async () => {
+      const taxonomyId = 'tax1';
+      const mockResponse = {
+        taxonomy: {
+          terms: {
+            results: [
+              { id: 'term1', name: 'Term 1', label: 'First Term' },
+              { id: 'term2', name: 'Term 2', label: 'Second Term' },
+            ],
+          },
+          system: {
+            id: taxonomyId,
+            name: 'Taxonomy 1',
+            version: 1,
+            label: 'First Taxonomy',
+            createdAt: '2024-01-01',
+            createdBy: 'user1',
+            updatedAt: '2024-01-02',
+            updatedBy: 'user2',
+            publishStatus: 'published',
+          },
+        },
+      };
+
+      requestStub.resolves(mockResponse);
+
+      const result = await client.getTaxonomy(taxonomyId);
+
+      expect(requestStub.calledOnce).to.be.true;
+      expect(requestStub.calledWith(GET_TAXONOMY_QUERY, { id: taxonomyId })).to.be.true;
+      expect(result).to.deep.equal(mockResponse.taxonomy);
+    });
+
+    it('should handle null response', async () => {
+      const taxonomyId = 'nonexistent';
+      requestStub.resolves({ taxonomy: null });
+
+      const result = await client.getTaxonomy(taxonomyId);
+      expect(result).to.be.null;
+    });
+
+    it('should handle errors when retrieving a taxonomy', async () => {
+      const taxonomyId = 'tax1';
+      const error = new Error('Failed to fetch taxonomy');
+      requestStub.rejects(error);
+
+      try {
+        await client.getTaxonomy(taxonomyId);
       } catch (err) {
         expect(err).to.equal(error);
       }

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -279,7 +279,7 @@ describe('content-client', () => {
       const callArgs = requestStub.getCall(0).args;
       expect(callArgs[1]).to.deep.equal({ pageSize: 2, after: '' });
       expect(result.results[0].system.name).to.equal('Taxonomy 1');
-      expect(result.results[0].terms.results[0].name).to.equal('Term 1');
+      expect(result.results[0].terms[0].name).to.equal('Term 1');
       expect(result.cursor).to.equal('cursor-taxonomies');
       expect(result.hasMore).to.be.true;
     });
@@ -319,7 +319,7 @@ describe('content-client', () => {
       const callArgs = requestStub.getCall(0).args;
       expect(callArgs[1]).to.deep.equal({ pageSize: 2, after: 'cursor-taxonomies' });
       expect(result.results[0].system.name).to.equal('Taxonomy 2');
-      expect(result.results[0].terms.results[0].name).to.equal('Term 2');
+      expect(result.results[0].terms[0].name).to.equal('Term 2');
       expect(result.cursor).to.equal('another-cursor');
       expect(result.hasMore).to.be.false;
     });
@@ -377,14 +377,17 @@ describe('content-client', () => {
 
       requestStub.resolves(mockResponse);
 
-      // Now expecting options object: { id, terms?: { pageSize, after } }
       const result = await client.getTaxonomy({
         id: taxonomyId,
         terms: { pageSize: 1, after: '' },
       });
       expect(requestStub.calledOnce).to.be.true;
       const callArgs = requestStub.getCall(0).args;
-      expect(callArgs[1]).to.deep.equal({ id: taxonomyId, termsPageSize: 1, termsAfter: '' });
+      expect(callArgs[1]).to.deep.equal({
+        id: taxonomyId,
+        termsPageSize: 1,
+        termsAfter: '',
+      });
       expect(result?.system.id).to.equal(taxonomyId);
       expect(result?.terms.results[0].name).to.equal('Term 1');
       expect(result?.terms.cursor).to.equal('cursor-terms');
@@ -416,11 +419,15 @@ describe('content-client', () => {
 
       requestStub.resolves(mockResponse);
 
-      // No terms object means no pagination (should send only id)
+      // Now expect undefineds for termsPageSize/termsAfter
       const result = await client.getTaxonomy({ id: taxonomyId });
       expect(requestStub.calledOnce).to.be.true;
       const callArgs = requestStub.getCall(0).args;
-      expect(callArgs[1]).to.deep.equal({ id: taxonomyId });
+      expect(callArgs[1]).to.deep.equal({
+        id: taxonomyId,
+        termsPageSize: undefined,
+        termsAfter: undefined,
+      });
       expect(result?.system.id).to.equal(taxonomyId);
       expect(result?.terms.results[0].name).to.equal('Term 2');
       expect(result?.terms.cursor).to.be.null;

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -244,7 +244,7 @@ describe('content-client', () => {
       requestStub = sinon.stub(client.graphqlClient, 'request');
     });
 
-    it('should retrieve taxonomies with terms and pagination support', async () => {
+    it('should retrieve the first page with after=""', async () => {
       const mockResponse = {
         manyTaxonomy: {
           results: [
@@ -254,16 +254,16 @@ describe('content-client', () => {
                 name: 'Taxonomy 1',
                 version: 1,
                 label: 'First Taxonomy',
-                createdAt: '2024-01-01',
-                createdBy: 'user1',
-                updatedAt: '2024-01-02',
-                updatedBy: 'user2',
-                publishStatus: 'published',
+                createdAt: '',
+                createdBy: '',
+                updatedAt: '',
+                updatedBy: '',
+                publishStatus: '',
               },
               terms: {
                 results: [{ id: 'term1', name: 'Term 1', label: 'First Term' }],
-                cursor: 'cursor-terms',
-                hasMore: true,
+                cursor: null,
+                hasMore: false,
               },
             },
           ],
@@ -271,29 +271,63 @@ describe('content-client', () => {
           hasMore: true,
         },
       };
-
       requestStub.resolves(mockResponse);
 
-      const result = await client.getTaxonomies(2, 1);
+      const result = await client.getTaxonomies({ pageSize: 2, after: '' });
 
       expect(requestStub.calledOnce).to.be.true;
-      expect(requestStub.calledWith(GET_TAXONOMIES_QUERY)).to.be.true;
+      const callArgs = requestStub.getCall(0).args;
+      expect(callArgs[1]).to.deep.equal({ pageSize: 2, after: '' });
       expect(result.results[0].system.name).to.equal('Taxonomy 1');
       expect(result.results[0].terms.results[0].name).to.equal('Term 1');
+      expect(result.cursor).to.equal('cursor-taxonomies');
+      expect(result.hasMore).to.be.true;
+    });
 
-      // Test fetchNext for taxonomies
-      if (result.fetchNext) {
-        requestStub.resolves(mockResponse); // Mock again for fetchNext
-        const nextPage = await result.fetchNext();
-        expect(requestStub.calledTwice).to.be.true;
-        expect(nextPage.results[0].system.name).to.equal('Taxonomy 1');
-      }
+    it('should retrieve the next page with a valid cursor', async () => {
+      const mockResponse = {
+        manyTaxonomy: {
+          results: [
+            {
+              system: {
+                id: 'tax2',
+                name: 'Taxonomy 2',
+                version: 1,
+                label: 'Second Taxonomy',
+                createdAt: '',
+                createdBy: '',
+                updatedAt: '',
+                updatedBy: '',
+                publishStatus: '',
+              },
+              terms: {
+                results: [{ id: 'term2', name: 'Term 2', label: 'Second Term' }],
+                cursor: null,
+                hasMore: false,
+              },
+            },
+          ],
+          cursor: 'another-cursor',
+          hasMore: false,
+        },
+      };
+      requestStub.resolves(mockResponse);
+
+      const result = await client.getTaxonomies({ pageSize: 2, after: 'cursor-taxonomies' });
+
+      expect(requestStub.calledOnce).to.be.true;
+      const callArgs = requestStub.getCall(0).args;
+      expect(callArgs[1]).to.deep.equal({ pageSize: 2, after: 'cursor-taxonomies' });
+      expect(result.results[0].system.name).to.equal('Taxonomy 2');
+      expect(result.results[0].terms.results[0].name).to.equal('Term 2');
+      expect(result.cursor).to.equal('another-cursor');
+      expect(result.hasMore).to.be.false;
     });
 
     it('should handle empty or null responses', async () => {
       requestStub.resolves({ manyTaxonomy: null });
 
-      const result = await client.getTaxonomies();
+      const result = await client.getTaxonomies({ pageSize: 2, after: '' });
       expect(result).to.deep.include({
         results: [],
         cursor: undefined,
@@ -318,7 +352,7 @@ describe('content-client', () => {
       requestStub = sinon.stub(client.graphqlClient, 'request');
     });
 
-    it('should retrieve a taxonomy by ID with paginated terms', async () => {
+    it('should retrieve a taxonomy by ID with paginated terms (first page)', async () => {
       const taxonomyId = 'tax1';
       const mockResponse = {
         taxonomy: {
@@ -327,11 +361,11 @@ describe('content-client', () => {
             name: 'Taxonomy 1',
             version: 1,
             label: 'First Taxonomy',
-            createdAt: '2024-01-01',
-            createdBy: 'user1',
-            updatedAt: '2024-01-02',
-            updatedBy: 'user2',
-            publishStatus: 'published',
+            createdAt: '',
+            createdBy: '',
+            updatedAt: '',
+            updatedBy: '',
+            publishStatus: '',
           },
           terms: {
             results: [{ id: 'term1', name: 'Term 1', label: 'First Term' }],
@@ -343,16 +377,18 @@ describe('content-client', () => {
 
       requestStub.resolves(mockResponse);
 
-      const result = await client.getTaxonomy(taxonomyId, 3);
+      // Now expecting options object: { id, terms?: { pageSize, after } }
+      const result = await client.getTaxonomy({
+        id: taxonomyId,
+        terms: { pageSize: 1, after: '' },
+      });
+      expect(requestStub.calledOnce).to.be.true;
+      const callArgs = requestStub.getCall(0).args;
+      expect(callArgs[1]).to.deep.equal({ id: taxonomyId, termsPageSize: 1, termsAfter: '' });
       expect(result?.system.id).to.equal(taxonomyId);
       expect(result?.terms.results[0].name).to.equal('Term 1');
-
-      // Test fetchNext for terms
-      if (result?.terms.fetchNext) {
-        requestStub.resolves(mockResponse); // Mock again for fetchNext
-        const nextTerms = await result.terms.fetchNext();
-        expect(nextTerms.results[0].name).to.equal('Term 1');
-      }
+      expect(result?.terms.cursor).to.equal('cursor-terms');
+      expect(result?.terms.hasMore).to.be.true;
     });
 
     it('should retrieve a taxonomy by ID without terms pagination', async () => {
@@ -364,11 +400,11 @@ describe('content-client', () => {
             name: 'Taxonomy 2',
             version: 1,
             label: 'Second Taxonomy',
-            createdAt: '2024-02-01',
-            createdBy: 'user3',
-            updatedAt: '2024-02-02',
-            updatedBy: 'user4',
-            publishStatus: 'published',
+            createdAt: '',
+            createdBy: '',
+            updatedAt: '',
+            updatedBy: '',
+            publishStatus: '',
           },
           terms: {
             results: [{ id: 'term2', name: 'Term 2', label: 'Second Term' }],
@@ -380,14 +416,20 @@ describe('content-client', () => {
 
       requestStub.resolves(mockResponse);
 
-      const result = await client.getTaxonomy(taxonomyId);
+      // No terms object means no pagination (should send only id)
+      const result = await client.getTaxonomy({ id: taxonomyId });
+      expect(requestStub.calledOnce).to.be.true;
+      const callArgs = requestStub.getCall(0).args;
+      expect(callArgs[1]).to.deep.equal({ id: taxonomyId });
       expect(result?.system.id).to.equal(taxonomyId);
       expect(result?.terms.results[0].name).to.equal('Term 2');
+      expect(result?.terms.cursor).to.be.null;
+      expect(result?.terms.hasMore).to.be.false;
     });
 
     it('should handle null taxonomy response', async () => {
       requestStub.resolves({ taxonomy: null });
-      const result = await client.getTaxonomy('invalid-id');
+      const result = await client.getTaxonomy({ id: 'invalid-id' });
       expect(result).to.be.null;
     });
   });

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -12,8 +12,11 @@ import {
 import {
   GET_TAXONOMY_QUERY,
   GET_TAXONOMIES_QUERY,
+  ContentItemList,
+  Taxonomy,
   TaxonomyQueryResponse,
   TaxonomiesQueryResponse,
+  TermList,
 } from './taxonomies';
 
 /**
@@ -137,24 +140,180 @@ export class ContentClient {
 
   /**
    * Retrieves all available taxonomies.
-   * @returns A promise that resolves to a list of taxonomies.
+   *
+   * This method supports optional pagination for both taxonomies and their terms.
+   * - If `taxonomyPageSize` is provided, it limits the number of taxonomies returned per request.
+   * - If `termsPageSize` is provided, it limits the number of terms returned per taxonomy per request.
+   * - If either is omitted, the API defaults are used (returns all results in a single request if no pagination is required).
+   *
+   * @param {number} [taxonomyPageSize] - Optional. The number of taxonomies per page.
+   * @param {number} [termsPageSize] - Optional. The number of terms per page within each taxonomy.
+   * @returns A promise that resolves to a paginated list of taxonomies, including pagination helpers (`fetchNext`) if applicable.
    */
-  async getTaxonomies() {
-    debug.content('Getting taxonomies');
+  async getTaxonomies(
+    taxonomyPageSize?: number,
+    termsPageSize?: number
+  ): Promise<ContentItemList<Taxonomy>> {
+    const fetchTaxonomiesPage = async (after: string = ''): Promise<ContentItemList<Taxonomy>> => {
+      debug.content(
+        'Fetching taxonomies (pageSize: %s, after: %s)',
+        taxonomyPageSize ?? 'API Default',
+        after
+      );
 
-    const response = await this.get<TaxonomiesQueryResponse>(GET_TAXONOMIES_QUERY);
-    return response?.manyTaxonomy;
+      const variables: Record<string, any> = {
+        after: after || '',
+        termsAfter: '', // Always provide for API requirements
+      };
+
+      if (taxonomyPageSize !== undefined) {
+        variables.minimumPageSize = taxonomyPageSize;
+      }
+
+      if (termsPageSize !== undefined) {
+        variables.termsPageSize = termsPageSize;
+      }
+
+      const response = await this.get<TaxonomiesQueryResponse>(GET_TAXONOMIES_QUERY, variables);
+      const data = response?.manyTaxonomy;
+
+      if (!data) {
+        return {
+          results: [],
+          cursor: undefined,
+          hasMore: false,
+        };
+      }
+
+      const taxonomies = await Promise.all(
+        data.results.map(async (taxonomy) => {
+          const fetchTermsPage = async (termsAfter: string = ''): Promise<TermList> => {
+            debug.content(
+              'Fetching terms for taxonomy %s (pageSize: %s, after: %s)',
+              taxonomy.system.id,
+              termsPageSize ?? 'API Default',
+              termsAfter
+            );
+
+            const termVariables: Record<string, any> = {
+              after: after || '',
+              termsAfter: termsAfter || '',
+            };
+
+            if (taxonomyPageSize !== undefined) {
+              termVariables.minimumPageSize = taxonomyPageSize;
+            }
+
+            if (termsPageSize !== undefined) {
+              termVariables.termsPageSize = termsPageSize;
+            }
+
+            const termResponse = await this.get<TaxonomiesQueryResponse>(
+              GET_TAXONOMIES_QUERY,
+              termVariables
+            );
+
+            const termData = termResponse?.manyTaxonomy?.results.find(
+              (r) => r.system.id === taxonomy.system.id
+            )?.terms;
+
+            return {
+              results: termData?.results ?? [],
+              cursor: termData?.cursor,
+              hasMore: termData?.hasMore ?? false,
+              fetchNext: termData?.hasMore
+                ? () => fetchTermsPage(termData.cursor || '')
+                : undefined,
+            };
+          };
+
+          return {
+            system: taxonomy.system,
+            terms: {
+              results: taxonomy.terms?.results ?? [],
+              cursor: taxonomy.terms?.cursor,
+              hasMore: taxonomy.terms?.hasMore ?? false,
+              fetchNext: taxonomy.terms?.hasMore
+                ? () => fetchTermsPage(taxonomy.terms.cursor || '')
+                : undefined,
+            },
+          };
+        })
+      );
+
+      return {
+        results: taxonomies,
+        cursor: data.cursor,
+        hasMore: data.hasMore,
+        fetchNext: data.hasMore ? () => fetchTaxonomiesPage(data.cursor || '') : undefined,
+      };
+    };
+
+    return fetchTaxonomiesPage();
   }
 
   /**
-   * Retrieves a taxonomy by its ID.
+   * Retrieves a single taxonomy by its ID.
+   *
+   * This method supports optional pagination for the terms within the taxonomy.
+   * - If `termsPageSize` is provided, it limits the number of terms returned per request.
+   * - If omitted, the API default is used (returns all terms in a single request).
+   *
+   * The returned taxonomy object includes the system metadata, the initial set of terms,
+   * and a `fetchNext` function for retrieving additional terms if more are available.
+   *
    * @param {string} id - The unique identifier of the taxonomy.
-   * @returns A promise that resolves to the taxonomy information associated with the specified ID.
+   * @param {number} [termsPageSize] - Optional. The number of terms per page.
+   * @returns A promise that resolves to the taxonomy object, or `null` if not found.
    */
-  async getTaxonomy(id: string) {
+  async getTaxonomy(id: string, termsPageSize?: number): Promise<Taxonomy | null> {
     debug.content('Getting taxonomy for id: %s', id);
 
-    const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, { id });
-    return response?.taxonomy;
+    const fetchTermsPage = async (termsAfter: string = ''): Promise<TermList> => {
+      debug.content(
+        'Fetching terms for taxonomy %s (pageSize: %s, after: %s)',
+        id,
+        termsPageSize ?? 'API Default',
+        termsAfter
+      );
+
+      const variables: Record<string, any> = { id, termsAfter };
+
+      if (termsPageSize !== undefined) {
+        variables.termsPageSize = termsPageSize;
+      }
+
+      const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, variables);
+      const terms = response?.taxonomy?.terms;
+
+      return {
+        results: terms?.results ?? [],
+        cursor: terms?.cursor,
+        hasMore: terms?.hasMore ?? false,
+        fetchNext: terms?.hasMore ? () => fetchTermsPage(terms.cursor || '') : undefined,
+      };
+    };
+
+    const initialVars: Record<string, any> = { id };
+    if (termsPageSize !== undefined) {
+      initialVars.termsPageSize = termsPageSize;
+    }
+
+    const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, initialVars);
+    const taxonomy = response?.taxonomy;
+
+    if (!taxonomy) return null;
+
+    return {
+      system: taxonomy.system,
+      terms: {
+        results: taxonomy.terms?.results ?? [],
+        cursor: taxonomy.terms?.cursor,
+        hasMore: taxonomy.terms?.hasMore ?? false,
+        fetchNext: taxonomy.terms?.hasMore
+          ? () => fetchTermsPage(taxonomy.terms.cursor || '')
+          : undefined,
+      },
+    };
   }
 }

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -139,40 +139,30 @@ export class ContentClient {
   }
 
   /**
-   * Retrieves all available taxonomies.
-   *
-   * This method supports optional pagination for both taxonomies and their terms.
-   * - If `taxonomyPageSize` is provided, it limits the number of taxonomies returned per request.
-   * - If `termsPageSize` is provided, it limits the number of terms returned per taxonomy per request.
-   * - If either is omitted, the API defaults are used (returns all results in a single request if no pagination is required).
-   *
-   * @param {number} [taxonomyPageSize] - Optional. The number of taxonomies per page.
-   * @param {number} [termsPageSize] - Optional. The number of terms per page within each taxonomy.
+   * Retrieves all available taxonomies, with optional pagination support.
+   * @param {number} [pageSize] - Optional. The number of taxonomies to return per page.
+   * @param {number} [termsPageSize] - Optional. The number of terms to return per page within each taxonomy.
    * @returns A promise that resolves to a paginated list of taxonomies, including pagination helpers (`fetchNext`) if applicable.
    */
   async getTaxonomies(
-    taxonomyPageSize?: number,
+    pageSize?: number,
     termsPageSize?: number
   ): Promise<ContentItemList<Taxonomy>> {
     const fetchTaxonomiesPage = async (after: string = ''): Promise<ContentItemList<Taxonomy>> => {
       debug.content(
         'Fetching taxonomies (pageSize: %s, after: %s)',
-        taxonomyPageSize ?? 'API Default',
+        pageSize ?? 'API Default',
         after
       );
 
-      const variables: Record<string, any> = {
-        after: after || '',
-        termsAfter: '', // Always provide for API requirements
-      };
+      const createVariables = (after = '', termsAfter = '') => ({
+        pageSize,
+        after,
+        termsAfter,
+        termsPageSize,
+      });
 
-      if (taxonomyPageSize !== undefined) {
-        variables.minimumPageSize = taxonomyPageSize;
-      }
-
-      if (termsPageSize !== undefined) {
-        variables.termsPageSize = termsPageSize;
-      }
+      const variables = createVariables(after);
 
       const response = await this.get<TaxonomiesQueryResponse>(GET_TAXONOMIES_QUERY, variables);
       const data = response?.manyTaxonomy;
@@ -189,30 +179,18 @@ export class ContentClient {
         data.results.map(async (taxonomy) => {
           const fetchTermsPage = async (termsAfter: string = ''): Promise<TermList> => {
             debug.content(
-              'Fetching terms for taxonomy %s (pageSize: %s, after: %s)',
+              'Fetching terms for taxonomy %s (termsPageSize: %s, after: %s)',
               taxonomy.system.id,
               termsPageSize ?? 'API Default',
               termsAfter
             );
 
-            const termVariables: Record<string, any> = {
-              after: after || '',
-              termsAfter: termsAfter || '',
-            };
-
-            if (taxonomyPageSize !== undefined) {
-              termVariables.minimumPageSize = taxonomyPageSize;
-            }
-
-            if (termsPageSize !== undefined) {
-              termVariables.termsPageSize = termsPageSize;
-            }
+            const termVariables = createVariables(after, termsAfter);
 
             const termResponse = await this.get<TaxonomiesQueryResponse>(
               GET_TAXONOMIES_QUERY,
               termVariables
             );
-
             const termData = termResponse?.manyTaxonomy?.results.find(
               (r) => r.system.id === taxonomy.system.id
             )?.terms;
@@ -253,35 +231,23 @@ export class ContentClient {
   }
 
   /**
-   * Retrieves a single taxonomy by its ID.
-   *
-   * This method supports optional pagination for the terms within the taxonomy.
-   * - If `termsPageSize` is provided, it limits the number of terms returned per request.
-   * - If omitted, the API default is used (returns all terms in a single request).
-   *
-   * The returned taxonomy object includes the system metadata, the initial set of terms,
-   * and a `fetchNext` function for retrieving additional terms if more are available.
-   *
+   * Retrieves a taxonomy by its ID, with optional pagination support for its terms.
    * @param {string} id - The unique identifier of the taxonomy.
-   * @param {number} [termsPageSize] - Optional. The number of terms per page.
-   * @returns A promise that resolves to the taxonomy object, or `null` if not found.
+   * @param {number} [termsPageSize] - Optional. The number of terms to return per page.
+   * @returns A promise that resolves to the taxonomy object, including its system metadata, the initial set of terms, and a `fetchNext` function for retrieving additional terms if available. Returns `null` if the taxonomy is not found.
    */
   async getTaxonomy(id: string, termsPageSize?: number): Promise<Taxonomy | null> {
     debug.content('Getting taxonomy for id: %s', id);
 
     const fetchTermsPage = async (termsAfter: string = ''): Promise<TermList> => {
       debug.content(
-        'Fetching terms for taxonomy %s (pageSize: %s, after: %s)',
+        'Fetching terms for taxonomy %s (termsPageSize: %s, after: %s)',
         id,
         termsPageSize ?? 'API Default',
         termsAfter
       );
 
-      const variables: Record<string, any> = { id, termsAfter };
-
-      if (termsPageSize !== undefined) {
-        variables.termsPageSize = termsPageSize;
-      }
+      const variables = { id, termsAfter, termsPageSize };
 
       const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, variables);
       const terms = response?.taxonomy?.terms;
@@ -294,10 +260,7 @@ export class ContentClient {
       };
     };
 
-    const initialVars: Record<string, any> = { id };
-    if (termsPageSize !== undefined) {
-      initialVars.termsPageSize = termsPageSize;
-    }
+    const initialVars = { id, termsPageSize };
 
     const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, initialVars);
     const taxonomy = response?.taxonomy;

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -14,7 +14,6 @@ import {
   GET_TAXONOMIES_QUERY,
   TaxonomyQueryResponse,
   TaxonomiesQueryResponse,
-  Taxonomy,
 } from './taxonomies';
 
 /**

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -16,7 +16,6 @@ import {
   Taxonomy,
   TaxonomyQueryResponse,
   TaxonomiesQueryResponse,
-  TermList,
 } from './taxonomies';
 
 /**
@@ -139,130 +138,76 @@ export class ContentClient {
   }
 
   /**
-   * Retrieves all available taxonomies, with optional pagination support.
-   * @param {number} [pageSize] - Optional. The number of taxonomies to return per page.
-   * @param {number} [termsPageSize] - Optional. The number of terms to return per page within each taxonomy.
-   * @returns A promise that resolves to a paginated list of taxonomies, including pagination helpers (`fetchNext`) if applicable.
+   * Retrieves all available taxonomies with optional pagination support.
+   * Note: Only taxonomies are paginated. Terms within each taxonomy are returned in full (no term pagination).
+   * @param {object} [options] - Optional pagination options.
+   * @param {number} [options.pageSize] - Optional. Limits the number of taxonomies returned per page. If not provided, defaults to Content Services API default (20).
+   * @param {string} [options.after] - Optional. Cursor for pagination. Used to fetch the next page of taxonomies.
+   * @returns A promise that resolves to a paginated list of taxonomies, including pagination metadata (`hasMore`, `cursor`) for developer-controlled pagination.
    */
-  async getTaxonomies(
-    pageSize?: number,
-    termsPageSize?: number
-  ): Promise<ContentItemList<Taxonomy>> {
-    const fetchTaxonomiesPage = async (after: string = ''): Promise<ContentItemList<Taxonomy>> => {
-      debug.content(
-        'Fetching taxonomies (pageSize: %s, after: %s)',
-        pageSize ?? 'API Default',
-        after
-      );
+  async getTaxonomies(options?: {
+    pageSize?: number;
+    after?: string;
+  }): Promise<ContentItemList<Taxonomy>> {
+    debug.content(
+      'Fetching taxonomies (pageSize: %s, after: %s)',
+      options?.pageSize ?? 'API Default',
+      options?.after ?? ''
+    );
 
-      const createVariables = (after = '', termsAfter = '') => ({
-        pageSize,
-        after,
-        termsAfter,
-        termsPageSize,
-      });
+    const variables: Record<string, any> = {};
+    if (options?.pageSize !== undefined) variables.pageSize = options.pageSize;
 
-      const variables = createVariables(after);
+    variables.after = options?.after ?? '';
 
-      const response = await this.get<TaxonomiesQueryResponse>(GET_TAXONOMIES_QUERY, variables);
-      const data = response?.manyTaxonomy;
+    const response = await this.get<TaxonomiesQueryResponse>(GET_TAXONOMIES_QUERY, variables);
+    const data = response?.manyTaxonomy;
 
-      if (!data) {
-        return {
-          results: [],
+    return {
+      results: (data?.results ?? []).map((taxonomy) => ({
+        system: taxonomy.system,
+        terms: {
+          results: taxonomy.terms?.results ?? [],
           cursor: undefined,
           hasMore: false,
-        };
-      }
-
-      const taxonomies = await Promise.all(
-        data.results.map(async (taxonomy) => {
-          const fetchTermsPage = async (termsAfter: string = ''): Promise<TermList> => {
-            debug.content(
-              'Fetching terms for taxonomy %s (termsPageSize: %s, after: %s)',
-              taxonomy.system.id,
-              termsPageSize ?? 'API Default',
-              termsAfter
-            );
-
-            const termVariables = createVariables(after, termsAfter);
-
-            const termResponse = await this.get<TaxonomiesQueryResponse>(
-              GET_TAXONOMIES_QUERY,
-              termVariables
-            );
-            const termData = termResponse?.manyTaxonomy?.results.find(
-              (r) => r.system.id === taxonomy.system.id
-            )?.terms;
-
-            return {
-              results: termData?.results ?? [],
-              cursor: termData?.cursor,
-              hasMore: termData?.hasMore ?? false,
-              fetchNext: termData?.hasMore
-                ? () => fetchTermsPage(termData.cursor || '')
-                : undefined,
-            };
-          };
-
-          return {
-            system: taxonomy.system,
-            terms: {
-              results: taxonomy.terms?.results ?? [],
-              cursor: taxonomy.terms?.cursor,
-              hasMore: taxonomy.terms?.hasMore ?? false,
-              fetchNext: taxonomy.terms?.hasMore
-                ? () => fetchTermsPage(taxonomy.terms.cursor || '')
-                : undefined,
-            },
-          };
-        })
-      );
-
-      return {
-        results: taxonomies,
-        cursor: data.cursor,
-        hasMore: data.hasMore,
-        fetchNext: data.hasMore ? () => fetchTaxonomiesPage(data.cursor || '') : undefined,
-      };
+        },
+      })),
+      cursor: data?.cursor,
+      hasMore: data?.hasMore ?? false,
     };
-
-    return fetchTaxonomiesPage();
   }
 
   /**
    * Retrieves a taxonomy by its ID, with optional pagination support for its terms.
-   * @param {string} id - The unique identifier of the taxonomy.
-   * @param {number} [termsPageSize] - Optional. The number of terms to return per page.
-   * @returns A promise that resolves to the taxonomy object, including its system metadata, the initial set of terms, and a `fetchNext` function for retrieving additional terms if available. Returns `null` if the taxonomy is not found.
+   * @param {object} options - Options for fetching the taxonomy.
+   * @param {string} options.id - The unique identifier of the taxonomy.
+   * @param {object} [options.terms] - Optional pagination options for terms.
+   * @param {number} [options.terms.pageSize] - Optional. Limits the number of terms returned per page.
+   * @param {string} [options.terms.after] - Optional. Cursor for pagination. Used to fetch the next page of terms.
+   * @returns A promise that resolves to the taxonomy object, including pagination metadata (`hasMore`, `cursor`) for its terms. Returns `null` if the taxonomy is not found.
    */
-  async getTaxonomy(id: string, termsPageSize?: number): Promise<Taxonomy | null> {
-    debug.content('Getting taxonomy for id: %s', id);
-
-    const fetchTermsPage = async (termsAfter: string = ''): Promise<TermList> => {
-      debug.content(
-        'Fetching terms for taxonomy %s (termsPageSize: %s, after: %s)',
-        id,
-        termsPageSize ?? 'API Default',
-        termsAfter
-      );
-
-      const variables = { id, termsAfter, termsPageSize };
-
-      const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, variables);
-      const terms = response?.taxonomy?.terms;
-
-      return {
-        results: terms?.results ?? [],
-        cursor: terms?.cursor,
-        hasMore: terms?.hasMore ?? false,
-        fetchNext: terms?.hasMore ? () => fetchTermsPage(terms.cursor || '') : undefined,
-      };
+  async getTaxonomy({
+    id,
+    terms,
+  }: {
+    id: string;
+    terms?: {
+      pageSize?: number;
+      after?: string;
     };
+  }): Promise<Taxonomy | null> {
+    debug.content(
+      'Getting taxonomy for id: %s (termsPageSize: %s, termsAfter: %s)',
+      id,
+      terms?.pageSize ?? 'API Default',
+      terms?.after ?? ''
+    );
 
-    const initialVars = { id, termsPageSize };
+    const variables: Record<string, any> = { id };
+    if (terms?.pageSize !== undefined) variables.termsPageSize = terms.pageSize;
+    if (terms?.after !== undefined) variables.termsAfter = terms.after;
 
-    const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, initialVars);
+    const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, variables);
     const taxonomy = response?.taxonomy;
 
     if (!taxonomy) return null;
@@ -273,9 +218,6 @@ export class ContentClient {
         results: taxonomy.terms?.results ?? [],
         cursor: taxonomy.terms?.cursor,
         hasMore: taxonomy.terms?.hasMore ?? false,
-        fetchNext: taxonomy.terms?.hasMore
-          ? () => fetchTermsPage(taxonomy.terms.cursor || '')
-          : undefined,
       },
     };
   }

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -12,7 +12,6 @@ import {
 import {
   GET_TAXONOMY_QUERY,
   GET_TAXONOMIES_QUERY,
-  ContentItemList,
   Taxonomy,
   TaxonomyQueryResponse,
   TaxonomiesQueryResponse,

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -139,26 +139,22 @@ export class ContentClient {
 
   /**
    * Retrieves all available taxonomies with optional pagination support.
-   * Note: Only taxonomies are paginated. Terms within each taxonomy are returned in full (no term pagination).
    * @param {object} [options] - Optional pagination options.
-   * @param {number} [options.pageSize] - Optional. Limits the number of taxonomies returned per page. If not provided, defaults to Content Services API default (20).
-   * @param {string} [options.after] - Optional. Cursor for pagination. Used to fetch the next page of taxonomies.
-   * @returns A promise that resolves to a paginated list of taxonomies, including pagination metadata (`hasMore`, `cursor`) for developer-controlled pagination.
+   * @param {number} [options.pageSize] - Limits the number of taxonomies returned per page. Defaults to the API's default
+   * @param {string} [options.after] - Cursor for pagination; use the `cursor` returned from the previous call to fetch the next page.
+   * @returns A promise that resolves to an object containing taxonomies, their terms, and pagination info.
    */
-  async getTaxonomies(options?: {
-    pageSize?: number;
-    after?: string;
-  }): Promise<ContentItemList<Taxonomy>> {
+  async getTaxonomies(options?: { pageSize?: number; after?: string }) {
     debug.content(
-      'Fetching taxonomies (pageSize: %s, after: %s)',
+      'Getting taxonomies (pageSize: %s, after: %s)',
       options?.pageSize ?? 'API Default',
       options?.after ?? ''
     );
 
-    const variables: Record<string, any> = {};
-    if (options?.pageSize !== undefined) variables.pageSize = options.pageSize;
-
-    variables.after = options?.after ?? '';
+    const variables: Record<string, any> = {
+      pageSize: options?.pageSize,
+      after: options?.after ?? '',
+    };
 
     const response = await this.get<TaxonomiesQueryResponse>(GET_TAXONOMIES_QUERY, variables);
     const data = response?.manyTaxonomy;
@@ -166,11 +162,7 @@ export class ContentClient {
     return {
       results: (data?.results ?? []).map((taxonomy) => ({
         system: taxonomy.system,
-        terms: {
-          results: taxonomy.terms?.results ?? [],
-          cursor: undefined,
-          hasMore: false,
-        },
+        terms: taxonomy.terms?.results ?? [],
       })),
       cursor: data?.cursor,
       hasMore: data?.hasMore ?? false,
@@ -203,9 +195,11 @@ export class ContentClient {
       terms?.after ?? ''
     );
 
-    const variables: Record<string, any> = { id };
-    if (terms?.pageSize !== undefined) variables.termsPageSize = terms.pageSize;
-    if (terms?.after !== undefined) variables.termsAfter = terms.after;
+    const variables: Record<string, any> = {
+      id,
+      termsPageSize: terms?.pageSize,
+      termsAfter: terms?.after,
+    };
 
     const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, variables);
     const taxonomy = response?.taxonomy;

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -9,6 +9,13 @@ import {
   LocaleQueryResponse,
   LocalesQueryResponse,
 } from './locales';
+import {
+  GET_TAXONOMY_QUERY,
+  GET_TAXONOMIES_QUERY,
+  TaxonomyQueryResponse,
+  TaxonomiesQueryResponse,
+  Taxonomy,
+} from './taxonomies';
 
 /**
  * Interface representing the options for the ContentClient.
@@ -103,7 +110,6 @@ export class ContentClient {
     options: FetchOptions = {}
   ): Promise<T> {
     debug.content('fetching content data');
-
     return this.graphqlClient.request<T>(query, variables, options);
   }
 
@@ -128,5 +134,28 @@ export class ContentClient {
 
     const response = await this.get<LocalesQueryResponse>(GET_LOCALES_QUERY);
     return response.manyLocale;
+  }
+
+  /**
+   * Retrieves all available taxonomies.
+   * @returns A promise that resolves to a list of taxonomies.
+   */
+  async getTaxonomies() {
+    debug.content('Getting taxonomies');
+
+    const response = await this.get<TaxonomiesQueryResponse>(GET_TAXONOMIES_QUERY);
+    return response?.manyTaxonomy;
+  }
+
+  /**
+   * Retrieves a taxonomy by its ID.
+   * @param {string} id - The unique identifier of the taxonomy.
+   * @returns A promise that resolves to the taxonomy information associated with the specified ID.
+   */
+  async getTaxonomy(id: string) {
+    debug.content('Getting taxonomy for id: %s', id);
+
+    const response = await this.get<TaxonomyQueryResponse>(GET_TAXONOMY_QUERY, { id });
+    return response?.taxonomy;
   }
 }

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -150,7 +150,7 @@ export class ContentClient {
       options?.after ?? ''
     );
 
-    const variables: Record<string, any> = {
+    const variables = {
       pageSize: options?.pageSize,
       after: options?.after ?? '',
     };
@@ -194,7 +194,7 @@ export class ContentClient {
       terms?.after ?? ''
     );
 
-    const variables: Record<string, any> = {
+    const variables = {
       id,
       termsPageSize: terms?.pageSize,
       termsAfter: terms?.after,

--- a/packages/core/src/content/taxonomies.ts
+++ b/packages/core/src/content/taxonomies.ts
@@ -1,0 +1,129 @@
+/**
+ * Represents a taxonomy term.
+ */
+export type TaxonomyTerm = {
+  /** The ID of the taxonomy term. */
+  id: string;
+  /** The name of the term. */
+  name: string;
+  /** A human readable description for the term. */
+  label?: string;
+};
+
+/**
+ * Represents a list of taxonomy terms.
+ */
+export type TaxonomyTermList = {
+  /** The cursor for the term. */
+  cursor: string | null;
+  /** Indicates if there are more terms to fetch. */
+  hasMore: boolean;
+  /** The list of terms. */
+  results: TaxonomyTerm[];
+};
+
+/**
+ * Represents system fields of a taxonomy.
+ */
+export type TaxonomySystem = {
+  id: string;
+  name: string;
+  version: number;
+  label: string;
+  createdAt: string;
+  createdBy: string;
+  updatedAt: string;
+  updatedBy: string;
+  publishStatus: string;
+};
+
+/**
+ * Represents a taxonomy.
+ */
+export type Taxonomy = {
+  /** The terms of the taxonomy. */
+  terms: TaxonomyTermList;
+  /** The system fields of the taxonomy. */
+  system: TaxonomySystem;
+};
+
+/**
+ * Represents the response structure for a query that retrieves a single taxonomy.
+ */
+export interface TaxonomyQueryResponse {
+  taxonomy: Taxonomy | null;
+}
+
+/**
+ * Represents the response structure for a query that retrieves multiple taxonomies.
+ */
+export interface TaxonomiesQueryResponse {
+  manyTaxonomy: {
+    results: Taxonomy[];
+  };
+}
+
+/**
+ * GraphQL query to retrieve a specific taxonomy by its ID.
+ *
+ * Variables:
+ * - id: The ID of the taxonomy to retrieve.
+ */
+export const GET_TAXONOMY_QUERY = `
+  query GetTaxonomyById($id: ID!) {
+    taxonomy(id: $id) {
+      terms {
+        cursor
+        hasMore
+        results {
+          id
+          name
+          label
+        }
+      }
+      system {
+        id
+        name
+        version
+        label
+        createdAt
+        createdBy
+        updatedAt
+        updatedBy
+        publishStatus
+      }
+    }
+  }
+`;
+
+/**
+ * GraphQL query to retrieve all available taxonomies.
+ */
+export const GET_TAXONOMIES_QUERY = `query GetAllTaxonomies {
+  manyTaxonomy {
+    cursor
+    hasMore
+    results {
+      terms {
+        cursor
+        hasMore
+        results {
+          id
+          name
+          label
+        }
+      }
+      system {
+        id
+        name
+        version
+        label
+        createdAt
+        createdBy
+        updatedAt
+        updatedBy
+        publishStatus
+      }
+    }
+  }
+}`;

--- a/packages/core/src/content/taxonomies.ts
+++ b/packages/core/src/content/taxonomies.ts
@@ -22,8 +22,6 @@ export interface TermList {
   cursor?: string | null;
   /** Indicates whether more terms are available after the current page. (Used only in getTaxonomy) */
   hasMore: boolean;
-  /** The minimum page size used for fetching terms (if provided). (Used only in getTaxonomy) */
-  minimumPageSize?: number;
 }
 
 /**
@@ -113,8 +111,6 @@ export interface ContentItemList<T> {
   cursor?: string;
   /** Indicates whether more items are available after the current page. */
   hasMore: boolean;
-  /** The minimum page size used for fetching items (if applicable). */
-  minimumPageSize?: number;
 }
 
 // --- GraphQL queries ---

--- a/packages/core/src/content/taxonomies.ts
+++ b/packages/core/src/content/taxonomies.ts
@@ -11,19 +11,19 @@ export type Term = {
 };
 
 /**
- * Represents a paginated list of terms within a taxonomy.
+ * Represents a list of terms within a taxonomy.
+ * In getTaxonomies, terms are always returned as a full list (no pagination).
+ * In getTaxonomy, terms may be paginated.
  */
 export interface TermList {
-  /** The list of terms in the current page. */
+  /** The list of terms in the current (or full) page. */
   results: Term[];
-  /** The cursor to fetch the next page of terms, if available. */
+  /** The cursor to fetch the next page of terms, if available. (Used only in getTaxonomy) */
   cursor?: string | null;
-  /** Indicates whether more terms are available after the current page. */
+  /** Indicates whether more terms are available after the current page. (Used only in getTaxonomy) */
   hasMore: boolean;
-  /** The minimum page size used for fetching terms (if provided). */
+  /** The minimum page size used for fetching terms (if provided). (Used only in getTaxonomy) */
   minimumPageSize?: number;
-  /** A function to fetch the next page of terms, if available. */
-  fetchNext?: () => Promise<TermList>;
 }
 
 /**
@@ -52,9 +52,10 @@ export type TaxonomySystem = {
 
 /**
  * Represents a taxonomy with its associated terms.
+ * Terms are paginated only in single-taxonomy queries (getTaxonomy).
  */
 export type Taxonomy = {
-  /** The list of terms within the taxonomy, with pagination support. */
+  /** The list of terms within the taxonomy. */
   terms: TermList;
   /** The system metadata of the taxonomy. */
   system: TaxonomySystem;
@@ -65,7 +66,16 @@ export type Taxonomy = {
  */
 export interface TaxonomyQueryResponse {
   /** The retrieved taxonomy. */
-  taxonomy: Taxonomy;
+  taxonomy: {
+    /** The system metadata of the taxonomy. */
+    system: TaxonomySystem;
+    /** The terms for the taxonomy (may be paginated). */
+    terms: {
+      results: Term[];
+      cursor?: string | null;
+      hasMore: boolean;
+    };
+  };
 }
 
 /**
@@ -76,7 +86,7 @@ export interface TaxonomiesQueryResponse {
   manyTaxonomy: {
     /** The list of taxonomies in the current page. */
     results: {
-      /** The terms associated with the taxonomy, in a paginated format. */
+      /** The terms associated with the taxonomy (always the full list, not paginated). */
       terms: {
         results: Term[];
         cursor?: string | null;
@@ -94,6 +104,7 @@ export interface TaxonomiesQueryResponse {
 
 /**
  * Represents a paginated list of content items (generic for various types, e.g., Taxonomy).
+ * Note: This type does not include any stateful fetchNext/fetchMore helpers. Pagination is stateless.
  */
 export interface ContentItemList<T> {
   /** The list of content items in the current page. */
@@ -104,31 +115,27 @@ export interface ContentItemList<T> {
   hasMore: boolean;
   /** The minimum page size used for fetching items (if applicable). */
   minimumPageSize?: number;
-  /** A function to fetch the next page of items, if available. */
-  fetchNext?: () => Promise<ContentItemList<T>>;
 }
 
+// --- GraphQL queries ---
+
 /**
- * GraphQL query to retrieve all taxonomies with optional pagination for taxonomies and terms.
+ * GraphQL query to retrieve all taxonomies with optional pagination for taxonomies only.
  *
  * Variables:
  * - pageSize: The number of taxonomies to retrieve per page.
- * - termsPageSize: The number of terms to retrieve per page within each taxonomy.
  * - after: The cursor for fetching the next page of taxonomies.
- * - termsAfter: The cursor for fetching the next page of terms within a taxonomy.
  */
 export const GET_TAXONOMIES_QUERY = `
   query GetAllTaxonomies(
     $pageSize: Int
-    $termsPageSize: Int
     $after: String
-    $termsAfter: String
   ) {
     manyTaxonomy(minimumPageSize: $pageSize, after: $after) {
       cursor
       hasMore
       results {
-        terms(minimumPageSize: $termsPageSize, after: $termsAfter) {
+        terms {
           cursor
           hasMore
           results {

--- a/packages/core/src/content/taxonomies.ts
+++ b/packages/core/src/content/taxonomies.ts
@@ -1,78 +1,170 @@
 /**
- * Represents a taxonomy term.
+ * Represents a term within a taxonomy.
  */
-export type TaxonomyTerm = {
-  /** The ID of the taxonomy term. */
+export type Term = {
+  /** The unique identifier of the term. */
   id: string;
-  /** The name of the term. */
+  /** The internal name of the term. */
   name: string;
-  /** A human readable description for the term. */
-  label?: string;
+  /** The display label of the term. */
+  label: string;
 };
 
 /**
- * Represents a list of taxonomy terms.
+ * Represents a paginated list of terms within a taxonomy.
  */
-export type TaxonomyTermList = {
-  /** The cursor for the term. */
-  cursor: string | null;
-  /** Indicates if there are more terms to fetch. */
+export interface TermList {
+  /** The list of terms in the current page. */
+  results: Term[];
+  /** The cursor to fetch the next page of terms, if available. */
+  cursor?: string | null;
+  /** Indicates whether more terms are available after the current page. */
   hasMore: boolean;
-  /** The list of terms. */
-  results: TaxonomyTerm[];
-};
+  /** The minimum page size used for fetching terms (if provided). */
+  minimumPageSize?: number;
+  /** A function to fetch the next page of terms, if available. */
+  fetchNext?: () => Promise<TermList>;
+}
 
 /**
- * Represents system fields of a taxonomy.
+ * Represents the system metadata of a taxonomy.
  */
 export type TaxonomySystem = {
+  /** The unique identifier of the taxonomy. */
   id: string;
+  /** The internal name of the taxonomy. */
   name: string;
+  /** The version of the taxonomy. */
   version: number;
+  /** The display label of the taxonomy. */
   label: string;
+  /** The timestamp when the taxonomy was created (ISO 8601 format). */
   createdAt: string;
+  /** The user ID who created the taxonomy. */
   createdBy: string;
+  /** The timestamp when the taxonomy was last updated (ISO 8601 format). */
   updatedAt: string;
+  /** The user ID who last updated the taxonomy. */
   updatedBy: string;
+  /** The publish status of the taxonomy (e.g., PREVIEW, PUBLISHED). */
   publishStatus: string;
 };
 
 /**
- * Represents a taxonomy.
+ * Represents a taxonomy with its associated terms.
  */
 export type Taxonomy = {
-  /** The terms of the taxonomy. */
-  terms: TaxonomyTermList;
-  /** The system fields of the taxonomy. */
+  /** The list of terms within the taxonomy, with pagination support. */
+  terms: TermList;
+  /** The system metadata of the taxonomy. */
   system: TaxonomySystem;
 };
 
 /**
- * Represents the response structure for a query that retrieves a single taxonomy.
+ * Represents the response structure for a query that retrieves a specific taxonomy by ID.
  */
 export interface TaxonomyQueryResponse {
-  taxonomy: Taxonomy | null;
+  /** The retrieved taxonomy. */
+  taxonomy: Taxonomy;
 }
 
 /**
  * Represents the response structure for a query that retrieves multiple taxonomies.
  */
 export interface TaxonomiesQueryResponse {
+  /** The list of retrieved taxonomies, with pagination metadata. */
   manyTaxonomy: {
-    results: Taxonomy[];
+    /** The list of taxonomies in the current page. */
+    results: {
+      /** The terms associated with the taxonomy, in a paginated format. */
+      terms: {
+        results: Term[];
+        cursor?: string | null;
+        hasMore: boolean;
+      };
+      /** The system metadata of the taxonomy. */
+      system: TaxonomySystem;
+    }[];
+    /** The cursor for fetching the next page of taxonomies, if available. */
+    cursor?: string;
+    /** Indicates whether more taxonomies are available after the current page. */
+    hasMore: boolean;
   };
 }
 
 /**
- * GraphQL query to retrieve a specific taxonomy by its ID.
+ * Represents a paginated list of content items (generic for various types, e.g., Taxonomy).
+ */
+export interface ContentItemList<T> {
+  /** The list of content items in the current page. */
+  results: T[];
+  /** The cursor for fetching the next page of items, if available. */
+  cursor?: string;
+  /** Indicates whether more items are available after the current page. */
+  hasMore: boolean;
+  /** The minimum page size used for fetching items (if applicable). */
+  minimumPageSize?: number;
+  /** A function to fetch the next page of items, if available. */
+  fetchNext?: () => Promise<ContentItemList<T>>;
+}
+
+/**
+ * GraphQL query to retrieve all taxonomies with optional pagination for taxonomies and terms.
  *
  * Variables:
- * - id: The ID of the taxonomy to retrieve.
+ * - minimumPageSize: The number of taxonomies to retrieve per page.
+ * - termsPageSize: The number of terms to retrieve per page within each taxonomy.
+ * - after: The cursor for fetching the next page of taxonomies.
+ * - termsAfter: The cursor for fetching the next page of terms within a taxonomy.
+ */
+export const GET_TAXONOMIES_QUERY = `
+  query GetAllTaxonomies(
+    $minimumPageSize: Int
+    $termsPageSize: Int
+    $after: String
+    $termsAfter: String
+  ) {
+    manyTaxonomy(minimumPageSize: $minimumPageSize, after: $after) {
+      cursor
+      hasMore
+      results {
+        terms(minimumPageSize: $termsPageSize, after: $termsAfter) {
+          cursor
+          hasMore
+          results {
+            id
+            name
+            label
+          }
+        }
+        system {
+          id
+          name
+          version
+          label
+          createdAt
+          createdBy
+          updatedAt
+          updatedBy
+          publishStatus
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * GraphQL query to retrieve a specific taxonomy by its ID, with optional pagination for its terms.
+ *
+ * Variables:
+ * - id: The unique ID of the taxonomy to retrieve.
+ * - termsPageSize: The number of terms to retrieve per page.
+ * - termsAfter: The cursor for fetching the next page of terms.
  */
 export const GET_TAXONOMY_QUERY = `
-  query GetTaxonomyById($id: ID!) {
+  query GetTaxonomyById($id: ID!, $termsPageSize: Int, $termsAfter: String) {
     taxonomy(id: $id) {
-      terms {
+      terms(minimumPageSize: $termsPageSize, after: $termsAfter) {
         cursor
         hasMore
         results {
@@ -95,35 +187,3 @@ export const GET_TAXONOMY_QUERY = `
     }
   }
 `;
-
-/**
- * GraphQL query to retrieve all available taxonomies.
- */
-export const GET_TAXONOMIES_QUERY = `query GetAllTaxonomies {
-  manyTaxonomy {
-    cursor
-    hasMore
-    results {
-      terms {
-        cursor
-        hasMore
-        results {
-          id
-          name
-          label
-        }
-      }
-      system {
-        id
-        name
-        version
-        label
-        createdAt
-        createdBy
-        updatedAt
-        updatedBy
-        publishStatus
-      }
-    }
-  }
-}`;

--- a/packages/core/src/content/taxonomies.ts
+++ b/packages/core/src/content/taxonomies.ts
@@ -112,19 +112,19 @@ export interface ContentItemList<T> {
  * GraphQL query to retrieve all taxonomies with optional pagination for taxonomies and terms.
  *
  * Variables:
- * - minimumPageSize: The number of taxonomies to retrieve per page.
+ * - pageSize: The number of taxonomies to retrieve per page.
  * - termsPageSize: The number of terms to retrieve per page within each taxonomy.
  * - after: The cursor for fetching the next page of taxonomies.
  * - termsAfter: The cursor for fetching the next page of terms within a taxonomy.
  */
 export const GET_TAXONOMIES_QUERY = `
   query GetAllTaxonomies(
-    $minimumPageSize: Int
+    $pageSize: Int
     $termsPageSize: Int
     $after: String
     $termsAfter: String
   ) {
-    manyTaxonomy(minimumPageSize: $minimumPageSize, after: $after) {
+    manyTaxonomy(minimumPageSize: $pageSize, after: $after) {
       cursor
       hasMore
       results {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
JSS-5343 -> This PR adds the `getTaxonomy` and `getTaxonomies` methods to the Content Client, providing the ability to retrieve taxonomy data from Content Services. It also introduces and exports the related queries and response types 

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
