### PR TITLE
[core] Update getLocale(s) based on new schema structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[core]`
 * `[Content - Name TBD] Support`:
-* - Updated `getLocale/getLocales` based on new GQL Schemas ([#105](https://github.com/Sitecore/content-sdk/pull/105))
   - Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
     - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
     - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
-  - Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))   
+  - Introduced `getLocale/getLocales` functionality on content client: 
+    - Updated `getLocale/getLocales` based on new GQL Schemas ([#105](https://github.com/Sitecore/content-sdk/pull/105))   
+    - Initial implementation of `getLocale/getLocales` ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ Our versioning strategy is as follows:
     - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
     - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
   - Introduced `getLocale/getLocales` functionality on content client: 
-    - Updated `getLocale/getLocales` based on new GQL Schemas ([#105](https://github.com/Sitecore/content-sdk/pull/105))   
-    - Initial implementation of `getLocale/getLocales` ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))
+    - Initial implementation of `getLocale/getLocales` ([#74](https://github.com/Sitecore/content-sdk/pull/74)) ([#78](https://github.com/Sitecore/content-sdk/pull/78)) ([#105](https://github.com/Sitecore/content-sdk/pull/105))   
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
+* `[core]` Update `getLocale/getLocales` ([#105](https://github.com/Sitecore/content-sdk/pull/105))
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.

--- a/packages/core/src/content/content-client.test.ts
+++ b/packages/core/src/content/content-client.test.ts
@@ -156,7 +156,9 @@ describe('content-client', () => {
 
     it('should retrieve a locale by ID', async () => {
       const localeId = 'en-us';
-      const mockResponse = { locale: { id: localeId, label: 'English (US)' } };
+      const mockResponse = {
+        locale: { system: { id: localeId, label: 'English (US)' } },
+      };
 
       requestStub.resolves(mockResponse);
 
@@ -164,7 +166,7 @@ describe('content-client', () => {
 
       expect(requestStub.calledOnce).to.be.true;
       expect(requestStub.calledWith(GET_LOCALE_QUERY, { id: localeId })).to.be.true;
-      expect(result).to.deep.equal(mockResponse.locale);
+      expect(result).to.deep.equal(mockResponse.locale.system);
     });
 
     it('should handle errors when retrieving a locale by ID', async () => {
@@ -200,8 +202,8 @@ describe('content-client', () => {
     it('should retrieve all available locales', async () => {
       const mockResponse = {
         manyLocale: [
-          { id: 'en-us', label: 'English (US)' },
-          { id: 'fr-fr', label: 'French (France)' },
+          { system: { id: 'en-us', label: 'English (US)' } },
+          { system: { id: 'fr-fr', label: 'French (France)' } },
         ],
       };
 
@@ -211,7 +213,7 @@ describe('content-client', () => {
 
       expect(requestStub.calledOnce).to.be.true;
       expect(requestStub.calledWith(GET_LOCALES_QUERY)).to.be.true;
-      expect(result).to.deep.equal(mockResponse.manyLocale);
+      expect(result).to.deep.equal(mockResponse.manyLocale.map((x) => x.system));
     });
 
     it('should handle errors when retrieving all locales', async () => {

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -122,7 +122,7 @@ export class ContentClient {
     debug.content('Getting locale for id: %s', id);
 
     const response = await this.get<LocaleQueryResponse>(GET_LOCALE_QUERY, { id });
-    return response.locale ? response?.locale?.system : null;
+    return response.locale?.system || null;
   }
 
   /**

--- a/packages/core/src/content/content-client.ts
+++ b/packages/core/src/content/content-client.ts
@@ -116,7 +116,7 @@ export class ContentClient {
     debug.content('Getting locale for id: %s', id);
 
     const response = await this.get<LocaleQueryResponse>(GET_LOCALE_QUERY, { id });
-    return response.locale;
+    return response.locale ? response?.locale?.system : null;
   }
 
   /**
@@ -127,6 +127,6 @@ export class ContentClient {
     debug.content('Getting all locales');
 
     const response = await this.get<LocalesQueryResponse>(GET_LOCALES_QUERY);
-    return response.manyLocale;
+    return response?.manyLocale?.map((entry) => entry.system) ?? [];
   }
 }

--- a/packages/core/src/content/index.ts
+++ b/packages/core/src/content/index.ts
@@ -4,6 +4,6 @@ export {
   GET_LOCALES_QUERY,
   LocaleQueryResponse,
   LocalesQueryResponse,
-  SingleLocale,
+  Locale,
 } from './locales';
 export { getContentUrl } from './utils';

--- a/packages/core/src/content/index.ts
+++ b/packages/core/src/content/index.ts
@@ -4,6 +4,6 @@ export {
   GET_LOCALES_QUERY,
   LocaleQueryResponse,
   LocalesQueryResponse,
-  Locale,
+  SingleLocale,
 } from './locales';
 export { getContentUrl } from './utils';

--- a/packages/core/src/content/locales.ts
+++ b/packages/core/src/content/locales.ts
@@ -1,30 +1,32 @@
 /**
- * Represents the "system" field in a locale response.
+ * Represents the locale entity.
  */
-export type SingleLocale = {
+export type Locale = {
+  /** The unique identifier of the locale. */
   id: string;
+  /** The label of the locale. */
   label: string;
 };
 
 /**
- * Represents a locale result with a system field.
+ * Represents a locale query response.
  */
-export type LocaleEntry = {
-  system: SingleLocale;
+export type LocaleItem = {
+  system: Locale;
 };
 
 /**
  * Represents the response structure for a query that retrieves a single locale.
  */
 export interface LocaleQueryResponse {
-  locale: LocaleEntry | null;
+  locale: LocaleItem | null;
 }
 
 /**
  * Represents the response structure for a query that retrieves multiple locales.
  */
 export interface LocalesQueryResponse {
-  manyLocale: LocaleEntry[];
+  manyLocale: LocaleItem[];
 }
 
 /**

--- a/packages/core/src/content/locales.ts
+++ b/packages/core/src/content/locales.ts
@@ -1,26 +1,31 @@
 /**
- * Represents the response structure for a query that retrieves a locale.
+ * Represents the "system" field in a locale response.
+ */
+export type SingleLocale = {
+  id: string;
+  label: string;
+};
+
+/**
+ * Represents a locale result with a system field.
+ */
+export type LocaleEntry = {
+  system: SingleLocale;
+};
+
+/**
+ * Represents the response structure for a query that retrieves a single locale.
  */
 export interface LocaleQueryResponse {
-  locale: Locale | null;
+  locale: LocaleEntry | null;
 }
 
 /**
  * Represents the response structure for a query that retrieves multiple locales.
  */
 export interface LocalesQueryResponse {
-  manyLocale: Locale[];
+  manyLocale: LocaleEntry[];
 }
-
-/**
- * Represents a locale with an id and a label.
- */
-export type Locale = {
-  /** The unique identifier for the locale. */
-  id: string;
-  /** The display name or label for the locale. */
-  label: string;
-};
 
 /**
  * GraphQL query to retrieve a specific locale by its ID.
@@ -29,10 +34,12 @@ export type Locale = {
  * - id: The ID of the locale to retrieve.
  */
 export const GET_LOCALE_QUERY = `
-  query GetLocaleById ($id: ID!) {
+  query GetLocaleById($id: ID!) {
     locale(id: $id) {
-      id
-      label
+      system {
+        id
+        label
+      }
     }
   }
 `;
@@ -41,10 +48,12 @@ export const GET_LOCALE_QUERY = `
  * GraphQL query to retrieve all available locales.
  */
 export const GET_LOCALES_QUERY = `
-  query GetAllLocales{
+  query GetAllLocales {
     manyLocale {
-      id
-      label
+      system {
+        id
+        label
+      }
     }
   }
 `;

--- a/packages/core/src/content/locales.ts
+++ b/packages/core/src/content/locales.ts
@@ -9,7 +9,7 @@ export type Locale = {
 };
 
 /**
- * Represents a locale query response.
+ * A locale item included in a locale query response.
  */
 export type LocaleItem = {
   system: Locale;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

This PR makes the following updates:

- Updates the GraphQL queries for locales `(GET_LOCALE_QUERY, GET_LOCALES_QUERY)` to reflect the new API response format, where id and label are now nested inside a system object.
- Refactors the corresponding content client methods `(getLocale, getLocales)` to handle the updated structure and return a flat `{ id, label }` object.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
