### PR TITLE
[cli] Content Services CLI Authentication: Basic commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ Our versioning strategy is as follows:
   - Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
     - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
     - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
-  - Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))   
+  - Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))
+* `[cli]` Introduce Sitecore Content Services Auth CLI commands ([106](https://github.com/Sitecore/content-sdk/pull/106))
+    - auth login – Authenticate using client credentials and store token info
+    - auth status – Show active tenant and auto-renew token if expired
+    - auth logout – Clear active tenant and delete stored credentials
+    - auth list – List all known tenants from local storage
+  - Token validation and renewal support
+  - Token and tenant metadata storage and active tenant tracking under `~/.sitecore/sitecore-tools/`
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
   - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,17 @@ Our versioning strategy is as follows:
   - Introduced get taxonomy/taxonomies functionality on content client ([#99](https://github.com/Sitecore/content-sdk/pull/99)):
     - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
     - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
-  - Introduced get locales functionality on content client ([#74](https://github.com/Sitecore/content-sdk/pull/74))([#78](https://github.com/Sitecore/content-sdk/pull/78))
-* `[cli]` Introduce Sitecore Content Services Auth CLI commands ([106](https://github.com/Sitecore/content-sdk/pull/106))
-        - auth login – Authenticate using client credentials and store token info
-        - auth status – Show active tenant and auto-renew token if expired
-        - auth logout – Clear active tenant and delete stored credentials
-        - auth list – List all known tenants from local storage
-      - Token validation and renewal support
-      - Token and tenant metadata storage and active tenant tracking under `~/.sitecore/sitecore-tools/`
-      - Introduced `getLocale/getLocales` functionality on content client: 
-      - Initial implementation of `getLocale/getLocales` ([#74](https://github.com/Sitecore/content-sdk/pull/74)) ([#78](https://github.com/Sitecore/content-sdk/pull/78)) ([#105](https://github.com/Sitecore/content-sdk/pull/105))   
+  - Introduced `getLocale/getLocales` functionality on content client: 
+    - Initial implementation of `getLocale/getLocales` ([#74](https://github.com/Sitecore/content-sdk/pull/74)) ([#78](https://github.com/Sitecore/content-sdk/pull/78)) ([#105](https://github.com/Sitecore/content-sdk/pull/105))
+* `[cli]` Introduce Sitecore Content Services Auth CLI commands ([106](https://github.com/Sitecore/content-sdk/pull/106)):
+    - auth login: Authenticate using client credentials and store token info.
+    - auth status: Show active tenant and auto-renew token if expired.
+    - auth logout: Clear active tenant and delete stored credentials.
+    - auth list: List all known tenants from local storage.
+  - Token validation and renewal support.
+  - Token and tenant metadata storage and active tenant tracking under `~/.sitecore/sitecore-tools/`.
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
-  - Introduced `.env.container.example`  
+  - Introduced `.env.container.example`
     - Intended for local development against a Sitecore container instance.
   - Introduced `.env.remote.example`
     - Intended for working with a remote Sitecore instance.

--- a/packages/cli/src/scripts/auth/index.ts
+++ b/packages/cli/src/scripts/auth/index.ts
@@ -1,4 +1,4 @@
-﻿﻿import { Argv } from 'yargs';
+﻿import { Argv } from 'yargs';
 import { login } from './login';
 import { logout } from './logout';
 import { status } from './status';

--- a/packages/cli/src/scripts/auth/index.ts
+++ b/packages/cli/src/scripts/auth/index.ts
@@ -1,0 +1,25 @@
+﻿﻿import { Argv } from 'yargs';
+import { login } from './login';
+import { logout } from './logout';
+import { status } from './status';
+import { list } from './list';
+
+/**
+ * Registers the `auth` command group and its subcommands (`login`, `logout`, `status`, `list`) with Yargs.
+ * @param {Argv} yargs - The Yargs instance used to define CLI commands.
+ * @returns The configured Yargs command group for authentication operations.
+ */
+export function builder(yargs: Argv) {
+  return yargs.command({
+    command: 'auth',
+    describe: 'Performs authentication for content services',
+    builder: (_yargs: Argv) => {
+      return _yargs
+        .command([login, logout, status, list] as any)
+        .strict()
+        .demandCommand(1, 'You need to specify a command to run')
+        .help();
+    },
+    handler: () => {},
+  });
+}

--- a/packages/cli/src/scripts/auth/list.test.ts
+++ b/packages/cli/src/scripts/auth/list.test.ts
@@ -1,0 +1,64 @@
+﻿﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import { list } from './list';
+import * as tenantStore from '../../../src/utils/auth/tenant-store';
+
+describe('list command', () => {
+  let getAllTenantsStub: sinon.SinonStub;
+  let consoleLogStub: sinon.SinonStub;
+  let logs: string[];
+
+  beforeEach(() => {
+    logs = [];
+    consoleLogStub = sinon.stub(console, 'log').callsFake((msg) => {
+      logs.push(String(msg));
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should log message if no tenants are found', async () => {
+    getAllTenantsStub = sinon.stub(tenantStore, 'getAllTenantsInfo').returns([]);
+
+    await list.handler({} as any);
+
+    expect(consoleLogStub.calledOnce).to.be.true;
+    expect(logs[0]).to.include('No tenant information found');
+  });
+
+  it('should log all tenant properties line by line', async () => {
+    const mockTenants = [
+      {
+        tenantId: 't1',
+        tenantName: 'Tenant One',
+        organizationId: 'org1',
+        clientId: 'client1',
+        authority: 'auth1',
+        audience: 'aud1',
+        baseUrl: 'base1',
+      },
+    ];
+
+    getAllTenantsStub = sinon.stub(tenantStore, 'getAllTenantsInfo').returns(mockTenants);
+
+    await list.handler({} as any);
+
+    const expectedLogs = [
+      '\n Known tenants:\n',
+      'Tenant 1:',
+      '  Tenant ID       : t1',
+      '  Tenant Name     : Tenant One',
+      '  Organization ID : org1',
+      '  Client ID       : client1',
+      '  Authority       : auth1',
+      '  Audience        : aud1',
+      '  Base URL        : base1',
+    ];
+
+    expectedLogs.forEach((expectedLine) => {
+      expect(logs).to.include(expectedLine);
+    });
+  });
+});

--- a/packages/cli/src/scripts/auth/list.test.ts
+++ b/packages/cli/src/scripts/auth/list.test.ts
@@ -1,4 +1,4 @@
-﻿﻿import { expect } from 'chai';
+﻿import { expect } from 'chai';
 import sinon from 'sinon';
 import { list } from './list';
 import * as tenantStore from '../../../src/utils/auth/tenant-store';

--- a/packages/cli/src/scripts/auth/list.ts
+++ b/packages/cli/src/scripts/auth/list.ts
@@ -1,0 +1,29 @@
+﻿import { CommandModule } from 'yargs';
+import { getAllTenantsInfo } from '../../utils/auth/tenant-store';
+
+export const list: CommandModule = {
+  command: 'list',
+  describe: 'List all known tenants',
+  handler: async () => {
+    const tenants = getAllTenantsInfo();
+
+    if (tenants.length === 0) {
+      console.log('\n No tenant information found.');
+      return;
+    }
+
+    console.log('\n Known tenants:\n');
+
+    tenants.forEach((tenant, index) => {
+      console.log(`Tenant ${index + 1}:`);
+      console.log(`  Tenant ID       : ${tenant.tenantId}`);
+      console.log(`  Tenant Name     : ${tenant.tenantName || 'N/A'}`);
+      console.log(`  Organization ID : ${tenant.organizationId}`);
+      console.log(`  Client ID       : ${tenant.clientId}`);
+      console.log(`  Authority       : ${tenant.authority || 'N/A'}`);
+      console.log(`  Audience        : ${tenant.audience || 'N/A'}`);
+      console.log(`  Base URL        : ${tenant.baseUrl || 'N/A'}`);
+      console.log();
+    });
+  },
+};

--- a/packages/cli/src/scripts/auth/login.test.ts
+++ b/packages/cli/src/scripts/auth/login.test.ts
@@ -1,0 +1,95 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import { login } from '../../../src/scripts/auth/login';
+import * as authFlow from '../../../src/utils/auth/flow';
+import * as tenantStore from '../../../src/utils/auth/tenant-store';
+import * as tenantState from '../../../src/utils/auth/tenant-state';
+
+describe('login command', () => {
+  const fakeArgs = {
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    tenantId: 'test-tenant-id',
+    organizationId: 'test-org-id',
+    audience: 'https://example.com/api',
+    authority: 'https://auth.example.com',
+    baseUrl: 'https://api.example.com',
+  };
+
+  const fakeAuthResponse = {
+    data: {
+      access_token: 'test-access-token',
+      expires_in: 3600,
+    },
+    tokenTenantId: 'test-tenant-id',
+    tokenOrgId: 'test-org-id',
+    tokenTenantName: 'TestTenant',
+  };
+
+  let clientCredentialsStub: sinon.SinonStub;
+  let writeTenantAuthStub: sinon.SinonStub;
+  let writeTenantInfoStub: sinon.SinonStub;
+  let setActiveTenantStub: sinon.SinonStub;
+  let consoleInfoStub: sinon.SinonStub;
+  let processExitStub: sinon.SinonStub;
+  let consoleErrorStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    clientCredentialsStub = sinon
+      .stub(authFlow, 'clientCredentialsFlow')
+      .resolves(fakeAuthResponse);
+    writeTenantAuthStub = sinon.stub(tenantStore, 'writeTenantAuthInfo').resolves();
+    writeTenantInfoStub = sinon.stub(tenantStore, 'writeTenantInfo').resolves();
+    setActiveTenantStub = sinon.stub(tenantState, 'setActiveTenant');
+    consoleInfoStub = sinon.stub(console, 'info');
+    processExitStub = sinon.stub(process, 'exit');
+    consoleErrorStub = sinon.stub(console, 'error');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should call clientCredentialsFlow and save tenant info', async () => {
+    await login.handler(fakeArgs as any);
+
+    expect(clientCredentialsStub.calledOnce).to.be.true;
+    expect(clientCredentialsStub.firstCall.args[0]).to.include({
+      clientId: fakeArgs.clientId,
+      clientSecret: fakeArgs.clientSecret,
+      organizationId: fakeArgs.organizationId,
+      tenantId: fakeArgs.tenantId,
+      audience: fakeArgs.audience,
+      authority: fakeArgs.authority,
+      baseUrl: fakeArgs.baseUrl,
+    });
+
+    expect(writeTenantAuthStub.calledOnce).to.be.true;
+    expect(writeTenantInfoStub.calledOnce).to.be.true;
+    expect(setActiveTenantStub.calledWith(fakeAuthResponse.tokenTenantId)).to.be.true;
+    expect(consoleInfoStub.calledWithMatch(/Logged in successfully/)).to.be.true;
+  });
+
+  it('should exit when clientCredentialsFlow throws', async () => {
+    clientCredentialsStub.rejects(new Error('invalid'));
+
+    processExitStub.callsFake(() => {
+      throw new Error('EXIT_CALLED');
+    });
+
+    const argv = {
+      clientId: 'test-client-id',
+      clientSecret: 'valid-secret',
+    };
+
+    try {
+      await login.handler(argv as any);
+      throw new Error('Test failed: process.exit was not called');
+    } catch (err) {
+      expect((err as Error).message).to.equal('EXIT_CALLED');
+    }
+
+    expect(consoleErrorStub.calledWithMatch('Login failed')).to.be.true;
+    expect(processExitStub.calledOnceWith(1)).to.be.true;
+  });
+});

--- a/packages/cli/src/scripts/auth/login.ts
+++ b/packages/cli/src/scripts/auth/login.ts
@@ -1,0 +1,113 @@
+﻿import { Argv, CommandModule } from 'yargs';
+import { clientCredentialsFlow, AUTH0_DOMAIN, AUDIENCE, BASE_URL } from '../../utils/auth/flow';
+import { writeTenantAuthInfo, writeTenantInfo } from '../../utils/auth/tenant-store';
+import { setActiveTenant } from '../../utils/auth/tenant-state';
+import { TenantArgs } from './models';
+
+export const login: CommandModule<object, TenantArgs> = {
+  command: 'login',
+  describe: 'Login into a tenant',
+  builder: (yargs: Argv<object>): Argv<TenantArgs> =>
+    yargs
+      .option('clientId', {
+        type: 'string',
+        requiresArg: true,
+        demandOption: true,
+        describe: 'Client ID for authentication',
+      })
+      .option('clientSecret', {
+        type: 'string',
+        demandOption: false,
+        describe: 'Client secret for authentication',
+      })
+      .option('tenantId', {
+        type: 'string',
+        demandOption: false,
+        describe: 'Tenant ID to login into.',
+      })
+      .option('organizationId', {
+        type: 'string',
+        demandOption: false,
+        describe: 'Organization ID to authenticate against.',
+      })
+      .option('authority', {
+        type: 'string',
+        demandOption: false,
+        describe: 'OAuth 2.0 authority URL for authentication.',
+      })
+      .option('audience', {
+        type: 'string',
+        demandOption: false,
+        describe: 'Intended recipient of the token, usually the API base URL.',
+      })
+      .option('baseUrl', {
+        type: 'string',
+        demandOption: false,
+        describe: 'Base URL for the API, used to construct the audience.',
+      })
+      .group(
+        [
+          'clientId',
+          'clientSecret',
+          'tenantId',
+          'organizationId',
+          'authority',
+          'audience',
+          'baseUrl',
+        ],
+        'Login Options:'
+      ),
+
+  handler: async (argv: TenantArgs) => {
+    const { clientId } = argv;
+
+    let authResult, tenantId, organizationId, tenantName;
+
+    if (argv.clientSecret) {
+      try {
+        const authData = await clientCredentialsFlow({
+          clientId,
+          clientSecret: argv.clientSecret,
+          organizationId: argv.organizationId,
+          tenantId: argv.tenantId,
+          audience: argv.audience,
+          authority: argv.authority,
+          baseUrl: argv.baseUrl,
+        });
+
+        authResult = authData.data;
+        tenantId = authData.tokenTenantId;
+        organizationId = authData.tokenOrgId;
+        tenantName = authData.tokenTenantName;
+      } catch (err) {
+        console.error(`\n Login failed: ${(err as Error).message}`);
+        process.exit(1);
+      }
+    } else {
+      // TODO: Implement Device Authorization Flow when clientSecret is not provided.
+      console.log('\n Please provide client secret for authentication.');
+      process.exit(1);
+    }
+
+    await writeTenantAuthInfo(tenantId, {
+      clientSecret: argv.clientSecret,
+      access_token: authResult.access_token,
+      expires_in: authResult.expires_in,
+      expires_at: new Date(Date.now() + authResult.expires_in * 1000).toISOString(),
+    });
+
+    await writeTenantInfo({
+      tenantId,
+      organizationId,
+      clientId,
+      tenantName,
+      authority: argv.authority || AUTH0_DOMAIN,
+      audience: argv.audience || AUDIENCE,
+      baseUrl: argv.baseUrl || BASE_URL,
+    });
+
+    setActiveTenant(tenantId);
+
+    console.info(`\n Logged in successfully to tenant ${tenantId}.`);
+  },
+};

--- a/packages/cli/src/scripts/auth/logout.test.ts
+++ b/packages/cli/src/scripts/auth/logout.test.ts
@@ -1,0 +1,46 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import { logout } from './logout';
+import * as tenantState from '../../../src/utils/auth/tenant-state';
+import * as tenantStore from '../../../src/utils/auth/tenant-store';
+
+describe('logout command', () => {
+  let getActiveTenantStub: sinon.SinonStub;
+  let clearActiveTenantStub: sinon.SinonStub;
+  let deleteTenantAuthInfoStub: sinon.SinonStub;
+  let consoleInfoStub: sinon.SinonStub;
+  let consoleErrorStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    consoleInfoStub = sinon.stub(console, 'info');
+    consoleErrorStub = sinon.stub(console, 'error');
+    clearActiveTenantStub = sinon.stub(tenantState, 'clearActiveTenant');
+    deleteTenantAuthInfoStub = sinon.stub(tenantStore, 'deleteTenantAuthInfo');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should show error if no active tenant is found', async () => {
+    getActiveTenantStub = sinon.stub(tenantState, 'getActiveTenant').returns(null);
+
+    await logout.handler({} as any);
+
+    expect(consoleErrorStub.calledOnce).to.be.true;
+    expect(consoleErrorStub.firstCall.args[0]).to.include('No active tenant found');
+    expect(clearActiveTenantStub.notCalled).to.be.true;
+    expect(deleteTenantAuthInfoStub.notCalled).to.be.true;
+  });
+
+  it('should logout and clean up when active tenant exists', async () => {
+    const mockTenantId = 'mock-tenant-id';
+    getActiveTenantStub = sinon.stub(tenantState, 'getActiveTenant').returns(mockTenantId);
+
+    await logout.handler({} as any);
+
+    expect(clearActiveTenantStub.calledOnce).to.be.true;
+    expect(deleteTenantAuthInfoStub.calledWith(mockTenantId)).to.be.true;
+    expect(consoleInfoStub.calledWithMatch(`Logged out from tenant ${mockTenantId}`)).to.be.true;
+  });
+});

--- a/packages/cli/src/scripts/auth/logout.ts
+++ b/packages/cli/src/scripts/auth/logout.ts
@@ -1,0 +1,20 @@
+﻿import { CommandModule } from 'yargs';
+import { getActiveTenant, clearActiveTenant } from '../../utils/auth/tenant-state';
+import { deleteTenantAuthInfo } from '../../utils/auth/tenant-store';
+
+export const logout: CommandModule = {
+  command: 'logout',
+  describe: 'Logout from the active tenant',
+  handler: async () => {
+    const tenantId = getActiveTenant();
+    if (!tenantId) {
+      console.error('\n No active tenant found. Please login first.');
+      return;
+    }
+
+    clearActiveTenant();
+    deleteTenantAuthInfo(tenantId);
+
+    console.info(`\n Logged out from tenant ${tenantId}`);
+  },
+};

--- a/packages/cli/src/scripts/auth/models.ts
+++ b/packages/cli/src/scripts/auth/models.ts
@@ -1,0 +1,100 @@
+﻿/**
+ * CLI arguments used for authentication and tenant identification.
+ */
+export interface TenantArgs {
+  /**
+   * OAuth2 client ID used to identify the application
+   */
+  clientId: string;
+  /**
+   * Client secret used for client credentials flow
+   */
+  clientSecret?: string;
+  /**
+   * Organization ID associated with the tenant
+   */
+  organizationId?: string;
+  /**
+   * Tenant ID used for scoping the login
+   */
+  tenantId?: string;
+  /**
+   * OAuth2 audience (e.g., API base URL the token is intended for)
+   */
+  audience?: string;
+  /**
+   * Auth authority/issuer URL (e.g., Sitecore identity endpoint)
+   */
+  authority?: string;
+  /**
+   * Base URL for the target Sitecore Content Management API
+   */
+  baseUrl?: string;
+}
+
+export interface TenantSettings {
+  /**
+   * Currently active tenant ID tracked by the CLI
+   */
+  activeTenant?: string;
+}
+
+/**
+ * Auth configuration stored per tenant for accessing Sitecore APIs.
+ */
+export interface TenantAuth {
+  /**
+   * Access token issued by the identity provider
+   */
+  access_token: string;
+  /**
+   * Token expiration duration in seconds
+   */
+  expires_in: number;
+  /**
+   * Exact ISO timestamp when the token expires
+   */
+  expires_at: string;
+  /**
+   * Secret used for client credentials flow and re-authenticate
+   */
+  clientSecret?: string;
+  /*
+   * Refresh token used to obtain new access tokens
+   */
+  refresh_token?: string;
+}
+
+/**
+ * Public metadata for a known tenant.
+ */
+export interface TenantInfo {
+  /**
+   * Unique ID of the tenant
+   */
+  tenantId: string;
+  /**
+   *  Human-readable name of the tenant
+   */
+  tenantName: string;
+  /**
+   * Organization ID the tenant belongs to
+   */
+  organizationId: string;
+  /**
+   * Client ID associated with this tenant's authentication
+   */
+  clientId: string;
+  /**
+   * OAuth2 audience (e.g., API base URL the token is intended for)
+   */
+  audience: string;
+  /**
+   * Auth authority/issuer URL (e.g., Sitecore identity endpoint)
+   */
+  authority: string;
+  /**
+   * Base URL for the target Sitecore Content Management API
+   */
+  baseUrl: string;
+}

--- a/packages/cli/src/scripts/auth/status.test.ts
+++ b/packages/cli/src/scripts/auth/status.test.ts
@@ -1,0 +1,61 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import { status } from './status';
+import * as auth from '../../utils/auth/renewal';
+import * as tenantStore from './../../utils/auth/tenant-store';
+
+describe('status command', () => {
+  let renewStub: sinon.SinonStub;
+  let readTenantInfoStub: sinon.SinonStub;
+  let consoleLogStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    consoleLogStub = sinon.stub(console, 'log');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should prompt login if no valid auth is found', async () => {
+    renewStub = sinon.stub(auth, 'renewAuthIfExpired').resolves(null);
+
+    await status.handler({} as any);
+
+    expect(consoleLogStub.calledOnce).to.be.true;
+    expect(consoleLogStub.firstCall.args[0]).to.include('No valid authentication found');
+  });
+
+  it('should show tenant info if valid auth is present', async () => {
+    const fakeTenantId = 'tenant-123';
+    const fakeTenantInfo = {
+      tenantId: fakeTenantId,
+      tenantName: 'DemoTenant',
+      organizationId: 'org-001',
+      clientId: 'client-abc',
+      authority: 'https://auth.example.com',
+      audience: 'https://api.example.com',
+      baseUrl: 'https://sitecore.example.com',
+    };
+
+    renewStub = sinon.stub(auth, 'renewAuthIfExpired').resolves({ tenantId: fakeTenantId });
+    readTenantInfoStub = sinon.stub(tenantStore, 'readTenantInfo').resolves(fakeTenantInfo);
+
+    await status.handler({} as any);
+
+    const expectedLines = [
+      '\n Active tenant:',
+      '  Tenant ID       : tenant-123',
+      '  Tenant Name     : DemoTenant',
+      '  Organization ID : org-001',
+      '  Client ID       : client-abc',
+      '  Authority       : https://auth.example.com',
+      '  Audience        : https://api.example.com',
+      '  Base URL        : https://sitecore.example.com',
+    ];
+
+    expectedLines.forEach((line) => {
+      expect(consoleLogStub.calledWithMatch(line)).to.be.true;
+    });
+  });
+});

--- a/packages/cli/src/scripts/auth/status.ts
+++ b/packages/cli/src/scripts/auth/status.ts
@@ -1,0 +1,27 @@
+﻿import { CommandModule } from 'yargs';
+import { readTenantInfo } from '../../utils/auth/tenant-store';
+import { renewAuthIfExpired } from '../../utils/auth/renewal';
+
+export const status: CommandModule = {
+  command: 'status',
+  describe: 'Show current status of active tenant',
+  handler: async () => {
+    const context = await renewAuthIfExpired();
+
+    if (!context) {
+      console.log('\n No valid authentication found. Please login.');
+      return;
+    }
+
+    const tenantInfo = await readTenantInfo(context.tenantId);
+
+    console.log('\n Active tenant:');
+    console.log(`  Tenant ID       : ${context.tenantId}`);
+    console.log(`  Tenant Name     : ${tenantInfo?.tenantName || 'N/A'}`);
+    console.log(`  Organization ID : ${tenantInfo?.organizationId}`);
+    console.log(`  Client ID       : ${tenantInfo?.clientId}`);
+    console.log(`  Authority       : ${tenantInfo?.authority || 'N/A'}`);
+    console.log(`  Audience        : ${tenantInfo?.audience || 'N/A'}`);
+    console.log(`  Base URL        : ${tenantInfo?.baseUrl || 'N/A'}`);
+  },
+};

--- a/packages/cli/src/scripts/index.ts
+++ b/packages/cli/src/scripts/index.ts
@@ -3,4 +3,7 @@
 
 import * as project from './project';
 
+import * as auth from './auth';
+
 export { project };
+export { auth };

--- a/packages/cli/src/utils/auth/flow.test.ts
+++ b/packages/cli/src/utils/auth/flow.test.ts
@@ -1,0 +1,193 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import { clientCredentialsFlow, AUDIENCE, BASE_URL } from './flow';
+import * as jwtUtil from './tenant-store';
+
+describe('clientCredentialsFlow', () => {
+  const fakeToken = 'fake.jwt.token';
+  const fakeDecoded = {
+    tokenTenantId: 'tenant123',
+    tokenOrgId: 'org456',
+    tokenTenantName: 'FakeTenant',
+  };
+
+  const fetchResponse = {
+    ok: true,
+    json: async () => ({
+      access_token: fakeToken,
+      expires_in: 3600,
+    }),
+  };
+
+  let fetchStub: sinon.SinonStub;
+  let decodeStub: sinon.SinonStub;
+  let consoleErrorStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch' as any).resolves(fetchResponse as any);
+    decodeStub = sinon.stub(jwtUtil, 'decodeJwtPayload').returns(fakeDecoded);
+    consoleErrorStub = sinon.stub(console, 'error');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should succeed when tenantId and organizationId are not passed and grab them from token claims', async () => {
+    const result = await clientCredentialsFlow({
+      clientId: 'id',
+      clientSecret: 'secret',
+    });
+
+    expect(result.data.access_token).to.equal(fakeToken);
+    expect(result.tokenTenantId).to.equal(fakeDecoded.tokenTenantId);
+    expect(result.tokenOrgId).to.equal(fakeDecoded.tokenOrgId);
+    expect(result.tokenTenantName).to.equal(fakeDecoded.tokenTenantName);
+  });
+
+  it('should succeed only if passed tenantId and organizationId match token claims', async () => {
+    decodeStub.returns({
+      tokenTenantId: 'tenant123',
+      tokenOrgId: 'org456',
+      tokenTenantName: 'FakeTenant',
+    });
+
+    const result = await clientCredentialsFlow({
+      clientId: 'id',
+      clientSecret: 'secret',
+      tenantId: 'tenant123',
+      organizationId: 'org456',
+    });
+
+    expect(result.data.access_token).to.equal(fakeToken);
+    expect(result.tokenTenantId).to.equal('tenant123');
+    expect(result.tokenOrgId).to.equal('org456');
+    expect(result.tokenTenantName).to.equal('FakeTenant');
+  });
+
+  it('should use default values when audience, authority, and baseUrl are not provided', async () => {
+    const expectedParams = new URLSearchParams({
+      client_id: 'id',
+      client_secret: 'secret',
+      organization_id: '',
+      tenant_id: '',
+      audience: AUDIENCE,
+      grant_type: 'client_credentials',
+      baseUrl: BASE_URL,
+    }).toString();
+
+    let actualRequestBody: string = '';
+
+    fetchStub.callsFake(async (_url: string, options: any) => {
+      actualRequestBody = options.body;
+      return fetchResponse as any;
+    });
+
+    await clientCredentialsFlow({
+      clientId: 'id',
+      clientSecret: 'secret',
+    });
+
+    expect(actualRequestBody).to.equal(expectedParams);
+  });
+
+  it('should override defaults when custom audience, authority, and baseUrl are provided', async () => {
+    const customAuthority = 'https://custom-authority.io';
+    const customAudience = 'https://custom-api.io';
+    const customBaseUrl = 'https://custom-base.io';
+
+    const expectedParams = new URLSearchParams({
+      client_id: 'id',
+      client_secret: 'secret',
+      organization_id: '',
+      tenant_id: '',
+      audience: customAudience,
+      grant_type: 'client_credentials',
+      baseUrl: customBaseUrl,
+    }).toString();
+
+    let actualUrl: string = '';
+    let actualRequestBody: string = '';
+
+    fetchStub.callsFake(async (url: string, options: any) => {
+      actualUrl = url;
+      actualRequestBody = options.body;
+      return fetchResponse as any;
+    });
+
+    await clientCredentialsFlow({
+      clientId: 'id',
+      clientSecret: 'secret',
+      authority: customAuthority,
+      audience: customAudience,
+      baseUrl: customBaseUrl,
+    });
+
+    expect(actualUrl).to.equal(`${customAuthority}/oauth/token`);
+    expect(actualRequestBody).to.equal(expectedParams);
+  });
+
+  it('should throw if token has missing claims', async () => {
+    decodeStub.returns({});
+
+    try {
+      await clientCredentialsFlow({
+        clientId: 'id',
+        clientSecret: 'secret',
+        tenantId: 'tenant123',
+        organizationId: 'org456',
+      });
+    } catch (err) {
+      expect((err as Error).message).to.include('Token is missing required claims');
+    }
+  });
+
+  it('should throw if tenantId does not match token', async () => {
+    decodeStub.returns({ ...fakeDecoded, tokenTenantId: 'wrong-id' });
+
+    try {
+      await clientCredentialsFlow({
+        clientId: 'id',
+        clientSecret: 'secret',
+        tenantId: 'tenant123',
+        organizationId: 'org456',
+      });
+    } catch (err) {
+      expect((err as Error).message).to.include('tenant ID does not match');
+    }
+  });
+
+  it('should throw if organizationId does not match token', async () => {
+    decodeStub.returns({ ...fakeDecoded, tokenOrgId: 'wrong-org' });
+
+    try {
+      await clientCredentialsFlow({
+        clientId: 'id',
+        clientSecret: 'secret',
+        tenantId: 'tenant123',
+        organizationId: 'org456',
+      });
+    } catch (err) {
+      expect((err as Error).message).to.include('organization ID does not match');
+    }
+  });
+
+  it('should throw and log error on non-OK response', async () => {
+    fetchStub.resolves({
+      ok: false,
+      json: async () => ({ error: 'unauthorized' }),
+    });
+
+    try {
+      await clientCredentialsFlow({
+        clientId: 'id',
+        clientSecret: 'secret',
+        tenantId: 'tenant123',
+        organizationId: 'org456',
+      });
+    } catch (err) {
+      expect(consoleErrorStub.called).to.be.true;
+      expect((err as Error).message).to.include('unauthorized');
+    }
+  });
+});

--- a/packages/cli/src/utils/auth/flow.ts
+++ b/packages/cli/src/utils/auth/flow.ts
@@ -1,0 +1,83 @@
+﻿import { TenantArgs } from '../../scripts/auth/models';
+import { decodeJwtPayload } from './tenant-store';
+
+export const AUTH0_DOMAIN = 'https://auth.sitecorecloud.io';
+export const AUDIENCE = 'https://api.sitecorecloud.io';
+export const BASE_URL = 'https://edge-platform.sitecorecloud.io/cs/api';
+const GRANT_TYPE = 'client_credentials';
+
+/**
+ * Performs the OAuth 2.0 client credentials flow to obtain a JWT access token
+ * from the Sitecore Identity Provider using the provided client credentials.
+ * @param {object} [args] - The arguments for client credentials flow
+ * @param {string} [args.clientId] - The client ID registered with Sitecore Identity
+ * @param {string} [args.clientSecret] - The client secret associated with the client ID
+ * @param {string} [args.organizationId] - The ID of the organization the client belongs to
+ * @param {string} [args.tenantId] - The tenant ID representing the specific Sitecore environment
+ * @param {string} [args.audience] - The API audience the token is intended for. Defaults to `AUDIENCE`
+ * @param {string} [args.authority] - The auth server base URL. Defaults to `AUTH0_DOMAIN`
+ * @param {string} [args.baseUrl] - The base URL for the API, used to construct the audience
+ * @returns A Promise that resolves to the access token response (including access token, token type, expiry, etc.)
+ * @throws Will log and exit the process if the request fails or returns a non-OK status
+ */
+export async function clientCredentialsFlow({
+  clientId,
+  clientSecret,
+  organizationId,
+  tenantId,
+  audience = AUDIENCE,
+  authority = AUTH0_DOMAIN,
+  baseUrl = BASE_URL,
+}: TenantArgs) {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret ?? '',
+    organization_id: organizationId ?? '',
+    tenant_id: tenantId ?? '',
+    audience,
+    grant_type: GRANT_TYPE,
+    baseUrl: baseUrl ?? '',
+  });
+
+  try {
+    const response = await fetch(`${authority}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(
+        data.error_description || data.error || 'Error during client credentials flow'
+      );
+    }
+
+    const decodedPayload = decodeJwtPayload(data.access_token) || {};
+
+    if (!decodedPayload?.tokenTenantId || !decodedPayload.tokenOrgId) {
+      throw new Error('\n Token is missing required claims tenant_id or org_id.');
+    }
+
+    const { tokenTenantId, tokenOrgId, tokenTenantName } = decodedPayload;
+
+    if (tenantId && tenantId !== tokenTenantId) {
+      throw new Error('\n Mismatch: Provided tenant ID does not match claims tenant ID.');
+    }
+
+    if (organizationId && organizationId !== tokenOrgId) {
+      throw new Error(
+        '\n Mismatch: Provided organization ID does not match claims organization ID.'
+      );
+    }
+
+    return { data, tokenOrgId, tokenTenantId, tokenTenantName };
+  } catch (error) {
+    console.error(
+      '\n Error during client credentials flow:',
+      error instanceof Error ? error.message : error
+    );
+    throw error;
+  }
+}

--- a/packages/cli/src/utils/auth/renewal.test.ts
+++ b/packages/cli/src/utils/auth/renewal.test.ts
@@ -1,0 +1,159 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import { validateAuthInfo, renewClientToken, renewAuthIfExpired } from './renewal';
+
+import * as authFlow from './flow';
+import * as tenantStore from './tenant-store';
+import * as tenantState from './tenant-state';
+
+describe('auth token renewal utilities', () => {
+  const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
+  const pastDate = new Date(Date.now() - 3600 * 1000).toISOString();
+
+  const authMock = {
+    clientSecret: 'secret',
+    access_token: 'token',
+    expires_in: 3600,
+    expires_at: futureDate,
+  };
+
+  const tenantMock = {
+    tenantId: 'tenant1',
+    tenantName: 'DemoTenant',
+    organizationId: 'org1',
+    clientId: 'cid',
+    audience: 'audience',
+    authority: 'auth',
+    baseUrl: 'https://fake.base.url',
+  };
+
+  let flowStub: sinon.SinonStub;
+  let writeStub: sinon.SinonStub;
+  let readAuthStub: sinon.SinonStub;
+  let readTenantInfoStub: sinon.SinonStub;
+  let getTenantStub: sinon.SinonStub;
+  let deleteAuthStub: sinon.SinonStub;
+  let clearActiveStub: sinon.SinonStub;
+  let consoleInfoStub: sinon.SinonStub;
+  let consoleErrorStub: sinon.SinonStub;
+  let consoleWarnStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    flowStub = sinon.stub(authFlow, 'clientCredentialsFlow').resolves({
+      data: {
+        access_token: 'new-token',
+        expires_in: 3600,
+      },
+      tokenOrgId: 'org1',
+      tokenTenantId: 'tenant1',
+      tokenTenantName: 'DemoTenant',
+    });
+
+    writeStub = sinon.stub(tenantStore, 'writeTenantAuthInfo').resolves();
+    readAuthStub = sinon.stub(tenantStore, 'readTenantAuthInfo');
+    readTenantInfoStub = sinon.stub(tenantStore, 'readTenantInfo');
+    getTenantStub = sinon.stub(tenantState, 'getActiveTenant');
+    deleteAuthStub = sinon.stub(tenantStore, 'deleteTenantAuthInfo').resolves();
+    clearActiveStub = sinon.stub(tenantState, 'clearActiveTenant').resolves();
+    consoleInfoStub = sinon.stub(console, 'info');
+    consoleErrorStub = sinon.stub(console, 'error');
+    consoleWarnStub = sinon.stub(console, 'warn');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('validateAuthInfo', () => {
+    it('should return true if token is not expired', () => {
+      const result = validateAuthInfo({ ...authMock, expires_at: futureDate });
+      expect(result).to.be.true;
+    });
+
+    it('should return false if token is expired', () => {
+      const result = validateAuthInfo({ ...authMock, expires_at: pastDate });
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('renewClientToken', () => {
+    it('should call flow and update auth file with new token', async () => {
+      await renewClientToken(authMock, tenantMock);
+
+      expect(flowStub.calledOnce).to.be.true;
+      expect(writeStub.calledOnce).to.be.true;
+      expect(writeStub.firstCall.args[0]).to.equal('tenant1');
+
+      const writtenAuth = writeStub.firstCall.args[1];
+      expect(writtenAuth).to.deep.include({
+        clientSecret: authMock.clientSecret,
+        access_token: 'new-token',
+        expires_in: 3600,
+      });
+      expect(writtenAuth.expires_at).to.be.a('string');
+    });
+  });
+
+  describe('renewAuthIfExpired', () => {
+    it('should return null if no active tenant', async () => {
+      getTenantStub.returns(null);
+
+      const result = await renewAuthIfExpired();
+      expect(result).to.be.null;
+    });
+
+    it('should return null if no auth config is found', async () => {
+      getTenantStub.returns('tenant1');
+      readAuthStub.resolves(null);
+
+      const result = await renewAuthIfExpired();
+      expect(result).to.be.null;
+    });
+
+    it('should return null if tenant info cannot be read', async () => {
+      getTenantStub.returns('tenant1');
+      readAuthStub.resolves({ ...authMock, expires_at: pastDate });
+      readTenantInfoStub.resolves(null);
+
+      const result = await renewAuthIfExpired();
+
+      expect(result).to.be.null;
+    });
+
+    it('should return tenantId if auth is still valid', async () => {
+      getTenantStub.returns('tenant1');
+      readAuthStub.resolves({ ...authMock, expires_at: futureDate });
+
+      const result = await renewAuthIfExpired();
+      expect(result).to.deep.equal({ tenantId: 'tenant1' });
+    });
+
+    it('should exit if token renewal fails unexpectedly', async () => {
+      getTenantStub.returns('tenant1');
+      readAuthStub.resolves({ ...authMock, expires_at: pastDate });
+      readTenantInfoStub.resolves(tenantMock);
+      flowStub.rejects(new Error('Unexpected failure'));
+
+      const exitStub = sinon.stub(process, 'exit').callsFake(() => {
+        throw new Error('EXIT_CALLED');
+      });
+
+      try {
+        await renewAuthIfExpired();
+        throw new Error('Test failed: process.exit not triggered');
+      } catch (err) {
+        if (err instanceof Error) {
+          expect(err.message).to.equal('EXIT_CALLED');
+        } else {
+          throw err;
+        }
+      }
+
+      expect(consoleErrorStub.calledWithMatch(/Failed to renew token/)).to.be.true;
+      expect(consoleWarnStub.calledWithMatch(/Cleaning up stale/)).to.be.true;
+      expect(deleteAuthStub.calledOnce).to.be.true;
+      expect(clearActiveStub.calledOnce).to.be.true;
+      expect(exitStub.calledOnceWith(1)).to.be.true;
+    });
+  });
+});

--- a/packages/cli/src/utils/auth/renewal.ts
+++ b/packages/cli/src/utils/auth/renewal.ts
@@ -1,0 +1,92 @@
+﻿import { getActiveTenant, clearActiveTenant } from './tenant-state';
+import { clientCredentialsFlow } from './flow';
+import { TenantAuth, TenantInfo } from './../../scripts/auth/models';
+import {
+  writeTenantAuthInfo,
+  readTenantAuthInfo,
+  deleteTenantAuthInfo,
+  readTenantInfo,
+} from './tenant-store';
+
+/**
+ * Validates whether a given auth config is still valid (i.e., not expired).
+ * @param {TenantAuth} authInfo - The tenant auth configuration.
+ * @returns True if the token is still valid, false if expired.
+ */
+export function validateAuthInfo(authInfo: TenantAuth): boolean {
+  const now = new Date();
+  const expiry = new Date(authInfo.expires_at);
+  return now < expiry;
+}
+
+/**
+ * Renews the token for a given tenant using stored credentials.
+ * @param {TenantAuth} authInfo - Current authentication info for the tenant.
+ * @param {TenantInfo} tenantInfo - Public metadata about the tenant (e.g., clientId).
+ * @returns Promise<void>
+ * @throws If credentials are missing or renewal fails.
+ */
+export async function renewClientToken(
+  authInfo: TenantAuth,
+  tenantInfo: TenantInfo
+): Promise<void> {
+  const result = await clientCredentialsFlow({
+    clientId: tenantInfo.clientId,
+    clientSecret: authInfo.clientSecret,
+    organizationId: tenantInfo.organizationId,
+    tenantId: tenantInfo.tenantId,
+    audience: tenantInfo.audience,
+    authority: tenantInfo.authority,
+    baseUrl: tenantInfo.baseUrl,
+  });
+  const tenantId = tenantInfo.tenantId;
+
+  await writeTenantAuthInfo(tenantId, {
+    clientSecret: authInfo.clientSecret,
+    access_token: result.data.access_token,
+    expires_in: result.data.expires_in,
+    expires_at: new Date(Date.now() + result.data.expires_in * 1000).toISOString(),
+  });
+
+  console.info(`\n Token for tenant ${tenantId} renewed.`);
+}
+
+/**
+ * Ensures a valid token exists, renews it if expired.
+ * Returns tenant context if successful, otherwise null.
+ */
+export async function renewAuthIfExpired(): Promise<{ tenantId: string } | null> {
+  const tenantId = getActiveTenant();
+  if (!tenantId) return null;
+
+  const authInfo = await readTenantAuthInfo(tenantId);
+  if (!authInfo) return null;
+
+  const isValid = validateAuthInfo(authInfo);
+  if (isValid) {
+    return { tenantId };
+  }
+  const tenantInfo = await readTenantInfo(tenantId);
+  if (!tenantInfo) return null;
+
+  console.info(`\n Token for tenant ${tenantId} is expired. Renewing...`);
+
+  try {
+    if (authInfo.clientSecret) {
+      await renewClientToken(authInfo, tenantInfo);
+    } else {
+      // <TODO>: Implement Device auth token renewal.
+      throw new Error('\n Please use clientSecret for authentication.');
+    }
+    return { tenantId };
+  } catch (err) {
+    console.error(`\n Failed to renew token for tenant '${tenantId}'`);
+
+    console.warn(`\n Cleaning up stale authentication data for tenant '${tenantId}'...`);
+    await deleteTenantAuthInfo(tenantId);
+    clearActiveTenant();
+
+    console.info('\n You will need to login again to re-authenticate.');
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/utils/auth/tenant-state.test.ts
+++ b/packages/cli/src/utils/auth/tenant-state.test.ts
@@ -1,0 +1,100 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { getActiveTenant, setActiveTenant, clearActiveTenant } from './tenant-state';
+
+describe('tenant-state utils', () => {
+  const settingsFile = path.join(os.homedir(), '.sitecore', 'sitecore-tools', 'settings.json');
+
+  let existsStub: sinon.SinonStub;
+  let readStub: sinon.SinonStub;
+  let writeStub: sinon.SinonStub;
+  let unlinkStub: sinon.SinonStub;
+  let mkdirStub: sinon.SinonStub;
+  let consoleErrorStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    existsStub = sinon.stub(fs, 'existsSync');
+    readStub = sinon.stub(fs, 'readFileSync');
+    writeStub = sinon.stub(fs, 'writeFileSync');
+    unlinkStub = sinon.stub(fs, 'unlinkSync');
+    mkdirStub = sinon.stub(fs, 'mkdirSync');
+    consoleErrorStub = sinon.stub(console, 'error');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('getActiveTenant()', () => {
+    it('should return null if settings file does not exist', () => {
+      existsStub.withArgs(settingsFile).returns(false);
+
+      const result = getActiveTenant();
+      expect(result).to.be.null;
+    });
+
+    it('should return activeTenant if settings file is valid', () => {
+      existsStub.withArgs(settingsFile).returns(true);
+      readStub.returns(JSON.stringify({ activeTenant: 'tenant-abc' }));
+
+      const result = getActiveTenant();
+      expect(result).to.equal('tenant-abc');
+    });
+
+    it('should return null and log error if file read fails', () => {
+      existsStub.withArgs(settingsFile).returns(true);
+      readStub.throws(new Error('Read failed'));
+
+      const result = getActiveTenant();
+      expect(result).to.be.null;
+      expect(consoleErrorStub.calledWithMatch(/Failed to read active tenant/)).to.be.true;
+    });
+  });
+
+  describe('setActiveTenant()', () => {
+    it('should create directory and write settings file', () => {
+      existsStub.withArgs(path.dirname(settingsFile)).returns(false);
+
+      setActiveTenant('tenant-xyz');
+
+      expect(mkdirStub.calledOnce).to.be.true;
+      expect(writeStub.calledWithMatch(settingsFile, sinon.match.string)).to.be.true;
+    });
+
+    it('should log error if writing file fails', () => {
+      existsStub.returns(true);
+      writeStub.throws(new Error('Write failed'));
+
+      setActiveTenant('tenant-xyz');
+
+      expect(consoleErrorStub.calledWithMatch(/Failed to set active tenant/)).to.be.true;
+    });
+  });
+
+  describe('clearActiveTenant()', () => {
+    it('should delete settings file if it exists', () => {
+      existsStub.withArgs(settingsFile).returns(true);
+
+      clearActiveTenant();
+      expect(unlinkStub.calledWith(settingsFile)).to.be.true;
+    });
+
+    it('should not throw if settings file does not exist', () => {
+      existsStub.withArgs(settingsFile).returns(false);
+
+      expect(() => clearActiveTenant()).to.not.throw();
+      expect(unlinkStub.notCalled).to.be.true;
+    });
+
+    it('should log error if file deletion fails', () => {
+      existsStub.withArgs(settingsFile).returns(true);
+      unlinkStub.throws(new Error('Delete failed'));
+
+      clearActiveTenant();
+      expect(consoleErrorStub.calledWithMatch(/Failed to clear active tenant/)).to.be.true;
+    });
+  });
+});

--- a/packages/cli/src/utils/auth/tenant-state.ts
+++ b/packages/cli/src/utils/auth/tenant-state.ts
@@ -1,0 +1,56 @@
+﻿import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { TenantSettings } from '../../scripts/auth/models';
+
+const configDir: string = path.join(os.homedir(), '.sitecore', 'sitecore-tools');
+const settingsFile: string = path.join(configDir, 'settings.json');
+
+/**
+ * Gets the ID of the currently active tenant from settings.json.
+ * @returns The active tenant ID if present, otherwise null.
+ */
+export function getActiveTenant(): string | null {
+  if (!fs.existsSync(settingsFile)) {
+    return null;
+  }
+
+  try {
+    const content: string = fs.readFileSync(settingsFile, 'utf-8');
+    const data: TenantSettings = JSON.parse(content);
+    return data.activeTenant ?? null;
+  } catch (error) {
+    console.error(`\n Failed to read active tenant: ${(error as Error).message}`);
+    return null;
+  }
+}
+
+/**
+ * Sets the currently active tenant by writing to settings.json.
+ * @param {string} tenantId - The tenant ID to set as active.
+ */
+export function setActiveTenant(tenantId: string): void {
+  try {
+    if (!fs.existsSync(configDir)) {
+      fs.mkdirSync(configDir, { recursive: true });
+    }
+
+    const data: TenantSettings = { activeTenant: tenantId };
+    fs.writeFileSync(settingsFile, JSON.stringify(data, null, 2));
+  } catch (error) {
+    console.error(`\n Failed to set active tenant '${tenantId}': ${(error as Error).message}`);
+  }
+}
+
+/**
+ * Clears the currently active tenant from settings.json by deleting the file.
+ */
+export function clearActiveTenant(): void {
+  try {
+    if (fs.existsSync(settingsFile)) {
+      fs.unlinkSync(settingsFile);
+    }
+  } catch (error) {
+    console.error(`\n Failed to clear active tenant: ${(error as Error).message}`);
+  }
+}

--- a/packages/cli/src/utils/auth/tenant-store.test.ts
+++ b/packages/cli/src/utils/auth/tenant-store.test.ts
@@ -1,0 +1,235 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  writeTenantAuthInfo,
+  readTenantAuthInfo,
+  writeTenantInfo,
+  readTenantInfo,
+  deleteTenantAuthInfo,
+  getAllTenantsInfo,
+  decodeJwtPayload,
+} from './tenant-store';
+
+describe('tenant-store utilities', () => {
+  const tenantId = 'tenant-abc';
+  const tenantDir = path.join(os.homedir(), '.sitecore', 'sitecore-tools', tenantId);
+  const authPath = path.join(tenantDir, 'auth.json');
+  const infoPath = path.join(tenantDir, 'info.json');
+
+  let mkdirStub: sinon.SinonStub;
+  let writeFileStub: sinon.SinonStub;
+  let readFileStub: sinon.SinonStub;
+  let existsStub: sinon.SinonStub;
+  let unlinkStub: sinon.SinonStub;
+  let statStub: sinon.SinonStub;
+  let readdirStub: sinon.SinonStub;
+  let consoleErrorStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    mkdirStub = sinon.stub(fs, 'mkdirSync');
+    writeFileStub = sinon.stub(fs, 'writeFileSync');
+    readFileStub = sinon.stub(fs, 'readFileSync');
+    existsStub = sinon.stub(fs, 'existsSync');
+    unlinkStub = sinon.stub(fs, 'unlinkSync');
+    statStub = sinon.stub(fs, 'statSync');
+    readdirStub = sinon.stub(fs, 'readdirSync');
+    consoleErrorStub = sinon.stub(console, 'error');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('writeTenantAuthInfo', () => {
+    it('should write auth.json file', async () => {
+      await writeTenantAuthInfo(tenantId, {
+        access_token: 'token',
+        clientId: 'cid',
+        expires_in: 1234,
+        expires_at: 'time',
+      });
+
+      expect(mkdirStub.calledWith(tenantDir)).to.be.true;
+      expect(writeFileStub.calledWith(authPath)).to.be.true;
+    });
+
+    it('should log error if writing fails', async () => {
+      writeFileStub.throws(new Error('fail'));
+      await writeTenantAuthInfo(tenantId, {
+        access_token: 'token',
+        clientId: 'cid',
+        expires_in: 1234,
+        expires_at: 'time',
+      });
+      expect(consoleErrorStub.called).to.be.true;
+    });
+  });
+
+  describe('readTenantAuthInfo', () => {
+    it('should return parsed auth info if file exists', async () => {
+      existsStub.withArgs(authPath).returns(true);
+      readFileStub.withArgs(authPath).returns(JSON.stringify({ clientId: 'cid' }));
+
+      const result = await readTenantAuthInfo(tenantId);
+      expect(result?.clientId).to.equal('cid');
+    });
+
+    it('should return null if file does not exist', async () => {
+      existsStub.withArgs(authPath).returns(false);
+
+      const result = await readTenantAuthInfo(tenantId);
+      expect(result).to.be.null;
+    });
+
+    it('should return null and log if JSON parsing fails', async () => {
+      existsStub.withArgs(authPath).returns(true);
+      readFileStub.throws(new Error('corrupt'));
+
+      const result = await readTenantAuthInfo(tenantId);
+      expect(result).to.be.null;
+      expect(consoleErrorStub.called).to.be.true;
+    });
+  });
+
+  describe('writeTenantInfo', () => {
+    it('should write info.json file', async () => {
+      await writeTenantInfo({
+        tenantId,
+        tenantName: 'T1',
+        organizationId: 'O1',
+        clientId: 'C1',
+      });
+
+      expect(mkdirStub.calledWith(tenantDir)).to.be.true;
+      expect(writeFileStub.calledWith(infoPath)).to.be.true;
+    });
+
+    it('should log error if writing info.json fails', async () => {
+      writeFileStub.throws(new Error('Write failed'));
+
+      await writeTenantInfo({
+        tenantId,
+        tenantName: 'T1',
+        organizationId: 'O1',
+        clientId: 'C1',
+      });
+
+      expect(consoleErrorStub.calledOnce).to.be.true;
+      expect(consoleErrorStub.firstCall.args[0]).to.include('Failed to write info.json');
+    });
+  });
+
+  describe('readTenantInfo', () => {
+    it('should return parsed tenant info if file exists', async () => {
+      existsStub.withArgs(infoPath).returns(true);
+      readFileStub.withArgs(infoPath).returns(
+        JSON.stringify({
+          tenantId,
+          tenantName: 'T1',
+          organizationId: 'O1',
+          clientId: 'C1',
+        })
+      );
+
+      const result = await readTenantInfo(tenantId);
+      expect(result?.tenantName).to.equal('T1');
+    });
+
+    it('should return null if file does not exist', async () => {
+      existsStub.withArgs(infoPath).returns(false);
+      const result = await readTenantInfo(tenantId);
+      expect(result).to.be.null;
+    });
+
+    it('should log error if file read fails', async () => {
+      existsStub.withArgs(infoPath).returns(true);
+      readFileStub.throws(new Error('read failed'));
+
+      const result = await readTenantInfo(tenantId);
+      expect(result).to.be.null;
+      expect(consoleErrorStub.called).to.be.true;
+    });
+  });
+
+  describe('deleteTenantAuthInfo', () => {
+    it('should delete auth.json if exists', async () => {
+      existsStub.withArgs(authPath).returns(true);
+      await deleteTenantAuthInfo(tenantId);
+      expect(unlinkStub.calledWith(authPath)).to.be.true;
+    });
+
+    it('should skip deletion if file does not exist', async () => {
+      existsStub.withArgs(authPath).returns(false);
+      await deleteTenantAuthInfo(tenantId);
+      expect(unlinkStub.called).to.be.false;
+    });
+
+    it('should log error on deletion failure', async () => {
+      existsStub.withArgs(authPath).returns(true);
+      unlinkStub.throws(new Error('unlink fail'));
+
+      await deleteTenantAuthInfo(tenantId);
+      expect(consoleErrorStub.called).to.be.true;
+    });
+  });
+
+  describe('getAllTenantsInfo', () => {
+    const basePath = path.join(os.homedir(), '.sitecore', 'sitecore-tools');
+
+    it('should return empty array if rootDir does not exist', () => {
+      existsStub.withArgs(basePath).returns(false);
+
+      const tenants = getAllTenantsInfo();
+      expect(tenants).to.deep.equal([]);
+    });
+
+    it('should return valid tenants from info.json files', () => {
+      existsStub.withArgs(basePath).returns(true);
+      readdirStub.returns(['tenant-1']);
+      statStub.returns({ isDirectory: () => true });
+
+      const fullInfoPath = path.join(basePath, 'tenant-1', 'info.json');
+      existsStub.withArgs(fullInfoPath).returns(true);
+      readFileStub.withArgs(fullInfoPath).returns(
+        JSON.stringify({
+          tenantId: 'tenant-1',
+          tenantName: 'Name1',
+          organizationId: 'org1',
+          clientId: 'cid1',
+        })
+      );
+
+      const tenants = getAllTenantsInfo();
+      expect(tenants).to.have.length(1);
+      expect(tenants[0].tenantName).to.equal('Name1');
+    });
+  });
+
+  describe('decodeJwtPayload', () => {
+    it('should decode and return claims from token', () => {
+      const payload = {
+        'https://auth.sitecorecloud.io/claims/tenant_id': 'tid',
+        'https://auth.sitecorecloud.io/claims/org_id': 'oid',
+        'https://auth.sitecorecloud.io/claims/tenant_name': 'tname',
+      };
+
+      const base64 = Buffer.from(JSON.stringify(payload)).toString('base64');
+      const token = `abc.${base64}.xyz`;
+
+      const result = decodeJwtPayload(token);
+      expect(result?.tokenTenantId).to.equal('tid');
+      expect(result?.tokenOrgId).to.equal('oid');
+      expect(result?.tokenTenantName).to.equal('tname');
+    });
+
+    it('should return null and log if decoding fails', () => {
+      const token = 'invalid.token.string';
+      const result = decodeJwtPayload(token);
+      expect(result).to.be.null;
+      expect(consoleErrorStub.called).to.be.true;
+    });
+  });
+});

--- a/packages/cli/src/utils/auth/tenant-store.ts
+++ b/packages/cli/src/utils/auth/tenant-store.ts
@@ -1,0 +1,172 @@
+﻿import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { TenantAuth, TenantInfo } from './../../scripts/auth/models';
+
+const CLAIMS = 'https://auth.sitecorecloud.io/claims';
+
+const rootDir = path.join(os.homedir(), '.sitecore', 'sitecore-tools');
+
+/**
+ * Get the full path to the tenant-specific folder.
+ * @param {string} tenantId - The tenant ID.
+ * @returns The absolute path to the tenant directory.
+ */
+function getTenantPath(tenantId: string): string {
+  return path.join(rootDir, tenantId);
+}
+
+/**
+ * Write the authentication configuration for a tenant.
+ * @param {string} tenantId - The tenant ID.
+ * @param {TenantAuth} authInfo - The tenant's auth data.
+ */
+export async function writeTenantAuthInfo(tenantId: string, authInfo: TenantAuth): Promise<void> {
+  try {
+    const dir = getTenantPath(tenantId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'auth.json'), JSON.stringify(authInfo, null, 2));
+  } catch (error) {
+    console.error(
+      `\n Failed to write auth.json for tenant '${tenantId}': ${(error as Error).message}`
+    );
+  }
+}
+
+/**
+ * Read the authentication configuration for a tenant.
+ * @param {string} tenantId - The tenant ID.
+ * @returns Parsed auth config or null if not found or failed to read.
+ */
+export async function readTenantAuthInfo(tenantId: string): Promise<TenantAuth | null> {
+  const filePath = path.join(getTenantPath(tenantId), 'auth.json');
+  if (!fs.existsSync(filePath)) return null;
+
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw);
+  } catch (error) {
+    console.error(
+      `\n Failed to read auth.json for tenant '${tenantId}': ${(error as Error).message}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Write the public metadata information for a tenant.
+ * @param {TenantInfo} info - The tenant info object.
+ */
+export async function writeTenantInfo(info: TenantInfo): Promise<void> {
+  try {
+    const dir = getTenantPath(info.tenantId);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'info.json'), JSON.stringify(info, null, 2));
+  } catch (error) {
+    console.error(
+      `\n Failed to write info.json for tenant '${info.tenantId}': ${(error as Error).message}`
+    );
+  }
+}
+
+/**
+ * Read the public metadata information for a tenant.
+ * @param {string} tenantId - The tenant ID.
+ * @returns Parsed tenant info or null if not found or failed to read.
+ */
+export async function readTenantInfo(tenantId: string): Promise<TenantInfo | null> {
+  const infoFilePath = path.join(getTenantPath(tenantId), 'info.json');
+
+  if (!fs.existsSync(infoFilePath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(infoFilePath, 'utf-8');
+    return JSON.parse(content) as TenantInfo;
+  } catch (error) {
+    console.error(
+      `\n Failed to read info.json for tenant '${tenantId}': ${(error as Error).message}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Deletes the stored auth.json file for the given tenant.
+ * @param {string} tenantId - The tenant ID.
+ */
+export async function deleteTenantAuthInfo(tenantId: string): Promise<void> {
+  const filePath = path.join(getTenantPath(tenantId), 'auth.json');
+  try {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch (error) {
+    console.error(
+      `\n Failed to delete auth.json for tenant '${tenantId}': ${(error as Error).message}`
+    );
+  }
+}
+
+/**
+ * Scans the CLI root directory and returns all valid tenant infos.
+ * @returns A list of TenantInfo objects found in {tenant-id}/info.json files.
+ */
+export function getAllTenantsInfo(): TenantInfo[] {
+  if (!fs.existsSync(rootDir)) return [];
+
+  const subDirs = fs
+    .readdirSync(rootDir)
+    .filter((entry) => fs.statSync(path.join(rootDir, entry)).isDirectory());
+
+  const tenants: TenantInfo[] = [];
+
+  for (const dir of subDirs) {
+    const infoPath = path.join(rootDir, dir, 'info.json');
+
+    if (fs.existsSync(infoPath)) {
+      try {
+        const content = fs.readFileSync(infoPath, 'utf-8');
+        const data = JSON.parse(content);
+
+        if (data.tenantId && data.tenantName && data.organizationId && data.clientId) {
+          tenants.push({
+            tenantId: data.tenantId,
+            tenantName: data.tenantName,
+            organizationId: data.organizationId,
+            clientId: data.clientId,
+            authority: data.authority,
+            audience: data.audience,
+            baseUrl: data.baseUrl,
+          });
+        }
+      } catch (error) {
+        console.error('\n Failed to read tenant info file', (error as Error).message);
+      }
+    }
+  }
+
+  return tenants;
+}
+
+/**
+ * Decodes a JWT without verifying its signature.
+ * @param {string} token - The access token string.
+ * @returns Decoded payload object or null if invalid.
+ */
+export function decodeJwtPayload(token: string): Record<string, any> | null {
+  try {
+    const base64Payload = token.split('.')[1];
+    const payload = Buffer.from(base64Payload, 'base64').toString('utf-8');
+    const decoded = JSON.parse(payload);
+    return {
+      tokenTenantId: decoded?.[`${CLAIMS}/tenant_id`],
+      tokenOrgId: decoded?.[`${CLAIMS}/org_id`],
+      tokenTenantName: decoded?.[`${CLAIMS}/tenant_name`],
+    };
+  } catch (error) {
+    console.error('\n Failed to decode access token:', (error as Error).message);
+    return null;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Duplicate of https://github.com/Sitecore/content-sdk/pull/102 (closed) since that was pointing to dev.

This PR introduces authentication to the CLI, allowing users to authenticate against Sitecore Content Services using the client credentials flow. It includes 
- persistent credential storage, 
- active tenant tracking
- support for multi-tenant management.

- Implemented Commands
   - `auth login`
      - Authenticates using client credentials only when `clientSecret` is present and stores:
         - `auth.json`: Access token info
         - `info.json`: Tenant metadata
         - `settings.json`: Tracks active tenant
         - Validates JWT claims against provided `tenantId` and `organizationId`.

   - `auth status`
      - Shows the currently active tenant registered under `~/.sitecore/sitecore-tools/settings.json`.
      - Automatically renews the token if expired.

   - `auth logout`
     - Logs out by clearing the active tenant and deleting its `auth.json`.

   - `auth list`
     - Lists all known tenants located under `~/.sitecore/sitecore-tools/{tenantId}`

- Token and tenant info stored under `~/.sitecore/sitecore-tools/{tenantId}-info.json`
- Auth metadata is under `~/.sitecore/sitecore-tools/{tenantId}-auth.json`
- `settings.json` tracks the active tenant globally under `~/.sitecore/sitecore-tools/settings.json`
- Token expiry is checked and token renewed automatically if expired.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
