### PR TITLE
[core] [templates/nextjs] - Add metadata generation support for mono-repo setup

### DIFF
--- a/packages/core/src/editing/metadata.ts
+++ b/packages/core/src/editing/metadata.ts
@@ -15,13 +15,17 @@ const trackedScopes = [
 
 /**
  * Get application metadata
+ * @param {boolean} allowWorkspaces - Whether to allow workspaces in the metadata generation.
+ * @returns {Metadata} The generated metadata.
  */
 export function getMetadata(allowWorkspaces: boolean = false): Metadata {
   const metadata: Metadata = { packages: {} };
 
   let queryResult: Package[] = [];
   try {
-    queryResult = JSON.parse(execSync(`npm query [name*=@sitecore] --workspaces ${allowWorkspaces}`).toString());
+    queryResult = JSON.parse(
+      execSync(`npm query [name*=@sitecore] --workspaces ${allowWorkspaces}`).toString()
+    );
   } catch (error) {
     console.error('Failed to retrieve sitecore packages using npm query', error);
     return metadata;

--- a/packages/core/src/editing/metadata.ts
+++ b/packages/core/src/editing/metadata.ts
@@ -16,12 +16,12 @@ const trackedScopes = [
 /**
  * Get application metadata
  */
-export function getMetadata(): Metadata {
+export function getMetadata(allowWorkspaces: boolean = false): Metadata {
   const metadata: Metadata = { packages: {} };
 
   let queryResult: Package[] = [];
   try {
-    queryResult = JSON.parse(execSync('npm query [name*=@sitecore] --workspaces false').toString());
+    queryResult = JSON.parse(execSync(`npm query [name*=@sitecore] --workspaces ${allowWorkspaces}`).toString());
   } catch (error) {
     console.error('Failed to retrieve sitecore packages using npm query', error);
     return metadata;

--- a/packages/core/src/tools/generateMetadata.test.ts
+++ b/packages/core/src/tools/generateMetadata.test.ts
@@ -39,4 +39,16 @@ describe('generateMetadata', () => {
     expect(writeFileSyncStub.calledOnce).to.be.true;
     expect(writeFileSyncStub.getCall(0).args[0]).to.be.equal(path.resolve(config.destinationPath));
   });
+
+  it('should generate metadata with allowWorkspaces set to true', async () => {
+    const config = { allowWorkspaces: true };
+    const generate = generateMetadata(config);
+    await generate();
+
+    expect(execSyncStub.calledOnce).to.be.true;
+    expect(writeFileSyncStub.calledOnce).to.be.true;
+    expect(writeFileSyncStub.getCall(0).args[0]).to.be.equal(
+      path.resolve('.sitecore/metadata.json')
+    );
+  });
 });

--- a/packages/core/src/tools/generateMetadata.ts
+++ b/packages/core/src/tools/generateMetadata.ts
@@ -19,17 +19,22 @@ export type GenerateMetadataConfig = {
    * If not provided, the default '.sitecore/metadata.json' will be used.
    */
   destinationPath?: string;
+  /**
+   * Optional flag to allow workspaces in the metadata generation.
+   * If not provided, the default is false.
+   */
+  allowWorkspaces?: boolean;
 };
 
 /**
  * Generate application metadata
  * @param {GenerateMetadataConfig} config - Optional configuration for generating metadata.
- * If not provided, the default '.sitecore/metadata.json' will be used.
+ * If not provided, the default '.sitecore/metadata.json' will be used and allowWorkspaces will be set to false.
  * @returns {Promise<void>} A promise that resolves when the metadata generation is complete.
  */
 export const generateMetadata = (config?: GenerateMetadataConfig): (() => Promise<void>) => {
   return async () => {
-    const metadata: Metadata = getMetadata();
+    const metadata: Metadata = getMetadata(config?.allowWorkspaces ?? false);
     writeMetadata(metadata, config?.destinationPath ?? '.sitecore/metadata.json');
   };
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs/sitecore.cli.config.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/sitecore.cli.config.ts
@@ -5,7 +5,9 @@ import { generateSites, generateMetadata } from '@sitecore-content-sdk/nextjs/to
 export default defineCliConfig({
   build: {
     commands: [
-      generateMetadata(),
+      generateMetadata({
+        allowWorkspaces: false,
+      }),
       generateSites({
         scConfig: config,
       }),

--- a/ref-docs/core/tools/functions/generateMetadata.md
+++ b/ref-docs/core/tools/functions/generateMetadata.md
@@ -16,7 +16,7 @@ Generate application metadata
 
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
-| `config?` | `GenerateMetadataConfig` | Optional configuration for generating metadata. If not provided, the default '.sitecore/metadata.json' will be used. |
+| `config?` | `GenerateMetadataConfig` | Optional configuration for generating metadata. If not provided, the default '.sitecore/metadata.json' will be used and allowWorkspaces will be set to false. |
 
 ## Returns
 

--- a/ref-docs/nextjs/tools/variables/generateMetadata.md
+++ b/ref-docs/nextjs/tools/variables/generateMetadata.md
@@ -16,7 +16,7 @@ Generate application metadata
 
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
-| `config?` | `GenerateMetadataConfig` | Optional configuration for generating metadata. If not provided, the default '.sitecore/metadata.json' will be used. |
+| `config?` | `GenerateMetadataConfig` | Optional configuration for generating metadata. If not provided, the default '.sitecore/metadata.json' will be used and allowWorkspaces will be set to false. |
 
 ## Returns
 


### PR DESCRIPTION
This commit allows metadata generation to query Sitecore packages without filtering out workspaces, enabling support for mono-repo setups.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [x] Upgrade guide entry added

## Description / Motivation
This PR adds support for mono-repo setups by allowing metadata generation to query Sitecore packages without filtering out workspaces. 

This change is necessary to ensure that metadata can be generated correctly in environments where multiple workspaces are used, such as in a mono-repo setup. 

It addresses the issue of metadata generation not accounting for workspaces, which can lead to incomplete or incorrect metadata.

## Testing Details
- **Unit Test Added**: A new unit test has been added to verify that the `generateMetadata` function correctly handles the `allowWorkspaces` property when set to `true`.
- **Manual Test/Other**: The changes have been manually tested in a mono-repo setup to ensure that metadata is generated correctly without filtering out workspaces.
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)