### PR TITLE
[DesignLibrary] Include metadata in the Design Library rendering mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Our versioning strategy is as follows:
 ### 🎉 New Features & Improvements
 
 * `[core]` [DesignLibrary] Call partial layout rendering endpoint via Envoy and ContextID ([#111](https://github.com/Sitecore/content-sdk/pull/111))
+* `[core]` `[nextjs]` [DesignLibrary] Include metadata in the Design Library rendering mechanism ([#118](https://github.com/Sitecore/content-sdk/pull/118))
 
 ### 🛠 Breaking Changes
 

--- a/packages/core/src/client/sitecore-client.test.ts
+++ b/packages/core/src/client/sitecore-client.test.ts
@@ -2,7 +2,7 @@
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import { SitecoreClient } from './sitecore-client';
-import { LayoutKind } from '../../editing';
+import { LayoutKind, DesignLibraryMode } from '../../editing';
 import { LayoutServiceData } from '../../layout';
 import { DefaultRetryStrategy } from '../retries';
 import { LayoutServicePageState } from '../layout';
@@ -760,6 +760,7 @@ describe('SitecoreClient', () => {
         dataSourceId: 'datasource-id',
         version: '1',
         pageState: LayoutServicePageState.Normal,
+        mode: DesignLibraryMode.Normal,
       };
 
       const componentData = {
@@ -806,6 +807,7 @@ describe('SitecoreClient', () => {
           renderingId: componentLibData.renderingId,
           dataSourceId: componentLibData.dataSourceId,
           version: componentLibData.version,
+          mode: componentLibData.mode,
         })
       ).to.be.true;
     });

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -418,6 +418,7 @@ export class SitecoreClient implements BaseSitecoreClient {
       renderingId,
       dataSourceId,
       version,
+      mode,
     } = designLibData;
 
     const componentData = await this.componentService.fetchComponentData({
@@ -428,6 +429,7 @@ export class SitecoreClient implements BaseSitecoreClient {
       renderingId,
       dataSourceId,
       version,
+      mode,
     });
 
     const dictionaryData = await this.editingService.fetchDictionaryData(

--- a/packages/core/src/editing/design-library.test.ts
+++ b/packages/core/src/editing/design-library.test.ts
@@ -6,9 +6,11 @@ import {
   getDesignLibraryStatusEvent,
   DesignLibraryStatus,
   getDesignLibraryScriptLink,
+  isDesignLibraryMode,
 } from './design-library';
 import testComponent from '../test-data/component-editing-data';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
+import { DesignLibraryMode } from './models';
 
 describe('component library utils', () => {
   const debugSpy = sinon.spy(console, 'debug');
@@ -186,6 +188,20 @@ describe('component library utils', () => {
       const customUrl = 'https://custom-designlibrary.com';
       const scriptLink = getDesignLibraryScriptLink(customUrl);
       expect(scriptLink).to.equal(`${customUrl}/v1/files/designlibrary/lib/rh-lib-script.js`);
+    });
+  });
+
+  describe('isDesignLibraryMode', () => {
+    it('should return true for DesignLibraryMode.Normal', () => {
+      expect(isDesignLibraryMode(DesignLibraryMode.Normal)).to.be.true;
+    });
+
+    it('should return true for DesignLibraryMode.Metadata', () => {
+      expect(isDesignLibraryMode(DesignLibraryMode.Metadata)).to.be.true;
+    });
+
+    it('should return false for other values', () => {
+      expect(isDesignLibraryMode('invalid')).to.be.false;
     });
   });
 

--- a/packages/core/src/editing/design-library.ts
+++ b/packages/core/src/editing/design-library.ts
@@ -1,6 +1,7 @@
 import { ComponentRendering, Field, GenericFieldValue } from '../layout/models';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 import { normalizeUrl } from '../utils/normalize-url';
+import { DesignLibraryMode } from './models';
 
 /**
  * Event to be sent when report status to design library
@@ -153,4 +154,13 @@ export function getDesignLibraryStatusEvent(
  */
 export function getDesignLibraryScriptLink(sitecoreEdgeUrl = SITECORE_EDGE_URL_DEFAULT): string {
   return `${normalizeUrl(sitecoreEdgeUrl)}/v1/files/designlibrary/lib/rh-lib-script.js`;
+}
+
+/**
+ * Checks if the given mode is a Design Library mode.
+ * @param {unknown} mode - The mode to check.
+ * @returns {boolean} True if the mode is a Design Library mode, false otherwise.
+ */
+export function isDesignLibraryMode(mode: unknown): mode is DesignLibraryMode {
+  return mode === DesignLibraryMode.Normal || mode === DesignLibraryMode.Metadata;
 }

--- a/packages/core/src/editing/index.ts
+++ b/packages/core/src/editing/index.ts
@@ -22,6 +22,7 @@ export {
   MetadataKind,
   EditingPreviewData,
   DesignLibraryRenderPreviewData,
+  DesignLibraryMode,
 } from './models';
 export {
   addComponentUpdateHandler,
@@ -29,4 +30,5 @@ export {
   DesignLibraryStatusEvent,
   getDesignLibraryStatusEvent,
   getDesignLibraryScriptLink,
+  isDesignLibraryMode,
 } from './design-library';

--- a/packages/core/src/editing/models.ts
+++ b/packages/core/src/editing/models.ts
@@ -12,7 +12,7 @@ export interface EditingRenderQueryParams {
   sc_itemid: string;
   sc_site: string;
   route: string;
-  mode: Exclude<LayoutServicePageState, 'normal'> | 'library';
+  mode: Exclude<LayoutServicePageState, 'normal'> | DesignLibraryMode;
   sc_layoutKind?: LayoutKind;
   sc_variant?: string;
   sc_version?: string;
@@ -30,7 +30,7 @@ export interface RenderComponentQueryParams {
   sc_renderingId: string;
   sc_uid: string;
   sc_site: string;
-  mode: 'library';
+  mode: DesignLibraryMode;
   sc_variant?: string;
   sc_version?: string;
 }
@@ -69,6 +69,20 @@ export type EditingPreviewData = {
 };
 
 /**
+ * Represents the mode of the Design Library.
+ */
+export enum DesignLibraryMode {
+  /**
+   * Normal mode
+   */
+  Normal = 'library',
+  /**
+   * Metadata mode
+   */
+  Metadata = 'library-metadata',
+}
+
+/**
  * Data for Design Library rendering mode
  */
 export interface DesignLibraryRenderPreviewData {
@@ -77,7 +91,7 @@ export interface DesignLibraryRenderPreviewData {
   renderingId: string;
   componentUid: string;
   language: string;
-  mode?: 'library';
+  mode?: DesignLibraryMode;
   variant?: string;
   version?: string;
   dataSourceId?: string;

--- a/packages/core/src/editing/models.ts
+++ b/packages/core/src/editing/models.ts
@@ -68,17 +68,11 @@ export type EditingPreviewData = {
   layoutKind?: LayoutKind;
 };
 
-/**
- * Represents the mode of the Design Library.
- */
+/** Represents the mode of the Design Library */
 export enum DesignLibraryMode {
-  /**
-   * Normal mode
-   */
+  /** Normal mode */
   Normal = 'library',
-  /**
-   * Metadata mode
-   */
+  /** Metadata mode */
   Metadata = 'library-metadata',
 }
 

--- a/packages/core/src/editing/rest-component-layout-service.test.ts
+++ b/packages/core/src/editing/rest-component-layout-service.test.ts
@@ -9,6 +9,7 @@ import {
 } from './rest-component-layout-service';
 import { LayoutServiceData } from '../layout/models';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
+import { DesignLibraryMode } from './models';
 
 use(spies);
 
@@ -50,6 +51,28 @@ describe('RestComponentLayoutService', () => {
 
     return service
       .fetchComponentData(defaultTestInput)
+      .then((layoutServiceData: LayoutServiceData & NativeDataFetcherConfig) => {
+        expect(layoutServiceData).to.deep.equal(defaultTestData);
+      });
+  });
+
+  it('should fetch component data in metadata mode', () => {
+    nock(SITECORE_EDGE_URL_DEFAULT, {
+      reqheaders: {
+        sc_editMode: 'true',
+      },
+    })
+      .get(
+        '/layout/component?sitecoreContextId=test-context-id&item=123&uid=456&sc_site=supersite&sc_lang=en',
+      )
+      .reply(200, () => defaultTestData);
+
+    const service = new RestComponentLayoutService({
+      contextId,
+    });
+
+    return service
+      .fetchComponentData({ ...defaultTestInput, mode: DesignLibraryMode.Metadata })
       .then((layoutServiceData: LayoutServiceData & NativeDataFetcherConfig) => {
         expect(layoutServiceData).to.deep.equal(defaultTestData);
       });

--- a/packages/core/src/editing/rest-component-layout-service.test.ts
+++ b/packages/core/src/editing/rest-component-layout-service.test.ts
@@ -63,7 +63,7 @@ describe('RestComponentLayoutService', () => {
       },
     })
       .get(
-        '/layout/component?sitecoreContextId=test-context-id&item=123&uid=456&sc_site=supersite&sc_lang=en',
+        '/layout/component?sitecoreContextId=test-context-id&item=123&uid=456&sc_site=supersite&sc_lang=en'
       )
       .reply(200, () => defaultTestData);
 

--- a/packages/core/src/editing/rest-component-layout-service.ts
+++ b/packages/core/src/editing/rest-component-layout-service.ts
@@ -85,7 +85,7 @@ export class RestComponentLayoutService {
     return fetcher
       .get<LayoutServiceData>(fetchUrl, {
         headers: {
-          sc_editMode: params.mode === DesignLibraryMode.Metadata ? 'true' : 'false',
+          sc_editMode: `${params.mode === DesignLibraryMode.Metadata}`,
         },
       })
       .then((response) => response.data)

--- a/packages/core/src/editing/rest-component-layout-service.ts
+++ b/packages/core/src/editing/rest-component-layout-service.ts
@@ -3,6 +3,7 @@ import { NativeDataFetcher, NativeDataFetcherConfig } from '../native-fetcher';
 import debug from '../debug';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 import { resolveUrl } from '../utils';
+import { DesignLibraryMode } from './models';
 
 /**
  * Params for requesting component data from service in Design Library mode
@@ -37,6 +38,10 @@ export interface ComponentLayoutRequestParams {
    * site name to be used as context for rendering the component
    */
   siteName: string;
+  /**
+   * mode to be used for rendering the component
+   */
+  mode?: DesignLibraryMode;
 }
 
 /**
@@ -78,7 +83,11 @@ export class RestComponentLayoutService {
     const fetchUrl = this.getFetchUrl(params);
 
     return fetcher
-      .get<LayoutServiceData>(fetchUrl)
+      .get<LayoutServiceData>(fetchUrl, {
+        headers: {
+          sc_editMode: params.mode === DesignLibraryMode.Metadata ? 'true' : 'false',
+        },
+      })
       .then((response) => response.data)
       .catch((error) => {
         if (error.response?.status === 404) {

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -7,6 +7,7 @@ import {
   EDITING_ALLOWED_ORIGINS,
   QUERY_PARAM_EDITING_SECRET,
   EditingRenderQueryParams,
+  DesignLibraryMode,
 } from '@sitecore-content-sdk/core/editing';
 import { EditingRenderMiddleware, EditingNextApiRequest } from './editing-render-middleware';
 import { spy } from 'sinon';
@@ -371,7 +372,7 @@ describe('EditingRenderMiddleware', () => {
 
   describe('Design Library handling', () => {
     const query = {
-      mode: 'library',
+      mode: DesignLibraryMode.Normal,
       sc_itemid: '{11111111-1111-1111-1111-111111111111}',
       sc_lang: 'en',
       sc_site: 'website',
@@ -398,7 +399,34 @@ describe('EditingRenderMiddleware', () => {
         renderingId: query.sc_renderingId,
         language: query.sc_lang,
         site: query.sc_site,
-        mode: 'library',
+        mode: DesignLibraryMode.Normal,
+        dataSourceId: query.dataSourceId,
+        version: query.sc_version,
+      });
+
+      expect(res.redirect).to.have.been.calledOnce;
+      expect(res.setHeader).to.have.been.calledWith(
+        'Content-Security-Policy',
+        `frame-ancestors 'self' https://allowed.com ${EDITING_ALLOWED_ORIGINS.join(' ')}`
+      );
+    });
+
+    it('should handle request with mode=library-metadata', async () => {
+      const req = mockRequest({ query: { ...query, mode: DesignLibraryMode.Metadata } });
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+      const handler = middleware.getHandler();
+
+      await handler(req, res);
+
+      expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({
+        itemId: query.sc_itemid,
+        componentUid: query.sc_uid,
+        renderingId: query.sc_renderingId,
+        language: query.sc_lang,
+        site: query.sc_site,
+        mode: DesignLibraryMode.Metadata,
         dataSourceId: query.dataSourceId,
         version: query.sc_version,
       });

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -7,6 +7,7 @@ import {
   DesignLibraryRenderPreviewData,
   EditingPreviewData,
   PREVIEW_KEY,
+  isDesignLibraryMode,
 } from '@sitecore-content-sdk/core/editing';
 import { LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
 import { getJssEditingSecret } from '../utils/utils';
@@ -49,7 +50,7 @@ export const isDesignLibraryPreviewData = (
     typeof data === 'object' &&
     data !== null &&
     'mode' in data &&
-    (data as DesignLibraryRenderPreviewData).mode === 'library'
+    isDesignLibraryMode((data as DesignLibraryRenderPreviewData).mode)
   );
 };
 
@@ -146,8 +147,9 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
       'sc_lang',
       'mode',
     ];
-    const requiredQueryParams =
-      mode === 'library' ? componentRequiredParams : defaultRequiredParams;
+    const requiredQueryParams = isDesignLibraryMode(mode)
+      ? componentRequiredParams
+      : defaultRequiredParams;
 
     const missingQueryParams = requiredQueryParams.filter((param) => !query[param]);
 
@@ -162,7 +164,7 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
       });
     }
 
-    if (mode === 'library') {
+    if (isDesignLibraryMode(mode)) {
       res.setPreviewData(
         {
           itemId: query.sc_itemid,
@@ -170,7 +172,7 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
           renderingId: query.sc_renderingId,
           language: query.sc_lang,
           site: query.sc_site,
-          mode: 'library',
+          mode,
           dataSourceId: query.dataSourceId,
           version: query.sc_version,
         } as DesignLibraryRenderPreviewData,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- Introduced `DesignLibraryMode` enum with two modes:
  - `Normal = 'library'` : Standard component rendering
  - `Metadata = 'library-metadata'` : Metadata-focused rendering

- Enhanced `RestComponentLayoutService` to support metadata mode:
  - Added mode parameter to `ComponentLayoutRequestParams`
  - Implemented conditional header setting (`sc_editMode`) based on mode

- Updated `EditingRenderMiddleware` to:
  - Support both normal and metadata modes
  - Implement proper validation for mode-specific parameters

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
