### PR TITLE
[Authentication] [cli]  Add Device Authorization Flow Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,13 @@ Our versioning strategy is as follows:
     - Introduced `getTaxonomy` and `getTaxonomies` methods on Content Client class
     - Support pagination for the above methods by implementing an internal `fetchNext` method to handle this in each method
   - Introduced `getLocale/getLocales` functionality on content client: 
-    - Initial implementation of `getLocale/getLocales` ([#74](https://github.com/Sitecore/content-sdk/pull/74)) ([#78](https://github.com/Sitecore/content-sdk/pull/78)) ([#105](https://github.com/Sitecore/content-sdk/pull/105))
-* `[cli]` Introduce Sitecore Content Services Auth CLI commands ([106](https://github.com/Sitecore/content-sdk/pull/106)) ([116](https://github.com/Sitecore/content-sdk/pull/116)):
-    - auth login: Authenticate using client credentials and store token info.
+    - Initial implementation of `getLocale/getLocales` ([#74](https://github.com/Sitecore/content-sdk/pull/74)) ([#78](https://github.com/Sitecore/content-sdk/pull/78)) ([#126](https://github.com/Sitecore/content-sdk/pull/126))
+* `[cli]` Authentication: Introduce Sitecore Content Services Auth CLI commands ([106](https://github.com/Sitecore/content-sdk/pull/106)) ([116](https://github.com/Sitecore/content-sdk/pull/116)):
+    - auth login: Authenticate using client credentials when client secret is provided else device authorization flow and store token info.
     - auth status: Show active tenant and auto-renew token if expired.
     - auth logout: Clear active tenant and delete stored credentials.
     - auth list: List all known tenants from local storage.
-  - Token validation and renewal support.
+  - Token validation and automatic renewal support.
   - Token and tenant metadata storage and active tenant tracking under `~/.sitecore/sitecore-tools/`.
   - Securely encrypts and decrypts authentication data file with AES-256-GCM and 256-bit keys. The encryption keys are stored per tenant in the OS keychain, ensuring credentials are safely persisted across sessions.
 * `[next.js]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):

--- a/packages/cli/src/scripts/auth/list.test.ts
+++ b/packages/cli/src/scripts/auth/list.test.ts
@@ -47,7 +47,7 @@ describe('list command', () => {
     await list.handler({} as any);
 
     const expectedLogs = [
-      '\n Known tenants:\n',
+      '\nKnown tenants:\n',
       'Tenant 1:',
       '  Tenant ID       : t1',
       '  Tenant Name     : Tenant One',

--- a/packages/cli/src/scripts/auth/list.ts
+++ b/packages/cli/src/scripts/auth/list.ts
@@ -18,7 +18,7 @@ export const list: CommandModule = {
       return;
     }
 
-    console.log('\n Known tenants:\n');
+    console.log('\nKnown tenants:\n');
 
     tenants.forEach((tenant, index) => {
       console.log(`Tenant ${index + 1}:`);

--- a/packages/cli/src/scripts/auth/login.test.ts
+++ b/packages/cli/src/scripts/auth/login.test.ts
@@ -24,11 +24,11 @@ describe('login command', () => {
   };
 
   const fakeDeviceAuthResponse = {
-    deviceCode: 'device-code-123',
-    userCode: 'user-code-456',
-    verificationUri: 'https://verify.example.com',
-    verificationUriComplete: 'https://verify.example.com/complete',
-    expiresIn: 900,
+    device_code: 'device-code-123',
+    user_code: 'user-code-456',
+    verification_uri: 'https://verify.example.com',
+    verification_uri_complete: 'https://verify.example.com/complete',
+    expires_in: 900,
     interval: 5,
   };
 
@@ -122,7 +122,7 @@ describe('login command', () => {
     expect(
       pollForTokenStub.calledWith({
         clientId: deviceFlowArgs.clientId,
-        deviceCode: fakeDeviceAuthResponse.deviceCode,
+        device_code: fakeDeviceAuthResponse.device_code,
         authority: deviceFlowArgs.authority,
         interval: fakeDeviceAuthResponse.interval,
       })

--- a/packages/cli/src/scripts/auth/login.test.ts
+++ b/packages/cli/src/scripts/auth/login.test.ts
@@ -13,7 +13,7 @@ describe('login command', () => {
     baseUrl: 'https://api.example.com',
   };
 
-  const fakeAuthResponse = {
+  const fakeClientAuthResponse = {
     data: {
       access_token: 'test-access-token',
       expires_in: 3600,
@@ -23,16 +23,47 @@ describe('login command', () => {
     tokenTenantName: 'TestTenant',
   };
 
+  const fakeDeviceAuthResponse = {
+    deviceCode: 'device-code-123',
+    userCode: 'user-code-456',
+    verificationUri: 'https://verify.example.com',
+    verificationUriComplete: 'https://verify.example.com/complete',
+    expiresIn: 900,
+    interval: 5,
+  };
+
+  const fakePolledTokenResponse = {
+    access_token: 'access-token-from-poll',
+    refresh_token: 'refresh-token-from-poll',
+    expires_in: 3600,
+    token_type: 'Bearer',
+  };
+
+  const fakeRefreshedTokenResponse = {
+    access_token: 'refreshed-access-token',
+    refresh_token: 'refreshed-refresh-token',
+    expires_in: 3600,
+    token_type: 'Bearer',
+    tenantName: 'TestTenant',
+  };
+
   let clientCredentialsStub: sinon.SinonStub;
+  let startDeviceAuthStub: sinon.SinonStub;
+  let pollForTokenStub: sinon.SinonStub;
+  let refreshAccessTokenStub: sinon.SinonStub;
+
   let writeTenantAuthStub: sinon.SinonStub;
   let writeTenantInfoStub: sinon.SinonStub;
   let setActiveTenantStub: sinon.SinonStub;
-  let consoleInfoStub: sinon.SinonStub;
   let processExitStub: sinon.SinonStub;
   let consoleErrorStub: sinon.SinonStub;
+  let consoleLogStub: sinon.SinonStub;
 
   beforeEach(() => {
-    clientCredentialsStub = sinon.stub().resolves(fakeAuthResponse);
+    clientCredentialsStub = sinon.stub().resolves(fakeClientAuthResponse);
+    startDeviceAuthStub = sinon.stub().resolves(fakeDeviceAuthResponse);
+    pollForTokenStub = sinon.stub().resolves(fakePolledTokenResponse);
+    refreshAccessTokenStub = sinon.stub().resolves(fakeRefreshedTokenResponse);
     writeTenantAuthStub = sinon.stub().resolves();
     writeTenantInfoStub = sinon.stub().resolves();
     setActiveTenantStub = sinon.stub();
@@ -41,11 +72,14 @@ describe('login command', () => {
       writeTenantAuthInfo: writeTenantAuthStub,
       writeTenantInfo: writeTenantInfoStub,
       setActiveTenant: setActiveTenantStub,
+      startDeviceAuthFlow: startDeviceAuthStub,
+      pollForDeviceToken: pollForTokenStub,
+      getRefreshAccessToken: refreshAccessTokenStub,
     });
 
-    consoleInfoStub = sinon.stub(console, 'info');
     processExitStub = sinon.stub(process, 'exit');
     consoleErrorStub = sinon.stub(console, 'error');
+    consoleLogStub = sinon.stub(console, 'log');
   });
 
   afterEach(() => {
@@ -68,8 +102,88 @@ describe('login command', () => {
 
     expect(writeTenantAuthStub.calledOnce).to.be.true;
     expect(writeTenantInfoStub.calledOnce).to.be.true;
-    expect(setActiveTenantStub.calledWith(fakeAuthResponse.tokenTenantId)).to.be.true;
-    expect(consoleInfoStub.calledWithMatch(/Logged in successfully/)).to.be.true;
+    expect(setActiveTenantStub.calledWith(fakeClientAuthResponse.tokenTenantId)).to.be.true;
+    expect(consoleLogStub.calledWithMatch(/Logged in successfully/)).to.be.true;
+  });
+
+  it('should perform login using device flow and refresh token', async () => {
+    const deviceFlowArgs = {
+      clientId: 'test-client-id',
+      tenantId: 'test-tenant-id',
+      organizationId: 'test-org-id',
+      authority: 'https://auth.example.com',
+      audience: 'https://api.example.com',
+      baseUrl: 'https://api.example.com',
+    };
+
+    await login.handler(deviceFlowArgs as any);
+
+    expect(startDeviceAuthStub.calledOnce).to.be.true;
+    expect(
+      pollForTokenStub.calledWith({
+        clientId: deviceFlowArgs.clientId,
+        deviceCode: fakeDeviceAuthResponse.deviceCode,
+        authority: deviceFlowArgs.authority,
+        interval: fakeDeviceAuthResponse.interval,
+      })
+    ).to.be.true;
+
+    expect(
+      refreshAccessTokenStub.calledWith({
+        clientId: deviceFlowArgs.clientId,
+        refreshToken: fakePolledTokenResponse.refresh_token,
+        tenantId: deviceFlowArgs.tenantId,
+        organizationId: deviceFlowArgs.organizationId,
+        authority: deviceFlowArgs.authority,
+      })
+    ).to.be.true;
+
+    expect(writeTenantAuthStub.calledOnce).to.be.true;
+    expect(writeTenantInfoStub.calledOnce).to.be.true;
+    expect(setActiveTenantStub.calledWith(deviceFlowArgs.tenantId)).to.be.true;
+    expect(consoleLogStub.calledWithMatch(/Logged in successfully/)).to.be.true;
+  });
+
+  it('should exit if tenantId is missing in device flow', async () => {
+    const args = {
+      clientId: 'test-client-id',
+      organizationId: 'test-org-id',
+    };
+
+    processExitStub.callsFake(() => {
+      throw new Error('EXIT_CALLED');
+    });
+
+    try {
+      await login.handler(args as any);
+      throw new Error('Test failed: process.exit was not called');
+    } catch (err) {
+      expect((err as Error).message).to.equal('EXIT_CALLED');
+      expect(consoleErrorStub.calledWithMatch(/Tenant ID is required/)).to.be.true;
+    }
+
+    expect(processExitStub.calledOnceWith(1)).to.be.true;
+  });
+
+  it('should exit if organizationId is missing in device flow', async () => {
+    const args = {
+      clientId: 'test-client-id',
+      tenantId: 'test-tenant-id',
+    };
+
+    processExitStub.callsFake(() => {
+      throw new Error('EXIT_CALLED');
+    });
+
+    try {
+      await login.handler(args as any);
+      throw new Error('Test failed: process.exit was not called');
+    } catch (err) {
+      expect((err as Error).message).to.equal('EXIT_CALLED');
+      expect(consoleErrorStub.calledWithMatch(/Organization ID is required/)).to.be.true;
+    }
+
+    expect(processExitStub.calledOnceWith(1)).to.be.true;
   });
 
   it('should exit when clientCredentialsFlow throws', async () => {

--- a/packages/cli/src/scripts/auth/login.ts
+++ b/packages/cli/src/scripts/auth/login.ts
@@ -1,14 +1,25 @@
 ﻿import { Argv, CommandModule } from 'yargs';
-import { auth, TenantArgs } from '@sitecore-content-sdk/core/tools';
+import { TenantArgs, auth } from '@sitecore-content-sdk/core/tools';
 import { constants } from '@sitecore-content-sdk/core';
 
-let { setActiveTenant, writeTenantAuthInfo, writeTenantInfo, clientCredentialsFlow } = auth;
+let {
+  setActiveTenant,
+  writeTenantAuthInfo,
+  writeTenantInfo,
+  clientCredentialsFlow,
+  getRefreshAccessToken,
+  pollForDeviceToken,
+  startDeviceAuthFlow,
+} = auth;
 
 export const unitMock = (formModule: any) => {
   setActiveTenant = formModule.setActiveTenant;
   writeTenantAuthInfo = formModule.writeTenantAuthInfo;
   writeTenantInfo = formModule.writeTenantInfo;
   clientCredentialsFlow = formModule.clientCredentialsFlow;
+  getRefreshAccessToken = formModule.getRefreshAccessToken;
+  pollForDeviceToken = formModule.pollForDeviceToken;
+  startDeviceAuthFlow = formModule.startDeviceAuthFlow;
 };
 
 export const login: CommandModule<object, TenantArgs> = {
@@ -66,61 +77,127 @@ export const login: CommandModule<object, TenantArgs> = {
       ),
 
   handler: async (argv: TenantArgs) => {
-    const { clientId } = argv;
-
-    let authResult, tenantId, organizationId, tenantName;
-
     const {
       DEFAULT_SITECORE_AUTH_DOMAIN,
       DEFAULT_SITECORE_AUTH_AUDIENCE,
       DEFAULT_SITECORE_AUTH_BASE_URL,
     } = constants;
+    const {
+      clientId,
+      clientSecret,
+      organizationId,
+      tenantId: inputTenantId,
+      audience = DEFAULT_SITECORE_AUTH_AUDIENCE,
+      authority = DEFAULT_SITECORE_AUTH_DOMAIN,
+      baseUrl = DEFAULT_SITECORE_AUTH_BASE_URL,
+    } = argv;
 
-    if (argv.clientSecret) {
-      try {
-        const authData = await clientCredentialsFlow({
+    let authResponse;
+    let tenantId;
+    let tenantName;
+    let orgId;
+
+    try {
+      if (clientSecret) {
+        console.log('\n Using Client Credentials Flow...');
+
+        const { data, tokenTenantId, tokenOrgId, tokenTenantName } = await clientCredentialsFlow({
           clientId,
-          clientSecret: argv.clientSecret,
-          organizationId: argv.organizationId,
-          tenantId: argv.tenantId,
-          audience: argv.audience,
-          authority: argv.authority,
-          baseUrl: argv.baseUrl,
+          clientSecret,
+          organizationId,
+          tenantId: inputTenantId,
+          audience,
+          authority,
+          baseUrl,
         });
 
-        authResult = authData.data;
-        tenantId = authData.tokenTenantId;
-        organizationId = authData.tokenOrgId;
-        tenantName = authData.tokenTenantName;
-      } catch (err) {
-        console.error(`\n Login failed: ${(err as Error).message}`);
-        process.exit(1);
+        authResponse = data;
+        tenantId = tokenTenantId;
+        orgId = tokenOrgId;
+        tenantName = tokenTenantName;
+      } else {
+        console.log('\n Using Device Code Flow...');
+
+        if (!inputTenantId) {
+          throw new Error('\n Tenant ID is required for Device Code Flow.');
+        }
+
+        if (!organizationId) {
+          throw new Error('\n Organization ID is required for Device Code Flow.');
+        }
+
+        const deviceAuthData = await startDeviceAuthFlow({
+          clientId,
+          audience,
+          authority,
+          baseUrl,
+        });
+
+        const {
+          deviceCode,
+          userCode,
+          verificationUri,
+          verificationUriComplete,
+          interval,
+        } = deviceAuthData;
+
+        console.log('\n🔐 Device Authorization Started');
+        if (verificationUriComplete) {
+          console.log(
+            `\n 👉 Open the following URL to authenticate:\n  ${verificationUriComplete}`
+          );
+        } else {
+          console.log(`👉 Visit: ${verificationUri}`);
+          console.log(`🔑 Then enter the code: ${userCode}`);
+        }
+
+        const { refresh_token } = await pollForDeviceToken({
+          clientId,
+          deviceCode,
+          authority,
+          interval,
+        });
+
+        // The initial device code flow does not support custom claims (e.g., tenantId, organizationId),
+        // which are required for proper token validation in our multi-tenant system.
+        // To include these claims, we immediately use the returned refresh_token to request a new
+        // access token with tenantId and organizationId explicitly provided.
+        authResponse = await getRefreshAccessToken({
+          clientId,
+          refreshToken: refresh_token,
+          tenantId: inputTenantId,
+          organizationId,
+          authority,
+        });
+
+        tenantId = inputTenantId;
+        orgId = organizationId;
+        tenantName = authResponse.tenantName;
+
+        console.log('\n Device Authorization Completed');
       }
-    } else {
-      // TODO: Implement Device Authorization Flow when clientSecret is not provided.
-      console.log('\n Please provide client secret for authentication.');
+
+      await writeTenantAuthInfo(tenantId || inputTenantId, {
+        expires_at: new Date(Date.now() + authResponse.expires_in * 1000).toISOString(),
+        ...authResponse,
+      });
+
+      await writeTenantInfo({
+        tenantId,
+        organizationId: orgId,
+        clientId,
+        tenantName,
+        authority,
+        audience,
+        baseUrl,
+      });
+
+      setActiveTenant(tenantId);
+
+      console.log(`\n Logged in successfully to tenant: ${tenantId}`);
+    } catch (error) {
+      console.error(`\n Login failed: ${(error as Error).message}`);
       process.exit(1);
     }
-
-    await writeTenantAuthInfo(tenantId, {
-      clientSecret: argv.clientSecret,
-      access_token: authResult.access_token,
-      expires_in: authResult.expires_in,
-      expires_at: new Date(Date.now() + authResult.expires_in * 1000).toISOString(),
-    });
-
-    await writeTenantInfo({
-      tenantId,
-      organizationId,
-      clientId,
-      tenantName,
-      authority: argv.authority || DEFAULT_SITECORE_AUTH_DOMAIN,
-      audience: argv.audience || DEFAULT_SITECORE_AUTH_AUDIENCE,
-      baseUrl: argv.baseUrl || DEFAULT_SITECORE_AUTH_BASE_URL,
-    });
-
-    setActiveTenant(tenantId);
-
-    console.info(`\n Logged in successfully to tenant ${tenantId}.`);
   },
 };

--- a/packages/cli/src/scripts/auth/login.ts
+++ b/packages/cli/src/scripts/auth/login.ts
@@ -116,7 +116,7 @@ export const login: CommandModule<object, TenantArgs> = {
         orgId = tokenOrgId;
         tenantName = tokenTenantName;
       } else {
-        console.log('\n Using Device Code Flow...');
+        console.log('\n Using Device Authorization Flow...');
 
         if (!inputTenantId) {
           throw new Error('\n Tenant ID is required for Device Code Flow.');
@@ -134,26 +134,27 @@ export const login: CommandModule<object, TenantArgs> = {
         });
 
         const {
-          deviceCode,
-          userCode,
-          verificationUri,
-          verificationUriComplete,
+          device_code,
+          user_code,
+          verification_uri,
+          verification_uri_complete,
           interval,
         } = deviceAuthData;
 
         console.log('\n🔐 Device Authorization Started');
-        if (verificationUriComplete) {
+
+        if (verification_uri_complete) {
           console.log(
-            `\n 👉 Open the following URL to authenticate:\n  ${verificationUriComplete}`
+            `\n 👉 Open the following URL to authenticate:\n  ${verification_uri_complete}`
           );
         } else {
-          console.log(`👉 Visit: ${verificationUri}`);
-          console.log(`🔑 Then enter the code: ${userCode}`);
+          console.log(`👉 Visit: ${verification_uri}`);
+          console.log(`🔑 Then enter the code: ${user_code}`);
         }
 
         const { refresh_token } = await pollForDeviceToken({
           clientId,
-          deviceCode,
+          device_code,
           authority,
           interval,
         });

--- a/packages/cli/src/scripts/auth/logout.test.ts
+++ b/packages/cli/src/scripts/auth/logout.test.ts
@@ -6,12 +6,12 @@ describe('logout command', () => {
   let getActiveTenantStub: sinon.SinonStub;
   let clearActiveTenantStub: sinon.SinonStub;
   let deleteTenantAuthInfoStub: sinon.SinonStub;
-  let consoleInfoStub: sinon.SinonStub;
+  let consoleLogStub: sinon.SinonStub;
   let consoleErrorStub: sinon.SinonStub;
   let deleteKeyStub: sinon.SinonStub;
 
   beforeEach(() => {
-    consoleInfoStub = sinon.stub(console, 'info');
+    consoleLogStub = sinon.stub(console, 'info');
     consoleErrorStub = sinon.stub(console, 'error');
     clearActiveTenantStub = sinon.stub();
     deleteTenantAuthInfoStub = sinon.stub();
@@ -50,6 +50,6 @@ describe('logout command', () => {
     expect(clearActiveTenantStub.calledOnce).to.be.true;
     expect(deleteTenantAuthInfoStub.calledWith(mockTenantId)).to.be.true;
     expect(deleteKeyStub.calledWith(mockTenantId)).to.be.true;
-    expect(consoleInfoStub.calledWithMatch(`Logged out from tenant ${mockTenantId}`)).to.be.true;
+    expect(consoleLogStub.calledWithMatch(`Logged out from tenant ${mockTenantId}`)).to.be.true;
   });
 });

--- a/packages/cli/src/scripts/auth/logout.test.ts
+++ b/packages/cli/src/scripts/auth/logout.test.ts
@@ -11,7 +11,7 @@ describe('logout command', () => {
   let deleteKeyStub: sinon.SinonStub;
 
   beforeEach(() => {
-    consoleLogStub = sinon.stub(console, 'info');
+    consoleLogStub = sinon.stub(console, 'log');
     consoleErrorStub = sinon.stub(console, 'error');
     clearActiveTenantStub = sinon.stub();
     deleteTenantAuthInfoStub = sinon.stub();

--- a/packages/cli/src/scripts/auth/logout.ts
+++ b/packages/cli/src/scripts/auth/logout.ts
@@ -20,8 +20,8 @@ export const logout: CommandModule = {
       return;
     }
 
-    deleteTenantAuthInfo(tenantId);
-    deleteKey(tenantId);
+    await deleteTenantAuthInfo(tenantId);
+    await deleteKey(tenantId);
     clearActiveTenant();
 
     console.log(`\n Logged out from tenant ${tenantId}`);

--- a/packages/cli/src/scripts/auth/logout.ts
+++ b/packages/cli/src/scripts/auth/logout.ts
@@ -24,6 +24,6 @@ export const logout: CommandModule = {
     deleteKey(tenantId);
     clearActiveTenant();
 
-    console.info(`\n Logged out from tenant ${tenantId}`);
+    console.log(`\n Logged out from tenant ${tenantId}`);
   },
 };

--- a/packages/cli/src/scripts/auth/status.ts
+++ b/packages/cli/src/scripts/auth/status.ts
@@ -15,7 +15,7 @@ export const status: CommandModule = {
     const context = await validateAndRenewAuthIfExpired();
 
     if (!context) {
-      console.log('\nNo valid authentication found. Please login.');
+      console.log('\n No valid authentication found. Please login.');
       return;
     }
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -12,7 +12,14 @@ export const SITECORE_EDGE_URL_DEFAULT = 'https://edge-platform.sitecorecloud.io
 
 export const HIDDEN_RENDERING_NAME = 'Hidden Rendering';
 
-export const CLAIMS = 'https://auth.sitecorecloud.io/claims';
+// Sitecore Auth constants
 export const DEFAULT_SITECORE_AUTH_DOMAIN = 'https://auth.sitecorecloud.io';
 export const DEFAULT_SITECORE_AUTH_AUDIENCE = 'https://api.sitecorecloud.io';
 export const DEFAULT_SITECORE_AUTH_BASE_URL = 'https://edge-platform.sitecorecloud.io/cs/api';
+export const CLAIMS = 'https://auth.sitecorecloud.io/claims';
+export const CLIENT_GRANT_TYPE = 'client_credentials';
+export const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+export const REFRESH_GRANT_TYPE = 'refresh_token';
+export const SCOPE = 'openid profile email offline_access';
+export const TIMEOUT = 600;
+export const DEFAULT_INTERVAL = 10;

--- a/packages/core/src/tools/auth/fetcher.test.ts
+++ b/packages/core/src/tools/auth/fetcher.test.ts
@@ -1,0 +1,100 @@
+﻿import { expect } from 'chai';
+import sinon from 'sinon';
+import { sendPostRequest } from './fetcher'; // adjust path accordingly
+
+describe('sendPostRequest', () => {
+  let fetchStub: sinon.SinonStub;
+
+  const testUrl = 'https://example.com/token';
+  const params = new URLSearchParams({ grant_type: 'client_credentials' });
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return data on successful response', async () => {
+    const mockData = { access_token: 'abc123', expires_in: 3600 };
+
+    fetchStub.resolves({
+      ok: true,
+      json: async () => mockData,
+    } as Response);
+
+    const result = await sendPostRequest<typeof mockData>(testUrl, params);
+
+    expect(
+      fetchStub.calledOnceWithExactly(testUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      })
+    ).to.be.true;
+
+    expect(result).to.deep.equal(mockData);
+  });
+
+  it('should throw error with error_description from response', async () => {
+    const errorResponse = { error_description: 'Invalid client credentials' };
+
+    fetchStub.resolves({
+      ok: false,
+      json: async () => errorResponse,
+    } as Response);
+
+    try {
+      await sendPostRequest(testUrl, params);
+      expect.fail('Expected to throw');
+    } catch (err) {
+      expect((err as Error).message).to.equal('Invalid client credentials');
+    }
+  });
+
+  it('should throw error with error field if error_description is missing', async () => {
+    const errorResponse = { error: 'invalid_request' };
+
+    fetchStub.resolves({
+      ok: false,
+      json: async () => errorResponse,
+    } as Response);
+
+    try {
+      await sendPostRequest(testUrl, params);
+      expect.fail('Expected to throw');
+    } catch (err) {
+      expect((err as Error).message).to.equal('invalid_request');
+    }
+  });
+
+  it('should throw generic error if neither error nor error_description is present', async () => {
+    const errorResponse = { message: 'unexpected failure' };
+
+    fetchStub.resolves({
+      ok: false,
+      json: async () => errorResponse,
+    } as Response);
+
+    try {
+      await sendPostRequest(testUrl, params);
+      expect.fail('Expected to throw');
+    } catch (err) {
+      expect((err as Error).message).to.equal('Unknown error occurred');
+    }
+  });
+
+  it('should return error response without throwing when throwOnError is false', async () => {
+    const errorResponse = { error: 'authorization_pending' };
+
+    fetchStub.resolves({
+      ok: false,
+      json: async () => errorResponse,
+    } as Response);
+
+    const result = await sendPostRequest<typeof errorResponse>(testUrl, params, false);
+
+    expect(result).to.deep.equal(errorResponse);
+  });
+});

--- a/packages/core/src/tools/auth/fetcher.ts
+++ b/packages/core/src/tools/auth/fetcher.ts
@@ -1,0 +1,39 @@
+﻿/* eslint-disable jsdoc/require-jsdoc */
+export const unitMocks = {
+  set sendPostRequest(mockImplementation) {
+    sendPostRequest = mockImplementation;
+  },
+  get sendPostRequest() {
+    return _sendPostRequest;
+  },
+};
+/**
+ * Performs a POST request with application/x-www-form-urlencoded headers.
+ * @param {string} url - The endpoint to post to.
+ * @param { URLSearchParams} params - A URLSearchParams instance representing the body.
+ * @returns Parsed JSON response.
+ * @throws Error if response is not OK.
+ */
+export let sendPostRequest = _sendPostRequest;
+
+async function _sendPostRequest<T>(
+  url: string,
+  params: URLSearchParams,
+  throwOnError = true
+): Promise<T> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  const data = await response.json();
+
+  if (throwOnError && !response.ok) {
+    throw new Error(data.error_description || data.error || 'Unknown error occurred');
+  }
+
+  return data;
+}

--- a/packages/core/src/tools/auth/flow.test.ts
+++ b/packages/core/src/tools/auth/flow.test.ts
@@ -1,10 +1,10 @@
 ﻿import { expect } from 'chai';
 import sinon from 'sinon';
-import { clientCredentialsFlow } from './flow';
+import { clientCredentialsFlow, startDeviceAuthFlow, pollForDeviceToken } from './flow';
 import * as jwtUtil from './tenant-store';
 import { DEFAULT_SITECORE_AUTH_AUDIENCE, DEFAULT_SITECORE_AUTH_BASE_URL } from '../../constants';
 
-describe('clientCredentialsFlow', () => {
+describe('Auth flows', () => {
   const fakeToken = 'fake.jwt.token';
   const fakeDecoded = {
     tokenTenantId: 'tenant123',
@@ -12,7 +12,23 @@ describe('clientCredentialsFlow', () => {
     tokenTenantName: 'FakeTenant',
   };
 
-  const fetchResponse = {
+  const tokenResponse = {
+    access_token: 'access123',
+    refresh_token: 'refresh123',
+    expires_in: 3600,
+    token_type: 'Bearer',
+  };
+
+  const deviceAuthMock = {
+    device_code: 'device123',
+    user_code: 'user123',
+    verification_uri: 'https://verify.uri',
+    verification_uri_complete: 'https://verify.uri/complete',
+    expires_in: 900,
+    interval: 5,
+  };
+
+  const fetchClientResponse = {
     ok: true,
     json: async () => ({
       access_token: fakeToken,
@@ -23,172 +39,271 @@ describe('clientCredentialsFlow', () => {
   let fetchStub: sinon.SinonStub;
   let decodeStub: sinon.SinonStub;
   let consoleErrorStub: sinon.SinonStub;
+  let consoleLogStub: sinon.SinonStub;
+  let clock: sinon.SinonFakeTimers;
 
   beforeEach(() => {
-    fetchStub = sinon.stub(global, 'fetch' as any).resolves(fetchResponse as any);
+    fetchStub = sinon.stub(global, 'fetch' as any).resolves(fetchClientResponse as any);
     decodeStub = sinon.stub().returns(fakeDecoded);
     sinon.replace.usingAccessor(jwtUtil.unitMocks, 'decodeJwtPayload', decodeStub);
+
     consoleErrorStub = sinon.stub(console, 'error');
+    consoleLogStub = sinon.stub(console, 'log');
+    clock = sinon.useFakeTimers();
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  it('should succeed when tenantId and organizationId are not passed and grab them from token claims', async () => {
-    const result = await clientCredentialsFlow({
-      clientId: 'id',
-      clientSecret: 'secret',
+  describe('clientCredentialsFlow', () => {
+    it('should succeed without tenantId/orgId using token claims', async () => {
+      fetchStub.resolves({
+        ok: true,
+        json: async () => ({ access_token: fakeToken, expires_in: 3600 }),
+      });
+
+      const result = await clientCredentialsFlow({ clientId: 'id', clientSecret: 'secret' });
+
+      expect(result.data.access_token).to.equal(fakeToken);
+      expect(result.tokenTenantId).to.equal(fakeDecoded.tokenTenantId);
     });
 
-    expect(result.data.access_token).to.equal(fakeToken);
-    expect(result.tokenTenantId).to.equal(fakeDecoded.tokenTenantId);
-    expect(result.tokenOrgId).to.equal(fakeDecoded.tokenOrgId);
-    expect(result.tokenTenantName).to.equal(fakeDecoded.tokenTenantName);
-  });
+    it('should succeed if tenantId/orgId match token', async () => {
+      decodeStub.returns({
+        tokenTenantId: 'tenant123',
+        tokenOrgId: 'org456',
+        tokenTenantName: 'FakeTenant',
+      });
 
-  it('should succeed only if passed tenantId and organizationId match token claims', async () => {
-    decodeStub.returns({
-      tokenTenantId: 'tenant123',
-      tokenOrgId: 'org456',
-      tokenTenantName: 'FakeTenant',
-    });
-
-    const result = await clientCredentialsFlow({
-      clientId: 'id',
-      clientSecret: 'secret',
-      tenantId: 'tenant123',
-      organizationId: 'org456',
-    });
-
-    expect(result.data.access_token).to.equal(fakeToken);
-    expect(result.tokenTenantId).to.equal('tenant123');
-    expect(result.tokenOrgId).to.equal('org456');
-    expect(result.tokenTenantName).to.equal('FakeTenant');
-  });
-
-  it('should use default values when audience, authority, and baseUrl are not provided', async () => {
-    const expectedParams = new URLSearchParams({
-      client_id: 'id',
-      client_secret: 'secret',
-      organization_id: '',
-      tenant_id: '',
-      audience: DEFAULT_SITECORE_AUTH_AUDIENCE,
-      grant_type: 'client_credentials',
-      baseUrl: DEFAULT_SITECORE_AUTH_BASE_URL,
-    }).toString();
-
-    let actualRequestBody: string = '';
-
-    fetchStub.callsFake(async (_url: string, options: any) => {
-      actualRequestBody = options.body;
-      return fetchResponse as any;
-    });
-
-    await clientCredentialsFlow({
-      clientId: 'id',
-      clientSecret: 'secret',
-    });
-
-    expect(actualRequestBody).to.equal(expectedParams);
-  });
-
-  it('should override defaults when custom audience, authority, and baseUrl are provided', async () => {
-    const customAuthority = 'https://custom-authority.io';
-    const customAudience = 'https://custom-api.io';
-    const customBaseUrl = 'https://custom-base.io';
-
-    const expectedParams = new URLSearchParams({
-      client_id: 'id',
-      client_secret: 'secret',
-      organization_id: '',
-      tenant_id: '',
-      audience: customAudience,
-      grant_type: 'client_credentials',
-      baseUrl: customBaseUrl,
-    }).toString();
-
-    let actualUrl: string = '';
-    let actualRequestBody: string = '';
-
-    fetchStub.callsFake(async (url: string, options: any) => {
-      actualUrl = url;
-      actualRequestBody = options.body;
-      return fetchResponse as any;
-    });
-
-    await clientCredentialsFlow({
-      clientId: 'id',
-      clientSecret: 'secret',
-      authority: customAuthority,
-      audience: customAudience,
-      baseUrl: customBaseUrl,
-    });
-
-    expect(actualUrl).to.equal(`${customAuthority}/oauth/token`);
-    expect(actualRequestBody).to.equal(expectedParams);
-  });
-
-  it('should throw if token has missing claims', async () => {
-    decodeStub.returns({});
-
-    try {
-      await clientCredentialsFlow({
+      const result = await clientCredentialsFlow({
         clientId: 'id',
         clientSecret: 'secret',
         tenantId: 'tenant123',
         organizationId: 'org456',
       });
-    } catch (err) {
-      expect((err as Error).message).to.include('Token is missing required claims');
-    }
-  });
 
-  it('should throw if tenantId does not match token', async () => {
-    decodeStub.returns({ ...fakeDecoded, tokenTenantId: 'wrong-id' });
-
-    try {
-      await clientCredentialsFlow({
-        clientId: 'id',
-        clientSecret: 'secret',
-        tenantId: 'tenant123',
-        organizationId: 'org456',
-      });
-    } catch (err) {
-      expect((err as Error).message).to.include('tenant ID does not match');
-    }
-  });
-
-  it('should throw if organizationId does not match token', async () => {
-    decodeStub.returns({ ...fakeDecoded, tokenOrgId: 'wrong-org' });
-
-    try {
-      await clientCredentialsFlow({
-        clientId: 'id',
-        clientSecret: 'secret',
-        tenantId: 'tenant123',
-        organizationId: 'org456',
-      });
-    } catch (err) {
-      expect((err as Error).message).to.include('organization ID does not match');
-    }
-  });
-
-  it('should throw and log error on non-OK response', async () => {
-    fetchStub.resolves({
-      ok: false,
-      json: async () => ({ error: 'unauthorized' }),
+      expect(result.data.access_token).to.equal(fakeToken);
+      expect(result.tokenTenantId).to.equal('tenant123');
+      expect(result.tokenOrgId).to.equal('org456');
+      expect(result.tokenTenantName).to.equal('FakeTenant');
     });
 
-    try {
+    it('should use default values when audience, authority, and baseUrl are not provided', async () => {
+      const expectedParams = new URLSearchParams({
+        client_id: 'id',
+        client_secret: 'secret',
+        organization_id: '',
+        tenant_id: '',
+        audience: DEFAULT_SITECORE_AUTH_AUDIENCE,
+        grant_type: 'client_credentials',
+        baseUrl: DEFAULT_SITECORE_AUTH_BASE_URL,
+      }).toString();
+
+      let actualRequestBody: string = '';
+
+      fetchStub.callsFake(async (_url: string, options: any) => {
+        actualRequestBody = options.body;
+        return fetchClientResponse as any;
+      });
+
       await clientCredentialsFlow({
         clientId: 'id',
         clientSecret: 'secret',
-        tenantId: 'tenant123',
-        organizationId: 'org456',
       });
-    } catch (err) {
-      expect((err as Error).message).to.include('unauthorized');
-    }
+
+      expect(actualRequestBody).to.equal(expectedParams);
+    });
+
+    it('should override defaults with custom values', async () => {
+      const authority = 'https://custom-authority';
+      const audience = 'https://custom-audience';
+      const baseUrl = 'https://custom-base';
+
+      let actualUrl = '';
+      let actualBody = '';
+      fetchStub.callsFake(async (url: string, options: any) => {
+        actualUrl = url;
+        actualBody = options.body;
+        return { ok: true, json: async () => ({ access_token: fakeToken, expires_in: 3600 }) };
+      });
+
+      await clientCredentialsFlow({
+        clientId: 'id',
+        clientSecret: 'secret',
+        authority,
+        audience,
+        baseUrl,
+      });
+
+      expect(actualUrl).to.equal(`${authority}/oauth/token`);
+      expect(actualBody).to.include(`audience=${encodeURIComponent(audience)}`);
+    });
+
+    it('should throw if token is missing required claims', async () => {
+      decodeStub.returns({});
+
+      try {
+        await clientCredentialsFlow({
+          clientId: 'id',
+          clientSecret: 'secret',
+          tenantId: 'tenant123',
+          organizationId: 'org456',
+        });
+      } catch (err) {
+        expect((err as Error).message).to.include('Token is missing required claims');
+      }
+    });
+
+    it('should throw if tenantId/orgId do not match token', async () => {
+      decodeStub.returns({ ...fakeDecoded, tokenTenantId: 'wrong-id' });
+
+      try {
+        await clientCredentialsFlow({
+          clientId: 'id',
+          clientSecret: 'secret',
+          tenantId: 'tenant123',
+          organizationId: 'org456',
+        });
+      } catch (err) {
+        expect((err as Error).message).to.include('tenant ID does not match');
+      }
+    });
+
+    it('should throw if fetch fails', async () => {
+      fetchStub.resolves({ ok: false, json: async () => ({ error: 'unauthorized' }) });
+
+      try {
+        await clientCredentialsFlow({
+          clientId: 'id',
+          clientSecret: 'secret',
+        });
+      } catch (err) {
+        expect((err as Error).message).to.equal('unauthorized');
+      }
+    });
+  });
+
+  describe('startDeviceAuthFlow', () => {
+    it('should return expected values on success', async () => {
+      fetchStub.resolves({ ok: true, json: async () => deviceAuthMock });
+
+      const result = await startDeviceAuthFlow({
+        clientId: 'abc',
+        authority: 'https://auth.example.com',
+        audience: 'https://api.example.com',
+        baseUrl: 'https://api.example.com',
+      });
+
+      expect(result).to.deep.equal({
+        deviceCode: 'device123',
+        userCode: 'user123',
+        verificationUri: 'https://verify.uri',
+        verificationUriComplete: 'https://verify.uri/complete',
+        expiresIn: 900,
+        interval: 5,
+      });
+    });
+
+    it('should throw if response is not ok', async () => {
+      fetchStub.resolves({
+        ok: false,
+        json: async () => ({ error_description: 'Invalid client ID' }),
+      });
+
+      try {
+        await startDeviceAuthFlow({
+          clientId: 'abc',
+          authority: 'https://auth.example.com',
+          audience: 'https://api.example.com',
+          baseUrl: 'https://api.example.com',
+        });
+      } catch (err) {
+        expect((err as Error).message).to.equal('Invalid client ID');
+      }
+    });
+  });
+
+  describe('pollForDeviceToken', () => {
+    it('should return token on first success', async () => {
+      fetchStub.resolves({ ok: true, json: async () => tokenResponse });
+
+      const result = await pollForDeviceToken({
+        clientId: 'client123',
+        deviceCode: 'device456',
+      });
+
+      expect(result).to.deep.equal(tokenResponse);
+    });
+
+    it('should poll through authorization_pending and return token', async () => {
+      fetchStub
+        .onCall(0)
+        .resolves({ ok: false, json: async () => ({ error: 'authorization_pending' }) })
+        .onCall(1)
+        .resolves({ ok: true, json: async () => tokenResponse });
+
+      const promise = pollForDeviceToken({
+        clientId: 'client123',
+        deviceCode: 'device456',
+        interval: 1,
+      });
+
+      await clock.tickAsync(1000);
+      await clock.tickAsync(1000);
+
+      const result = await promise;
+      expect(result).to.deep.equal(tokenResponse);
+    });
+
+    it('should increase interval on slow_down', async () => {
+      fetchStub
+        .onCall(0)
+        .resolves({ ok: false, json: async () => ({ error: 'slow_down' }) })
+        .onCall(1)
+        .resolves({ ok: true, json: async () => tokenResponse });
+
+      const promise = pollForDeviceToken({
+        clientId: 'client123',
+        deviceCode: 'device456',
+        interval: 1,
+      });
+
+      await clock.tickAsync(1000);
+      await clock.tickAsync(6000);
+
+      const result = await promise;
+      expect(result).to.deep.equal(tokenResponse);
+    });
+
+    it('should throw for unknown error', async () => {
+      fetchStub.resolves({ ok: false, json: async () => ({ error: 'invalid_grant' }) });
+
+      try {
+        await pollForDeviceToken({ clientId: 'client123', deviceCode: 'device456' });
+      } catch (err) {
+        expect((err as Error).message).to.equal('invalid_grant');
+      }
+    });
+
+    it('should throw timeout error after polling', async () => {
+      fetchStub.resolves({ ok: false, json: async () => ({ error: 'authorization_pending' }) });
+
+      const promise = pollForDeviceToken({
+        clientId: 'client123',
+        deviceCode: 'device456',
+        interval: 1,
+      });
+
+      await clock.tickAsync(601000);
+
+      try {
+        await promise;
+      } catch (err) {
+        expect((err as Error).message).to.equal(
+          '⏳ Timeout: User did not complete authorization in time.'
+        );
+      }
+    });
   });
 });

--- a/packages/core/src/tools/auth/flow.test.ts
+++ b/packages/core/src/tools/auth/flow.test.ts
@@ -2,7 +2,7 @@
 import sinon from 'sinon';
 import { clientCredentialsFlow, startDeviceAuthFlow, pollForDeviceToken } from './flow';
 import * as jwtUtil from './tenant-store';
-import { DEFAULT_SITECORE_AUTH_AUDIENCE, DEFAULT_SITECORE_AUTH_BASE_URL } from '../../constants';
+import * as fetcherUtil from './fetcher';
 
 describe('Auth flows', () => {
   const fakeToken = 'fake.jwt.token';
@@ -36,16 +36,17 @@ describe('Auth flows', () => {
     }),
   };
 
-  let fetchStub: sinon.SinonStub;
+  let postStub: sinon.SinonStub;
   let decodeStub: sinon.SinonStub;
   let consoleErrorStub: sinon.SinonStub;
   let consoleLogStub: sinon.SinonStub;
   let clock: sinon.SinonFakeTimers;
 
   beforeEach(() => {
-    fetchStub = sinon.stub(global, 'fetch' as any).resolves(fetchClientResponse as any);
+    postStub = sinon.stub();
     decodeStub = sinon.stub().returns(fakeDecoded);
     sinon.replace.usingAccessor(jwtUtil.unitMocks, 'decodeJwtPayload', decodeStub);
+    sinon.replace.usingAccessor(fetcherUtil.unitMocks, 'sendPostRequest', postStub);
 
     consoleErrorStub = sinon.stub(console, 'error');
     consoleLogStub = sinon.stub(console, 'log');
@@ -58,10 +59,7 @@ describe('Auth flows', () => {
 
   describe('clientCredentialsFlow', () => {
     it('should succeed without tenantId/orgId using token claims', async () => {
-      fetchStub.resolves({
-        ok: true,
-        json: async () => ({ access_token: fakeToken, expires_in: 3600 }),
-      });
+      postStub.resolves({ access_token: fakeToken });
 
       const result = await clientCredentialsFlow({ clientId: 'id', clientSecret: 'secret' });
 
@@ -75,6 +73,7 @@ describe('Auth flows', () => {
         tokenOrgId: 'org456',
         tokenTenantName: 'FakeTenant',
       });
+      postStub.resolves({ access_token: fakeToken });
 
       const result = await clientCredentialsFlow({
         clientId: 'id',
@@ -82,6 +81,8 @@ describe('Auth flows', () => {
         tenantId: 'tenant123',
         organizationId: 'org456',
       });
+
+      console.log('test', result);
 
       expect(result.data.access_token).to.equal(fakeToken);
       expect(result.tokenTenantId).to.equal('tenant123');
@@ -95,21 +96,24 @@ describe('Auth flows', () => {
         client_secret: 'secret',
         organization_id: '',
         tenant_id: '',
-        audience: DEFAULT_SITECORE_AUTH_AUDIENCE,
+        audience: 'https://custom-authority',
         grant_type: 'client_credentials',
-        baseUrl: DEFAULT_SITECORE_AUTH_BASE_URL,
+        baseUrl: 'https://custom-base',
       }).toString();
 
-      let actualRequestBody: string = '';
+      let actualRequestBody = '';
 
-      fetchStub.callsFake(async (_url: string, options: any) => {
-        actualRequestBody = options.body;
-        return fetchClientResponse as any;
+      postStub.callsFake(async (url: string, params: URLSearchParams) => {
+        actualRequestBody = params.toString(); // capture the request body
+        return fetchClientResponse;
       });
 
       await clientCredentialsFlow({
         clientId: 'id',
         clientSecret: 'secret',
+        audience: 'https://custom-authority',
+        authority: 'https://custom-authority',
+        baseUrl: 'https://custom-base',
       });
 
       expect(actualRequestBody).to.equal(expectedParams);
@@ -122,10 +126,11 @@ describe('Auth flows', () => {
 
       let actualUrl = '';
       let actualBody = '';
-      fetchStub.callsFake(async (url: string, options: any) => {
+
+      postStub.callsFake(async (url: string, params: URLSearchParams) => {
         actualUrl = url;
-        actualBody = options.body;
-        return { ok: true, json: async () => ({ access_token: fakeToken, expires_in: 3600 }) };
+        actualBody = params.toString();
+        return { access_token: fakeToken };
       });
 
       await clientCredentialsFlow({
@@ -138,10 +143,12 @@ describe('Auth flows', () => {
 
       expect(actualUrl).to.equal(`${authority}/oauth/token`);
       expect(actualBody).to.include(`audience=${encodeURIComponent(audience)}`);
+      expect(actualBody).to.include(`baseUrl=${encodeURIComponent(baseUrl)}`);
     });
 
     it('should throw if token is missing required claims', async () => {
       decodeStub.returns({});
+      postStub.resolves({ access_token: null });
 
       try {
         await clientCredentialsFlow({
@@ -158,6 +165,8 @@ describe('Auth flows', () => {
     it('should throw if tenantId/orgId do not match token', async () => {
       decodeStub.returns({ ...fakeDecoded, tokenTenantId: 'wrong-id' });
 
+      postStub.resolves({ access_token: fakeToken });
+
       try {
         await clientCredentialsFlow({
           clientId: 'id',
@@ -171,7 +180,7 @@ describe('Auth flows', () => {
     });
 
     it('should throw if fetch fails', async () => {
-      fetchStub.resolves({ ok: false, json: async () => ({ error: 'unauthorized' }) });
+      postStub.resolves({ error: 'unauthorized' });
 
       try {
         await clientCredentialsFlow({
@@ -186,7 +195,7 @@ describe('Auth flows', () => {
 
   describe('startDeviceAuthFlow', () => {
     it('should return expected values on success', async () => {
-      fetchStub.resolves({ ok: true, json: async () => deviceAuthMock });
+      postStub.resolves(deviceAuthMock);
 
       const result = await startDeviceAuthFlow({
         clientId: 'abc',
@@ -195,21 +204,11 @@ describe('Auth flows', () => {
         baseUrl: 'https://api.example.com',
       });
 
-      expect(result).to.deep.equal({
-        deviceCode: 'device123',
-        userCode: 'user123',
-        verificationUri: 'https://verify.uri',
-        verificationUriComplete: 'https://verify.uri/complete',
-        expiresIn: 900,
-        interval: 5,
-      });
+      expect(result).to.deep.equal(deviceAuthMock);
     });
 
     it('should throw if response is not ok', async () => {
-      fetchStub.resolves({
-        ok: false,
-        json: async () => ({ error_description: 'Invalid client ID' }),
-      });
+      postStub.resolves({ error_description: 'Invalid client ID' });
 
       try {
         await startDeviceAuthFlow({
@@ -226,26 +225,26 @@ describe('Auth flows', () => {
 
   describe('pollForDeviceToken', () => {
     it('should return token on first success', async () => {
-      fetchStub.resolves({ ok: true, json: async () => tokenResponse });
+      postStub.resolves(tokenResponse);
 
       const result = await pollForDeviceToken({
         clientId: 'client123',
-        deviceCode: 'device456',
+        device_code: 'device456',
       });
 
       expect(result).to.deep.equal(tokenResponse);
     });
 
     it('should poll through authorization_pending and return token', async () => {
-      fetchStub
+      postStub
         .onCall(0)
-        .resolves({ ok: false, json: async () => ({ error: 'authorization_pending' }) })
+        .resolves({ error: 'authorization_pending' })
         .onCall(1)
-        .resolves({ ok: true, json: async () => tokenResponse });
+        .resolves(tokenResponse);
 
       const promise = pollForDeviceToken({
         clientId: 'client123',
-        deviceCode: 'device456',
+        device_code: 'device456',
         interval: 1,
       });
 
@@ -257,15 +256,15 @@ describe('Auth flows', () => {
     });
 
     it('should increase interval on slow_down', async () => {
-      fetchStub
+      postStub
         .onCall(0)
-        .resolves({ ok: false, json: async () => ({ error: 'slow_down' }) })
+        .resolves({ error: 'slow_down' })
         .onCall(1)
-        .resolves({ ok: true, json: async () => tokenResponse });
+        .resolves(tokenResponse);
 
       const promise = pollForDeviceToken({
         clientId: 'client123',
-        deviceCode: 'device456',
+        device_code: 'device456',
         interval: 1,
       });
 
@@ -277,21 +276,21 @@ describe('Auth flows', () => {
     });
 
     it('should throw for unknown error', async () => {
-      fetchStub.resolves({ ok: false, json: async () => ({ error: 'invalid_grant' }) });
+      postStub.resolves({ error: 'invalid_grant' });
 
       try {
-        await pollForDeviceToken({ clientId: 'client123', deviceCode: 'device456' });
+        await pollForDeviceToken({ clientId: 'client123', device_code: 'device456' });
       } catch (err) {
         expect((err as Error).message).to.equal('invalid_grant');
       }
     });
 
     it('should throw timeout error after polling', async () => {
-      fetchStub.resolves({ ok: false, json: async () => ({ error: 'authorization_pending' }) });
+      postStub.resolves({ error: 'authorization_pending' });
 
       const promise = pollForDeviceToken({
         clientId: 'client123',
-        deviceCode: 'device456',
+        device_code: 'device456',
         interval: 1,
       });
 

--- a/packages/core/src/tools/auth/flow.test.ts
+++ b/packages/core/src/tools/auth/flow.test.ts
@@ -84,7 +84,7 @@ describe('Auth flows', () => {
 
       console.log('test', result);
 
-      expect(result.data.access_token).to.equal(fakeToken);
+      expect(result.accessToken).to.equal(fakeToken);
       expect(result.tokenTenantId).to.equal('tenant123');
       expect(result.tokenOrgId).to.equal('org456');
       expect(result.tokenTenantName).to.equal('FakeTenant');

--- a/packages/core/src/tools/auth/flow.ts
+++ b/packages/core/src/tools/auth/flow.ts
@@ -4,8 +4,10 @@ import {
   DeviceAuthResponse,
   DeviceTokenPollRequest,
   TenantArgs,
+  AuthResponse,
 } from './models';
 import { decodeJwtPayload } from './tenant-store';
+import { sendPostRequest } from './fetcher';
 import {
   DEFAULT_SITECORE_AUTH_DOMAIN,
   DEFAULT_SITECORE_AUTH_AUDIENCE,
@@ -20,14 +22,7 @@ import {
 /**
  * Performs the OAuth 2.0 client credentials flow to obtain a JWT access token
  * from the Sitecore Identity Provider using the provided client credentials.
- * @param {object} [args] - The arguments for client credentials flow
- * @param {string} [args.clientId] - The client ID registered with Sitecore Identity
- * @param {string} [args.clientSecret] - The client secret associated with the client ID
- * @param {string} [args.organizationId] - The ID of the organization the client belongs to
- * @param {string} [args.tenantId] - The tenant ID representing the specific Sitecore environment
- * @param {string} [args.audience] - The API audience the token is intended for. Defaults to `constants.DEFAULT_SITECORE_AUTH_AUDIENCE`
- * @param {string} [args.authority] - The auth server base URL. Defaults to `constants.DEFAULT_SITECORE_AUTH_DOMAIN`
- * @param {string} [args.baseUrl] - The base URL for the API, used to construct the audience. Defaults to `constants.DEFAULT_SITECORE_AUTH_BASE_URL`
+ * @param {TenantArgs} params - Parameters including clientId, clientSecret, organizationId, tenantId, audience, authority, and baseUrl.
  * @returns A Promise that resolves to the access token response (including access token, token type, expiry, etc.)
  * @throws Will log and exit the process if the request fails or returns a non-OK status
  */
@@ -94,17 +89,8 @@ async function _clientCredentialsFlow({
     baseUrl: baseUrl ?? '',
   });
 
-  const response = await fetch(`${authority}/oauth/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: params.toString(),
-  });
-
-  const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error(data.error_description || data.error || 'Error during client credentials flow');
-  }
+  const url = `${authority}/oauth/token`;
+  const data = await sendPostRequest<AuthResponse>(url, params);
 
   const decodedPayload = decodeJwtPayload(data.access_token) || {};
 
@@ -122,7 +108,7 @@ async function _clientCredentialsFlow({
     throw new Error('\n Mismatch: Provided organization ID does not match claims organization ID.');
   }
 
-  return { data, tokenOrgId, tokenTenantId, tokenTenantName, accessToken: data.access_token };
+  return { data, tokenOrgId, tokenTenantId, tokenTenantName };
 }
 
 export async function _startDeviceAuthFlow({
@@ -138,87 +124,53 @@ export async function _startDeviceAuthFlow({
     baseUrl,
   });
 
-  const response = await fetch(`${authority}/oauth/device/code`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: params.toString(),
-  });
+  const url = `${authority}/oauth/device/code`;
+  const responseBody = (await sendPostRequest(url, params)) as DeviceAuthResponse;
 
-  const responseBody = await response.json();
-
-  if (!response.ok) {
-    throw new Error(
-      responseBody.error_description ||
-        responseBody.error ||
-        'Error during device authorization flow'
-    );
-  }
-
-  const {
-    device_code: deviceCode,
-    user_code: userCode,
-    verification_uri: verificationUri,
-    verification_uri_complete: verificationUriComplete,
-    expires_in: expiresIn,
-    interval,
-  } = responseBody;
-
-  return {
-    deviceCode,
-    userCode,
-    verificationUri,
-    verificationUriComplete,
-    expiresIn,
-    interval,
-  };
+  return responseBody;
 }
 
 export async function _pollForDeviceToken({
   clientId,
-  deviceCode,
+  device_code,
   interval = DEFAULT_INTERVAL,
   authority = DEFAULT_SITECORE_AUTH_DOMAIN,
-}: DeviceTokenPollRequest) {
+}: DeviceTokenPollRequest): Promise<AuthResponse> {
   const startTime = Date.now();
 
   while (Date.now() - startTime < TIMEOUT * 1000) {
     const params = new URLSearchParams({
       grant_type: DEVICE_GRANT_TYPE,
-      device_code: deviceCode,
+      device_code,
       client_id: clientId,
     });
 
-    const response = await fetch(`${authority}/oauth/token`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: params.toString(),
-    });
+    const url = `${authority}/oauth/token`;
+    const responseBody = await sendPostRequest<AuthResponse>(url, params, false);
 
-    const responseBody = await response.json();
+    if ('error' in responseBody) {
+      switch (responseBody.error) {
+        case 'authorization_pending':
+          console.log('\n ⌛ Waiting for user authorization...');
+          break;
 
-    if (response.ok) {
+        case 'slow_down':
+          console.log('🐢 Slowing down polling interval...');
+          interval += 5;
+          break;
+
+        default:
+          throw new Error(
+            responseBody.error_description ||
+              responseBody.error ||
+              'Unknown error during device token polling.'
+          );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, interval * 1000));
+    } else {
       return responseBody;
     }
-
-    switch (responseBody.error) {
-      case 'authorization_pending':
-        console.log('\n ⌛ Waiting for user authorization...');
-        break;
-
-      case 'slow_down':
-        console.log('🐢 Slowing down polling interval...');
-        interval += 5;
-        break;
-
-      default:
-        throw new Error(
-          responseBody.error_description ||
-            responseBody.error ||
-            'Unknown error during device token polling.'
-        );
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, interval * 1000));
   }
 
   throw new Error('⏳ Timeout: User did not complete authorization in time.');

--- a/packages/core/src/tools/auth/flow.ts
+++ b/packages/core/src/tools/auth/flow.ts
@@ -108,7 +108,7 @@ async function _clientCredentialsFlow({
     throw new Error('\n Mismatch: Provided organization ID does not match claims organization ID.');
   }
 
-  return { data, tokenOrgId, tokenTenantId, tokenTenantName };
+  return { data, tokenOrgId, tokenTenantId, tokenTenantName, accessToken: data.access_token };
 }
 
 export async function _startDeviceAuthFlow({

--- a/packages/core/src/tools/auth/flow.ts
+++ b/packages/core/src/tools/auth/flow.ts
@@ -1,13 +1,21 @@
 ﻿/* eslint-disable jsdoc/require-jsdoc */
-import { TenantArgs } from './models';
+import {
+  DeviceAuthRequest,
+  DeviceAuthResponse,
+  DeviceTokenPollRequest,
+  TenantArgs,
+} from './models';
 import { decodeJwtPayload } from './tenant-store';
 import {
   DEFAULT_SITECORE_AUTH_DOMAIN,
   DEFAULT_SITECORE_AUTH_AUDIENCE,
   DEFAULT_SITECORE_AUTH_BASE_URL,
+  DEVICE_GRANT_TYPE,
+  CLIENT_GRANT_TYPE,
+  SCOPE,
+  TIMEOUT,
+  DEFAULT_INTERVAL,
 } from '../../constants';
-
-const GRANT_TYPE = 'client_credentials';
 
 /**
  * Performs the OAuth 2.0 client credentials flow to obtain a JWT access token
@@ -25,6 +33,24 @@ const GRANT_TYPE = 'client_credentials';
  */
 export let clientCredentialsFlow = _clientCredentialsFlow;
 
+/**
+ * Initiates the OAuth 2.0 Device Authorization flow by requesting a device and user code.
+ * This flow is typically used by devices or CLI apps that cannot input credentials directly.
+ * @param {DeviceAuthRequest} params - Parameters including clientId, audience, authority, and baseUrl.
+ * @returns {Promise<DeviceAuthResponse>} A promise resolving to device authorization metadata needed for polling.
+ * @throws {Error} If the device authorization request fails or returns an error response.
+ */
+export let startDeviceAuthFlow = _startDeviceAuthFlow;
+
+/**
+ * Polls the OAuth 2.0 device token endpoint to retrieve the access token once the user has authorized the device.
+ * This is typically used to continue the device authorization process after a user enters a code on a browser.
+ * @param {DeviceTokenPollRequest} params - Parameters for polling including clientId, deviceCode, interval, and authority.
+ * @returns {Promise<any>} A promise resolving to the device token response including access token and refresh token.
+ * @throws {Error} If polling fails or exceeds the timeout period.
+ */
+export let pollForDeviceToken = _pollForDeviceToken;
+
 // mock setup for unit tests to make sinon happy and mock-able with esbuild/tsx
 // https://sinonjs.org/how-to/typescript-swc/
 // This, plus the `_` names make the exports writable for sinon
@@ -34,6 +60,18 @@ export const unitMocks = {
   },
   get clientCredentialsFlow() {
     return _clientCredentialsFlow;
+  },
+  set startDeviceAuthFlow(mockImplementation) {
+    startDeviceAuthFlow = mockImplementation;
+  },
+  get startDeviceAuthFlow() {
+    return _startDeviceAuthFlow;
+  },
+  set pollForDeviceToken(mockImplementation) {
+    pollForDeviceToken = mockImplementation;
+  },
+  get pollForDeviceToken() {
+    return _pollForDeviceToken;
   },
 };
 
@@ -52,7 +90,7 @@ async function _clientCredentialsFlow({
     organization_id: organizationId ?? '',
     tenant_id: tenantId ?? '',
     audience,
-    grant_type: GRANT_TYPE,
+    grant_type: CLIENT_GRANT_TYPE,
     baseUrl: baseUrl ?? '',
   });
 
@@ -85,4 +123,103 @@ async function _clientCredentialsFlow({
   }
 
   return { data, tokenOrgId, tokenTenantId, tokenTenantName, accessToken: data.access_token };
+}
+
+export async function _startDeviceAuthFlow({
+  clientId,
+  audience,
+  authority,
+  baseUrl,
+}: DeviceAuthRequest): Promise<DeviceAuthResponse> {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    scope: SCOPE,
+    audience,
+    baseUrl,
+  });
+
+  const response = await fetch(`${authority}/oauth/device/code`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  const responseBody = await response.json();
+
+  if (!response.ok) {
+    throw new Error(
+      responseBody.error_description ||
+        responseBody.error ||
+        'Error during device authorization flow'
+    );
+  }
+
+  const {
+    device_code: deviceCode,
+    user_code: userCode,
+    verification_uri: verificationUri,
+    verification_uri_complete: verificationUriComplete,
+    expires_in: expiresIn,
+    interval,
+  } = responseBody;
+
+  return {
+    deviceCode,
+    userCode,
+    verificationUri,
+    verificationUriComplete,
+    expiresIn,
+    interval,
+  };
+}
+
+export async function _pollForDeviceToken({
+  clientId,
+  deviceCode,
+  interval = DEFAULT_INTERVAL,
+  authority = DEFAULT_SITECORE_AUTH_DOMAIN,
+}: DeviceTokenPollRequest) {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < TIMEOUT * 1000) {
+    const params = new URLSearchParams({
+      grant_type: DEVICE_GRANT_TYPE,
+      device_code: deviceCode,
+      client_id: clientId,
+    });
+
+    const response = await fetch(`${authority}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+
+    const responseBody = await response.json();
+
+    if (response.ok) {
+      return responseBody;
+    }
+
+    switch (responseBody.error) {
+      case 'authorization_pending':
+        console.log('\n ⌛ Waiting for user authorization...');
+        break;
+
+      case 'slow_down':
+        console.log('🐢 Slowing down polling interval...');
+        interval += 5;
+        break;
+
+      default:
+        throw new Error(
+          responseBody.error_description ||
+            responseBody.error ||
+            'Unknown error during device token polling.'
+        );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, interval * 1000));
+  }
+
+  throw new Error('⏳ Timeout: User did not complete authorization in time.');
 }

--- a/packages/core/src/tools/auth/index.ts
+++ b/packages/core/src/tools/auth/index.ts
@@ -1,5 +1,10 @@
-export { clientCredentialsFlow } from './flow';
-export { renewClientToken, validateAndRenewAuthIfExpired, validateAuthInfo } from './renewal';
+export { clientCredentialsFlow, startDeviceAuthFlow, pollForDeviceToken } from './flow';
+export {
+  renewClientToken,
+  validateAndRenewAuthIfExpired,
+  validateAuthInfo,
+  getRefreshAccessToken,
+} from './renewal';
 export { getActiveTenant, setActiveTenant, clearActiveTenant } from './tenant-state';
 export {
   writeTenantAuthInfo,

--- a/packages/core/src/tools/auth/models.ts
+++ b/packages/core/src/tools/auth/models.ts
@@ -170,23 +170,23 @@ export interface DeviceAuthResponse {
   /**
    * Code the device will use to poll the token endpoint.
    */
-  deviceCode: string;
+  device_code: string;
   /**
    * Code shown to the user for manual input during verification.
    */
-  userCode: string;
+  user_code: string;
   /**
    * URI where the user should go to complete authentication.
    */
-  verificationUri: string;
+  verification_uri: string;
   /**
    * Optional URI that includes the user code, allowing for a streamlined login experience.
    */
-  verificationUriComplete?: string;
+  verification_uri_complete?: string;
   /**
    * Time (in seconds) until the device code expires.
    */
-  expiresIn: number;
+  expires_in: number;
   /**
    * Recommended polling interval (in seconds) for token requests.
    */
@@ -204,7 +204,7 @@ export interface DeviceTokenPollRequest {
   /**
    * Device code previously obtained from the device authorization flow.
    */
-  deviceCode: string;
+  device_code: string;
   /**
    * Optional polling interval in seconds. If not provided, a default is used.
    */
@@ -213,4 +213,38 @@ export interface DeviceTokenPollRequest {
    * Optional OAuth 2.0 authority endpoint for token polling.
    */
   authority?: string;
+}
+
+/**
+ * Represents the raw OAuth token response returned by the authorization server.
+ * This includes the access token, refresh token, and optional ID token and scope.
+ */
+export interface TokenResponse {
+  /** The access token used for authenticating API requests */
+  access_token: string;
+  /** The refresh token used to obtain a new access token when it expires */
+  refresh_token: string;
+  /** The number of seconds until the access token expires */
+  expires_in: number;
+  /** The type of token issued, typically "Bearer" */
+  token_type: string;
+  /** An optional ID token containing user identity claims (usually JWT) */
+  id_token?: string;
+  /** The scopes granted for the access token, space-delimited */
+  scope?: string;
+}
+
+/**
+ * Represents the application-specific token response returned by `_getRefreshAccessToken`.
+ * In addition to the raw OAuth tokens, it includes the decoded `tenantName` for convenience.
+ */
+export interface RefreshAccessTokenResponse extends TokenResponse {
+  /** The tenant name extracted from the decoded access token payload */
+  tenantName?: string;
+}
+
+export interface AuthResponse {
+  [key: string]: any;
+  access_token: string;
+  expires_in: number;
 }

--- a/packages/core/src/tools/auth/models.ts
+++ b/packages/core/src/tools/auth/models.ts
@@ -42,7 +42,7 @@ export interface TenantSettings {
 /**
  * Auth configuration stored per tenant for accessing Sitecore APIs.
  */
-export interface TenantAuth {
+export interface TenantAuthInfo {
   /**
    * Access token issued by the identity provider
    */
@@ -113,3 +113,104 @@ export type EncryptedPayload = {
    */
   encryptedData: string;
 };
+
+/**
+ * Input parameters for exchanging a refresh token for a new access token.
+ */
+export interface RefreshTokenRequest {
+  /**
+   * OAuth 2.0 client identifier.
+   */
+  clientId: string;
+  /**
+   * Refresh token previously issued by the authorization server.
+   */
+  refreshToken: string;
+  /**
+   * Tenant identifier to bind the request to a specific tenant context.
+   */
+  tenantId: string;
+  /**
+   * Organization identifier for multi-tenant authorization scope.
+   */
+  organizationId: string;
+  /**
+   * Optional OAuth 2.0 authority endpoint (token issuer URL).
+   * Defaults to the Sitecore standard authority if not provided.
+   */
+  authority?: string;
+}
+
+/**
+ * Input parameters for initiating the OAuth 2.0 Device Authorization flow.
+ */
+export interface DeviceAuthRequest {
+  /**
+   * OAuth 2.0 client identifier.
+   */
+  clientId: string;
+  /**
+   * The intended recipient of the token (usually your protected resource or API).
+   */
+  audience: string;
+  /**
+   * OAuth 2.0 authority URL (token issuer).
+   */
+  authority: string;
+  /**
+   * Base URL for your API, used to build custom claims or context if needed.
+   */
+  baseUrl: string;
+}
+
+/**
+ * Response structure returned after initiating the device authorization flow.
+ */
+export interface DeviceAuthResponse {
+  /**
+   * Code the device will use to poll the token endpoint.
+   */
+  deviceCode: string;
+  /**
+   * Code shown to the user for manual input during verification.
+   */
+  userCode: string;
+  /**
+   * URI where the user should go to complete authentication.
+   */
+  verificationUri: string;
+  /**
+   * Optional URI that includes the user code, allowing for a streamlined login experience.
+   */
+  verificationUriComplete?: string;
+  /**
+   * Time (in seconds) until the device code expires.
+   */
+  expiresIn: number;
+  /**
+   * Recommended polling interval (in seconds) for token requests.
+   */
+  interval: number;
+}
+
+/**
+ * Input parameters for polling the OAuth 2.0 device token endpoint.
+ */
+export interface DeviceTokenPollRequest {
+  /**
+   * OAuth 2.0 client identifier.
+   */
+  clientId: string;
+  /**
+   * Device code previously obtained from the device authorization flow.
+   */
+  deviceCode: string;
+  /**
+   * Optional polling interval in seconds. If not provided, a default is used.
+   */
+  interval?: number;
+  /**
+   * Optional OAuth 2.0 authority endpoint for token polling.
+   */
+  authority?: string;
+}

--- a/packages/core/src/tools/auth/renewal.test.ts
+++ b/packages/core/src/tools/auth/renewal.test.ts
@@ -270,7 +270,7 @@ describe('getRefreshAccessToken', () => {
   it('should return token data with tenantName on success', async () => {
     postStub.resolves(fakeRefreshTokenResponseData);
 
-    decodeStub.returns({ tenantName: 'DemoTenant' });
+    decodeStub.returns({ tokenTenantName: 'DemoTenant' });
 
     const result = await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
 
@@ -282,16 +282,12 @@ describe('getRefreshAccessToken', () => {
     expect(postStub.calledOnce).to.be.true;
     const [url, options] = postStub.firstCall.args;
     expect(url).to.equal(`${fakeRefreshTokenInput.authority}/oauth/token`);
-    expect(options.method).to.equal('POST');
-
+    expect(options.toString()).to.include(`refresh_token=${fakeRefreshTokenInput.refreshToken}`);
     expect(decodeStub.calledOnceWith(fakeRefreshTokenResponseData.access_token)).to.be.true;
   });
 
   it('should throw with error_description on failure', async () => {
-    postStub.resolves({
-      error: 'invalid_request',
-      error_description: 'Invalid refresh token',
-    });
+    postStub.rejects(new Error('Invalid refresh token'));
 
     try {
       await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
@@ -303,9 +299,7 @@ describe('getRefreshAccessToken', () => {
   });
 
   it('should throw with error message on failure if error_description is missing', async () => {
-    postStub.resolves({
-      error: 'unauthorized_client',
-    });
+    postStub.rejects(new Error('unauthorized_client'));
 
     try {
       await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
@@ -317,7 +311,7 @@ describe('getRefreshAccessToken', () => {
   });
 
   it('should throw generic error when no error info is available', async () => {
-    postStub.resolves({});
+    postStub.rejects(new Error('Error refreshing access token'));
 
     try {
       await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);

--- a/packages/core/src/tools/auth/renewal.test.ts
+++ b/packages/core/src/tools/auth/renewal.test.ts
@@ -183,7 +183,7 @@ describe('Auth Token Renewal Utilities', () => {
 
     it('should exit if no valid credentials for renewal are present', async () => {
       getTenantStub.returns('tenant1');
-      readAuthStub.resolves({ expires_at: pastDate }); // no clientSecret or refresh_token
+      readAuthStub.resolves({ expires_at: pastDate });
       readTenantInfoStub.resolves(tenantMock);
 
       const exitStub = sinon.stub(process, 'exit').callsFake(() => {

--- a/packages/core/src/tools/auth/renewal.test.ts
+++ b/packages/core/src/tools/auth/renewal.test.ts
@@ -7,8 +7,9 @@ import * as tenantStore from './tenant-store';
 import * as tenantState from './tenant-state';
 import * as encryptionUtil from './encryption';
 import * as renewalUtils from './renewal';
+import * as fetcherUtil from './fetcher';
 
-describe('Auth Token Renewal Utilities', () => {
+describe.only('Auth Token Renewal Utilities', () => {
   const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
   const pastDate = new Date(Date.now() - 3600 * 1000).toISOString();
 
@@ -172,6 +173,10 @@ describe('Auth Token Renewal Utilities', () => {
       getTenantStub.returns('tenant1');
       readAuthStub.resolves({ refresh_token: 'test-refresh-token', expires_at: pastDate });
       readTenantInfoStub.resolves(tenantMock);
+      refreshTokenStub.resolves({
+        ...fakeRefreshTokenResponseData,
+        tenantName: 'DemoTenant',
+      });
 
       const result = await validateAndRenewAuthIfExpired();
 
@@ -247,14 +252,15 @@ describe('getRefreshAccessToken', () => {
     token_type: 'Bearer',
   };
 
-  let fetchStub: sinon.SinonStub;
+  let postStub: sinon.SinonStub;
   let decodeStub: sinon.SinonStub;
 
   beforeEach(() => {
     decodeStub = sinon.stub().returns(fakeRefreshTokenResponseData);
-    fetchStub = sinon.stub(global, 'fetch');
+    postStub = sinon.stub();
 
     sinon.replace.usingAccessor(jwtUtils.unitMocks, 'decodeJwtPayload', decodeStub);
+    sinon.replace.usingAccessor(fetcherUtil.unitMocks, 'sendPostRequest', postStub);
   });
 
   afterEach(() => {
@@ -262,10 +268,7 @@ describe('getRefreshAccessToken', () => {
   });
 
   it('should return token data with tenantName on success', async () => {
-    fetchStub.resolves({
-      ok: true,
-      json: async () => fakeRefreshTokenResponseData,
-    } as Response);
+    postStub.resolves(fakeRefreshTokenResponseData);
 
     decodeStub.returns({ tenantName: 'DemoTenant' });
 
@@ -276,8 +279,8 @@ describe('getRefreshAccessToken', () => {
       tenantName: 'DemoTenant',
     });
 
-    expect(fetchStub.calledOnce).to.be.true;
-    const [url, options] = fetchStub.firstCall.args;
+    expect(postStub.calledOnce).to.be.true;
+    const [url, options] = postStub.firstCall.args;
     expect(url).to.equal(`${fakeRefreshTokenInput.authority}/oauth/token`);
     expect(options.method).to.equal('POST');
 
@@ -285,13 +288,10 @@ describe('getRefreshAccessToken', () => {
   });
 
   it('should throw with error_description on failure', async () => {
-    fetchStub.resolves({
-      ok: false,
-      json: async () => ({
-        error: 'invalid_request',
-        error_description: 'Invalid refresh token',
-      }),
-    } as Response);
+    postStub.resolves({
+      error: 'invalid_request',
+      error_description: 'Invalid refresh token',
+    });
 
     try {
       await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
@@ -303,12 +303,9 @@ describe('getRefreshAccessToken', () => {
   });
 
   it('should throw with error message on failure if error_description is missing', async () => {
-    fetchStub.resolves({
-      ok: false,
-      json: async () => ({
-        error: 'unauthorized_client',
-      }),
-    } as Response);
+    postStub.resolves({
+      error: 'unauthorized_client',
+    });
 
     try {
       await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
@@ -320,10 +317,7 @@ describe('getRefreshAccessToken', () => {
   });
 
   it('should throw generic error when no error info is available', async () => {
-    fetchStub.resolves({
-      ok: false,
-      json: async () => ({}),
-    } as Response);
+    postStub.resolves({});
 
     try {
       await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);

--- a/packages/core/src/tools/auth/renewal.test.ts
+++ b/packages/core/src/tools/auth/renewal.test.ts
@@ -1,13 +1,14 @@
 ﻿import { expect } from 'chai';
 import sinon from 'sinon';
-import { validateAuthInfo, renewClientToken, validateAndRenewAuthIfExpired } from './renewal';
-
+import { validateAuthInfo, validateAndRenewAuthIfExpired, renewClientToken } from './renewal';
+import * as jwtUtils from './tenant-store';
 import * as authFlow from './flow';
 import * as tenantStore from './tenant-store';
 import * as tenantState from './tenant-state';
 import * as encryptionUtil from './encryption';
+import * as renewalUtils from './renewal';
 
-describe('auth token renewal utilities', () => {
+describe('Auth Token Renewal Utilities', () => {
   const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
   const pastDate = new Date(Date.now() - 3600 * 1000).toISOString();
 
@@ -28,20 +29,27 @@ describe('auth token renewal utilities', () => {
     baseUrl: 'https://fake.base.url',
   };
 
-  let flowStub: sinon.SinonStub;
+  const fakeRefreshTokenResponseData = {
+    access_token: 'fake-access-token',
+    refresh_token: 'new-refresh-token',
+    expires_in: 3600,
+    token_type: 'Bearer',
+  };
+
+  let clientCredentialsFlowStub: sinon.SinonStub;
   let writeStub: sinon.SinonStub;
   let readAuthStub: sinon.SinonStub;
   let readTenantInfoStub: sinon.SinonStub;
   let getTenantStub: sinon.SinonStub;
   let deleteAuthStub: sinon.SinonStub;
   let clearActiveStub: sinon.SinonStub;
-  let consoleInfoStub: sinon.SinonStub;
+  let consoleLogStub: sinon.SinonStub;
   let consoleErrorStub: sinon.SinonStub;
-  let consoleWarnStub: sinon.SinonStub;
   let deleteKeyStub: sinon.SinonStub;
+  let refreshTokenStub: sinon.SinonStub;
 
   beforeEach(() => {
-    flowStub = sinon.stub().resolves({
+    clientCredentialsFlowStub = sinon.stub().resolves({
       data: {
         access_token: 'new-token',
         expires_in: 3600,
@@ -50,29 +58,35 @@ describe('auth token renewal utilities', () => {
       tokenTenantId: 'tenant1',
       tokenTenantName: 'DemoTenant',
     });
-    sinon.replace.usingAccessor(authFlow.unitMocks, 'clientCredentialsFlow', flowStub);
 
     writeStub = sinon.stub().resolves();
     readAuthStub = sinon.stub();
     readTenantInfoStub = sinon.stub();
     deleteAuthStub = sinon.stub().resolves();
     deleteKeyStub = sinon.stub().resolves();
+    clearActiveStub = sinon.stub().resolves();
+    getTenantStub = sinon.stub();
+    refreshTokenStub = sinon.stub().resolves({
+      data: fakeRefreshTokenResponseData,
+      tenantName: 'DemoTenant',
+    });
 
     sinon.replace.usingAccessor(tenantStore.unitMocks, 'writeTenantAuthInfo', writeStub);
     sinon.replace.usingAccessor(tenantStore.unitMocks, 'readTenantAuthInfo', readAuthStub);
     sinon.replace.usingAccessor(tenantStore.unitMocks, 'readTenantInfo', readTenantInfoStub);
     sinon.replace.usingAccessor(tenantStore.unitMocks, 'deleteTenantAuthInfo', deleteAuthStub);
     sinon.replace.usingAccessor(encryptionUtil.unitMocks, 'deleteKey', deleteKeyStub);
-
-    getTenantStub = sinon.stub();
-    clearActiveStub = sinon.stub().resolves();
-
     sinon.replace.usingAccessor(tenantState.unitMocks, 'getActiveTenant', getTenantStub);
     sinon.replace.usingAccessor(tenantState.unitMocks, 'clearActiveTenant', clearActiveStub);
+    sinon.replace.usingAccessor(
+      authFlow.unitMocks,
+      'clientCredentialsFlow',
+      clientCredentialsFlowStub
+    );
+    sinon.replace.usingAccessor(renewalUtils.unitMocks, 'getRefreshAccessToken', refreshTokenStub);
 
-    consoleInfoStub = sinon.stub(console, 'info');
+    consoleLogStub = sinon.stub(console, 'log');
     consoleErrorStub = sinon.stub(console, 'error');
-    consoleWarnStub = sinon.stub(console, 'warn');
   });
 
   afterEach(() => {
@@ -95,7 +109,7 @@ describe('auth token renewal utilities', () => {
     it('should call flow and update auth file with new token', async () => {
       await renewClientToken(authMock, tenantMock);
 
-      expect(flowStub.calledOnce).to.be.true;
+      expect(clientCredentialsFlowStub.calledOnce).to.be.true;
       expect(writeStub.calledOnce).to.be.true;
       expect(writeStub.firstCall.args[0]).to.equal('tenant1');
 
@@ -143,11 +157,54 @@ describe('auth token renewal utilities', () => {
       expect(result).to.deep.equal({ tenantId: 'tenant1' });
     });
 
+    it('should renew token using client credentials flow if clientSecret is present', async () => {
+      getTenantStub.returns('tenant1');
+      readAuthStub.resolves({ ...authMock, expires_at: pastDate });
+      readTenantInfoStub.resolves(tenantMock);
+
+      const result = await validateAndRenewAuthIfExpired();
+
+      expect(clientCredentialsFlowStub.calledOnce).to.be.true;
+      expect(result).to.deep.equal({ tenantId: 'tenant1' });
+    });
+
+    it('should renew token using refresh token if present', async () => {
+      getTenantStub.returns('tenant1');
+      readAuthStub.resolves({ refresh_token: 'test-refresh-token', expires_at: pastDate });
+      readTenantInfoStub.resolves(tenantMock);
+
+      const result = await validateAndRenewAuthIfExpired();
+
+      expect(writeStub.calledOnce).to.be.true;
+      expect(writeStub.firstCall.args[0]).to.equal('tenant1');
+      expect(writeStub.firstCall.args[1]).to.have.property('access_token', 'fake-access-token');
+      expect(result).to.deep.equal({ tenantId: 'tenant1' });
+    });
+
+    it('should exit if no valid credentials for renewal are present', async () => {
+      getTenantStub.returns('tenant1');
+      readAuthStub.resolves({ expires_at: pastDate }); // no clientSecret or refresh_token
+      readTenantInfoStub.resolves(tenantMock);
+
+      const exitStub = sinon.stub(process, 'exit').callsFake(() => {
+        throw new Error('EXIT_CALLED');
+      });
+
+      try {
+        await validateAndRenewAuthIfExpired();
+        throw new Error('Test failed');
+      } catch (err) {
+        expect((err as Error).message).to.equal('EXIT_CALLED');
+      }
+
+      expect(consoleErrorStub.calledWithMatch(/No valid credentials/)).to.be.true;
+    });
+
     it('should exit if token renewal fails unexpectedly', async () => {
       getTenantStub.returns('tenant1');
       readAuthStub.resolves({ ...authMock, expires_at: pastDate });
       readTenantInfoStub.resolves(tenantMock);
-      flowStub.rejects(new Error('Unexpected failure'));
+      clientCredentialsFlowStub.rejects(new Error('Unexpected failure'));
 
       const exitStub = sinon.stub(process, 'exit').callsFake(() => {
         throw new Error('EXIT_CALLED');
@@ -165,11 +222,115 @@ describe('auth token renewal utilities', () => {
       }
 
       expect(consoleErrorStub.calledWithMatch(/Failed to renew token/)).to.be.true;
-      expect(consoleWarnStub.calledWithMatch(/Cleaning up stale/)).to.be.true;
+      expect(consoleLogStub.calledWithMatch(/Cleaning up stale/)).to.be.true;
       expect(deleteAuthStub.calledOnce).to.be.true;
       expect(deleteKeyStub.calledOnceWithExactly('tenant1')).to.be.true;
       expect(clearActiveStub.calledOnce).to.be.true;
       expect(exitStub.calledOnceWith(1)).to.be.true;
     });
+  });
+});
+
+describe('getRefreshAccessToken', () => {
+  const fakeRefreshTokenInput = {
+    clientId: 'test-client-id',
+    refreshToken: 'test-refresh-token',
+    tenantId: 'test-tenant-id',
+    organizationId: 'test-org-id',
+    authority: 'https://auth.example.com',
+  };
+
+  const fakeRefreshTokenResponseData = {
+    access_token: 'fake-access-token',
+    refresh_token: 'new-refresh-token',
+    expires_in: 3600,
+    token_type: 'Bearer',
+  };
+
+  let fetchStub: sinon.SinonStub;
+  let decodeStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    decodeStub = sinon.stub().returns(fakeRefreshTokenResponseData);
+    fetchStub = sinon.stub(global, 'fetch');
+
+    sinon.replace.usingAccessor(jwtUtils.unitMocks, 'decodeJwtPayload', decodeStub);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return token data with tenantName on success', async () => {
+    fetchStub.resolves({
+      ok: true,
+      json: async () => fakeRefreshTokenResponseData,
+    } as Response);
+
+    decodeStub.returns({ tenantName: 'DemoTenant' });
+
+    const result = await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
+
+    expect(result).to.deep.equal({
+      ...fakeRefreshTokenResponseData,
+      tenantName: 'DemoTenant',
+    });
+
+    expect(fetchStub.calledOnce).to.be.true;
+    const [url, options] = fetchStub.firstCall.args;
+    expect(url).to.equal(`${fakeRefreshTokenInput.authority}/oauth/token`);
+    expect(options.method).to.equal('POST');
+
+    expect(decodeStub.calledOnceWith(fakeRefreshTokenResponseData.access_token)).to.be.true;
+  });
+
+  it('should throw with error_description on failure', async () => {
+    fetchStub.resolves({
+      ok: false,
+      json: async () => ({
+        error: 'invalid_request',
+        error_description: 'Invalid refresh token',
+      }),
+    } as Response);
+
+    try {
+      await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
+      expect.fail('Expected function to throw');
+    } catch (err) {
+      expect(err).to.be.instanceOf(Error);
+      expect((err as Error).message).to.equal('Invalid refresh token');
+    }
+  });
+
+  it('should throw with error message on failure if error_description is missing', async () => {
+    fetchStub.resolves({
+      ok: false,
+      json: async () => ({
+        error: 'unauthorized_client',
+      }),
+    } as Response);
+
+    try {
+      await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
+      expect.fail('Expected function to throw');
+    } catch (err) {
+      expect(err).to.be.instanceOf(Error);
+      expect((err as Error).message).to.equal('unauthorized_client');
+    }
+  });
+
+  it('should throw generic error when no error info is available', async () => {
+    fetchStub.resolves({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    try {
+      await renewalUtils.getRefreshAccessToken(fakeRefreshTokenInput);
+      expect.fail('Expected function to throw');
+    } catch (err) {
+      expect(err).to.be.instanceOf(Error);
+      expect((err as Error).message).to.equal('Error refreshing access token');
+    }
   });
 });

--- a/packages/core/src/tools/auth/renewal.test.ts
+++ b/packages/core/src/tools/auth/renewal.test.ts
@@ -9,7 +9,7 @@ import * as encryptionUtil from './encryption';
 import * as renewalUtils from './renewal';
 import * as fetcherUtil from './fetcher';
 
-describe.only('Auth Token Renewal Utilities', () => {
+describe('Auth Token Renewal Utilities', () => {
   const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
   const pastDate = new Date(Date.now() - 3600 * 1000).toISOString();
 

--- a/packages/core/src/tools/auth/renewal.ts
+++ b/packages/core/src/tools/auth/renewal.ts
@@ -1,6 +1,12 @@
 ﻿import { getActiveTenant, clearActiveTenant } from './tenant-state';
 import { clientCredentialsFlow } from './flow';
-import { RefreshTokenRequest, TenantAuthInfo, TenantInfo } from './models';
+import {
+  RefreshAccessTokenResponse,
+  RefreshTokenRequest,
+  TenantAuthInfo,
+  TenantInfo,
+  TokenResponse,
+} from './models';
 import {
   writeTenantAuthInfo,
   readTenantAuthInfo,
@@ -10,6 +16,7 @@ import {
 import { deleteKey } from './encryption';
 import { DEFAULT_SITECORE_AUTH_DOMAIN, REFRESH_GRANT_TYPE } from './../../constants';
 import { decodeJwtPayload } from './tenant-store';
+import { sendPostRequest } from './fetcher';
 
 /**
  * Requests a new access token using the OAuth 2.0 refresh token grant type.
@@ -96,6 +103,7 @@ export async function validateAndRenewAuthIfExpired(): Promise<{ tenantId: strin
   try {
     if (authInfo.clientSecret) {
       await renewClientToken(authInfo, tenantInfo);
+      return { tenantId };
     } else if (authInfo.refresh_token) {
       const refreshTokenResponse = await getRefreshAccessToken({
         clientId: tenantInfo.clientId,
@@ -106,17 +114,16 @@ export async function validateAndRenewAuthIfExpired(): Promise<{ tenantId: strin
       });
 
       await writeTenantAuthInfo(tenantId, {
-        expires_at: new Date(
-          Date.now() + refreshTokenResponse.data.expires_in * 1000
-        ).toISOString(),
-        ...refreshTokenResponse.data,
+        expires_at: new Date(Date.now() + refreshTokenResponse.expires_in * 1000).toISOString(),
+        ...refreshTokenResponse,
       });
 
       console.log(`\n Token for tenant ${tenantId} renewed.`);
+
+      return { tenantId };
     } else {
       throw new Error('\n No valid credentials found for token renewal.');
     }
-    return { tenantId };
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
     console.error(`\n Failed to renew token for tenant '${tenantId}: ${errorMessage}'`);
@@ -138,7 +145,7 @@ async function _getRefreshAccessToken({
   tenantId,
   organizationId,
   authority = DEFAULT_SITECORE_AUTH_DOMAIN,
-}: RefreshTokenRequest) {
+}: RefreshTokenRequest): Promise<RefreshAccessTokenResponse> {
   const params = new URLSearchParams({
     client_id: clientId,
     grant_type: REFRESH_GRANT_TYPE,
@@ -147,19 +154,10 @@ async function _getRefreshAccessToken({
     organization_id: organizationId,
   });
 
-  const response = await fetch(`${authority}/oauth/token`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: params.toString(),
-  });
+  const url = `${authority}/oauth/token`;
+  const data = await sendPostRequest<TokenResponse>(url, params);
 
-  const data = await response.json();
+  const { tokenTenantName } = decodeJwtPayload(data.access_token) || {};
 
-  if (!response.ok) {
-    throw new Error(data.error_description || data.error || 'Error refreshing access token');
-  }
-
-  const { tenantName } = decodeJwtPayload(data.access_token) || {};
-
-  return { ...data, tenantName };
+  return { ...data, tenantName: tokenTenantName };
 }

--- a/packages/core/src/tools/auth/renewal.ts
+++ b/packages/core/src/tools/auth/renewal.ts
@@ -1,6 +1,6 @@
 ﻿import { getActiveTenant, clearActiveTenant } from './tenant-state';
 import { clientCredentialsFlow } from './flow';
-import { TenantAuth, TenantInfo } from './models';
+import { RefreshTokenRequest, TenantAuthInfo, TenantInfo } from './models';
 import {
   writeTenantAuthInfo,
   readTenantAuthInfo,
@@ -8,13 +8,33 @@ import {
   readTenantInfo,
 } from './tenant-store';
 import { deleteKey } from './encryption';
+import { DEFAULT_SITECORE_AUTH_DOMAIN, REFRESH_GRANT_TYPE } from './../../constants';
+import { decodeJwtPayload } from './tenant-store';
+
+/**
+ * Requests a new access token using the OAuth 2.0 refresh token grant type.
+ * This is used to "upgrade" an initial device flow token by including tenant-specific context.
+ * @param {RefreshTokenRequest} options - Configuration for the refresh token request.
+ * @returns {Promise<any>} A promise that resolves to the refreshed token data including tenant context.
+ * @throws {Error} If the token request fails or returns an error response.
+ */
+export let getRefreshAccessToken = _getRefreshAccessToken;
+
+export const unitMocks = {
+  get getRefreshAccessToken() {
+    return _getRefreshAccessToken;
+  },
+  set getRefreshAccessToken(mockFn) {
+    getRefreshAccessToken = mockFn;
+  },
+};
 
 /**
  * Validates whether a given auth config is still valid (i.e., not expired).
  * @param {TenantAuth} authInfo - The tenant auth configuration.
  * @returns True if the token is still valid, false if expired.
  */
-export function validateAuthInfo(authInfo: TenantAuth): boolean {
+export function validateAuthInfo(authInfo: TenantAuthInfo): boolean {
   const now = new Date();
   const expiry = new Date(authInfo.expires_at);
   return now < expiry;
@@ -24,11 +44,11 @@ export function validateAuthInfo(authInfo: TenantAuth): boolean {
  * Renews the token for a given tenant using stored credentials.
  * @param {TenantAuth} authInfo - Current authentication info for the tenant.
  * @param {TenantInfo} tenantInfo - Public metadata about the tenant (e.g., clientId).
- * @returns Promise<void>
+ * @returns {Promise<void>} resolving when the token is successfully renewed.
  * @throws If credentials are missing or renewal fails.
  */
 export async function renewClientToken(
-  authInfo: TenantAuth,
+  authInfo: TenantAuthInfo,
   tenantInfo: TenantInfo
 ): Promise<void> {
   const result = await clientCredentialsFlow({
@@ -49,12 +69,13 @@ export async function renewClientToken(
     expires_at: new Date(Date.now() + result.data.expires_in * 1000).toISOString(),
   });
 
-  console.info(`\n Token for tenant ${tenantId} renewed.`);
+  console.log(`\n Token for tenant ${tenantId} renewed.`);
 }
 
 /**
  * Ensures a valid token exists, renews it if expired.
- * Returns tenant context if successful, otherwise null.
+ * @returns {Promise<{ tenantId: string } | null>} returns tenant context if successful, otherwise null.
+ * @throws If renewal fails or credentials are missing.
  */
 export async function validateAndRenewAuthIfExpired(): Promise<{ tenantId: string } | null> {
   const tenantId = getActiveTenant();
@@ -70,25 +91,75 @@ export async function validateAndRenewAuthIfExpired(): Promise<{ tenantId: strin
   const tenantInfo = await readTenantInfo(tenantId);
   if (!tenantInfo) return null;
 
-  console.info(`\n Token for tenant ${tenantId} is expired. Renewing...`);
+  console.log(`\n Token for tenant ${tenantId} is expired. Renewing...`);
 
   try {
     if (authInfo.clientSecret) {
       await renewClientToken(authInfo, tenantInfo);
+    } else if (authInfo.refresh_token) {
+      const refreshTokenResponse = await getRefreshAccessToken({
+        clientId: tenantInfo.clientId,
+        refreshToken: authInfo.refresh_token,
+        tenantId: tenantId,
+        organizationId: tenantInfo.organizationId,
+        authority: tenantInfo.authority,
+      });
+
+      await writeTenantAuthInfo(tenantId, {
+        expires_at: new Date(
+          Date.now() + refreshTokenResponse.data.expires_in * 1000
+        ).toISOString(),
+        ...refreshTokenResponse.data,
+      });
+
+      console.log(`\n Token for tenant ${tenantId} renewed.`);
     } else {
-      // <TODO>: Implement Device auth token renewal.
-      throw new Error('\n Please use clientSecret for authentication.');
+      throw new Error('\n No valid credentials found for token renewal.');
     }
     return { tenantId };
   } catch (err) {
-    console.error(`\n Failed to renew token for tenant '${tenantId}'`);
+    const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
+    console.error(`\n Failed to renew token for tenant '${tenantId}: ${errorMessage}'`);
 
-    console.warn(`\n Cleaning up stale authentication data for tenant '${tenantId}'...`);
+    console.log(`\n Cleaning up stale authentication data for tenant '${tenantId}'...`);
     await deleteTenantAuthInfo(tenantId);
     await deleteKey(tenantId);
     clearActiveTenant();
 
-    console.info('\n You will need to login again to re-authenticate.');
+    console.log('\n You will need to login again to re-authenticate.');
     process.exit(1);
   }
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+async function _getRefreshAccessToken({
+  clientId,
+  refreshToken,
+  tenantId,
+  organizationId,
+  authority = DEFAULT_SITECORE_AUTH_DOMAIN,
+}: RefreshTokenRequest) {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    grant_type: REFRESH_GRANT_TYPE,
+    refresh_token: refreshToken,
+    tenant_id: tenantId,
+    organization_id: organizationId,
+  });
+
+  const response = await fetch(`${authority}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data.error_description || data.error || 'Error refreshing access token');
+  }
+
+  const { tenantName } = decodeJwtPayload(data.access_token) || {};
+
+  return { ...data, tenantName };
 }

--- a/packages/core/src/tools/auth/tenant-state.test.ts
+++ b/packages/core/src/tools/auth/tenant-state.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import os from 'os';
 import { getActiveTenant, setActiveTenant, clearActiveTenant } from './tenant-state';
 
-describe('tenant-state utils', () => {
+describe('Tenant-State Utils', () => {
   const settingsFile = path.join(os.homedir(), '.sitecore', 'sitecore-tools', 'settings.json');
 
   let existsStub: sinon.SinonStub;

--- a/packages/core/src/tools/auth/tenant-store.test.ts
+++ b/packages/core/src/tools/auth/tenant-store.test.ts
@@ -13,7 +13,7 @@ import {
   decodeJwtPayload,
 } from './tenant-store';
 
-describe('tenant-store utils', () => {
+describe('Tenant-Store Utils', () => {
   const tenantId = 'tenant-abc';
   const tenantDir = path.join(os.homedir(), '.sitecore', 'sitecore-tools', tenantId);
   const authPath = path.join(tenantDir, 'auth.json');

--- a/packages/core/src/tools/auth/tenant-store.ts
+++ b/packages/core/src/tools/auth/tenant-store.ts
@@ -2,7 +2,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { TenantAuth, TenantInfo } from './models';
+import { TenantAuthInfo, TenantInfo } from './models';
 import { encryptData, decryptData } from './encryption';
 import { CLAIMS } from './../../constants';
 
@@ -111,7 +111,7 @@ export function getTenantPath(tenantId: string): string {
   return path.join(rootDir, tenantId);
 }
 
-async function _writeTenantAuthInfo(tenantId: string, authInfo: TenantAuth): Promise<void> {
+async function _writeTenantAuthInfo(tenantId: string, authInfo: TenantAuthInfo): Promise<void> {
   try {
     const dir = getTenantPath(tenantId);
     fs.mkdirSync(dir, { recursive: true });
@@ -125,7 +125,7 @@ async function _writeTenantAuthInfo(tenantId: string, authInfo: TenantAuth): Pro
   }
 }
 
-async function _readTenantAuthInfo(tenantId: string): Promise<TenantAuth | null> {
+async function _readTenantAuthInfo(tenantId: string): Promise<TenantAuthInfo | null> {
   const filePath = path.join(getTenantPath(tenantId), 'auth.json');
   if (!fs.existsSync(filePath)) return null;
 
@@ -136,7 +136,7 @@ async function _readTenantAuthInfo(tenantId: string): Promise<TenantAuth | null>
     if (decryptedData === null) {
       return null;
     }
-    return JSON.parse(decryptedData) as TenantAuth;
+    return JSON.parse(decryptedData) as TenantAuthInfo;
   } catch (error) {
     console.error(
       `\n Failed to read auth.json for tenant '${tenantId}': ${(error as Error).message}`
@@ -205,7 +205,7 @@ function _getAllTenantsInfo(): TenantInfo[] {
         const content = fs.readFileSync(infoPath, 'utf-8');
         const data = JSON.parse(content);
 
-        if (data.tenantId && data.tenantName && data.organizationId && data.clientId) {
+        if (data.tenantId && data.tenantName && data.organizationId) {
           tenants.push({
             tenantId: data.tenantId,
             tenantName: data.tenantName,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR introduces support for the OAuth Device Authorization Flow to enable secure authentication for environments without a browser interface. Following are key functions introduced:

- Added `startDeviceAuthFlow`
   Initiates the device authorization process by generating the device_code and verification URIs.

- Added `pollForDeviceToken`
   Handles polling against the token endpoint at specified intervals until the user completes authorization or a timeout occurs.

- Added `getRefreshAccessToken`
  Enables token renewal using a refresh token when the access token expires, ensuring seamless re-authentication.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
