### PR TITLE
[core] Remove env var names references from console warnings

### DIFF
--- a/packages/core/src/config/define-config.ts
+++ b/packages/core/src/config/define-config.ts
@@ -137,7 +137,7 @@ const validateConfig = (config: SitecoreConfigInput) => {
   if (!hasEdgeContextId && !hasClientContextId && hasLocalApi) {
     console.warn(
       'Warning: Redirects and Personalization middleware require Edge API configuration. ' +
-        'Consider setting SITECORE_EDGE_CONTEXT_ID or NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID.'
+        'Please ensure that either an Edge context ID (for server-side) or a client context ID (for client-side) is provided in your configuration'
     );
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR is for removing env variable name references from the console warnings

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
