### PR TITLE
[react] ErrorBoundary now does not render Suspense when it is wrapping BYOCWrapper, to prevent hydration errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Our versioning strategy is as follows:
 * `[core]` Fix for making clientContextId optional for client-side execution to avoid runtime errors ([#121](https://github.com/Sitecore/content-sdk/pull/121))
 * `[core]` `[sitecore.config]` Fallback values are not respected when framework specific value is empty & validate resolved config instead of base ([#97](https://github.com/Sitecore/content-sdk/pull/97))
 * `[nextjs]` Improve device detection and prevent false prefetch handling in Personalize middleware and also ensure personalized responses are not served from prefetch cache and proper personalization was applied during client side navigation. ([#129](https://github.com/Sitecore/content-sdk/pull/129))
+* `[react]` Suspense in ErrorBoundary component is not rendered when it is wrapping a BYOCWrapper to prevent client side hydration errors ([#132](https://github.com/Sitecore/content-sdk/pull/132))
 
 ## 0.2.1
 

--- a/packages/react/src/components/Placeholder.test.tsx
+++ b/packages/react/src/components/Placeholder.test.tsx
@@ -25,6 +25,7 @@ import * as BYOCWrapper from './BYOCWrapper';
 import * as FEAASComponent from './FEaaSComponent';
 import * as FEAASWrapper from './FEaaSWrapper';
 import * as HiddenRendering from './HiddenRendering';
+import * as ErrorBoundary from './ErrorBoundary';
 import { MissingComponent, MissingComponentProps } from './MissingComponent';
 import { Placeholder } from './Placeholder';
 import { ComponentProps } from './PlaceholderCommon';
@@ -416,14 +417,17 @@ describe('BYOC fallback', () => {
       </div>
     ));
 
-    const renderedComponent = mount(
-      <SitecoreContext componentFactory={componentFactory}>
+    const suspenseSpy = spy(React, 'Suspense');
+    const errorBoundarySpy = spy(ErrorBoundary, 'default');
+
+    render(
+      <SitecoreProvider componentMap={componentMap}>
         <Placeholder name={phKey} rendering={component} />
-      </SitecoreContext>
+      </SitecoreProvider>
     );
 
-    expect(renderedComponent.find('ErrorBoundary').length).to.equal(2);
-    expect(renderedComponent.find('Suspense').length).to.equal(1);
+    expect(errorBoundarySpy.called).to.be.true;
+    expect(suspenseSpy.called).to.be.false;
 
     byocComponentStub.restore();
     byocWrapperStub.restore();

--- a/packages/react/src/components/Placeholder.test.tsx
+++ b/packages/react/src/components/Placeholder.test.tsx
@@ -402,32 +402,32 @@ describe('BYOC fallback', () => {
     byocWrapperStub.restore();
   });
 
-  it('should render ErrorBoundary without Suspense for byoc wrapper', () => {Add commentMore actions
-      const component = byocWrapperData.sitecore.route as RouteData;
-      const phKey = 'main';
+  it('should render ErrorBoundary without Suspense for byoc wrapper', () => {
+    const component = byocWrapperData.sitecore.route as RouteData;
+    const phKey = 'main';
 
-      byocComponentStub = stub(BYOCComponent, 'BYOCComponent').callsFake(() => (
-        <p className="byoc-component">Foo</p>
-      ));
+    byocComponentStub = stub(BYOCComponent, 'BYOCComponent').callsFake(() => (
+      <p className="byoc-component">Foo</p>
+    ));
 
-      byocWrapperStub = stub(BYOCWrapper, 'BYOCWrapper').callsFake(() => (
-        <div className="byoc-wrapper">
-          <BYOCComponent.BYOCComponent />
-        </div>
-      ));
+    byocWrapperStub = stub(BYOCWrapper, 'BYOCWrapper').callsFake(() => (
+      <div className="byoc-wrapper">
+        <BYOCComponent.BYOCComponent />
+      </div>
+    ));
 
-      const renderedComponent = mount(
-        <SitecoreContext componentFactory={componentFactory}>
-          <Placeholder name={phKey} rendering={component} />
-        </SitecoreContext>
-      );
+    const renderedComponent = mount(
+      <SitecoreContext componentFactory={componentFactory}>
+        <Placeholder name={phKey} rendering={component} />
+      </SitecoreContext>
+    );
 
-      expect(renderedComponent.find('ErrorBoundary').length).to.equal(2);
-      expect(renderedComponent.find('Suspense').length).to.equal(1);
+    expect(renderedComponent.find('ErrorBoundary').length).to.equal(2);
+    expect(renderedComponent.find('Suspense').length).to.equal(1);
 
-      byocComponentStub.restore();
-      byocWrapperStub.restore();
-    });
+    byocComponentStub.restore();
+    byocWrapperStub.restore();
+  });
 });
 
 describe('FEaaS fallback', () => {

--- a/packages/react/src/components/Placeholder.test.tsx
+++ b/packages/react/src/components/Placeholder.test.tsx
@@ -403,7 +403,7 @@ describe('BYOC fallback', () => {
     byocWrapperStub.restore();
   });
 
-  it('should render ErrorBoundary without Suspense for byoc wrapper', () => {
+  it('should render ErrorBoundary with isDynamic prop for byoc wrapper', () => {
     const component = byocWrapperData.sitecore.route as RouteData;
     const phKey = 'main';
 
@@ -417,7 +417,6 @@ describe('BYOC fallback', () => {
       </div>
     ));
 
-    const suspenseSpy = spy(React, 'Suspense');
     const errorBoundarySpy = spy(ErrorBoundary, 'default');
 
     render(
@@ -426,8 +425,7 @@ describe('BYOC fallback', () => {
       </SitecoreProvider>
     );
 
-    expect(errorBoundarySpy.called).to.be.true;
-    expect(suspenseSpy.called).to.be.false;
+    expect(errorBoundarySpy.calledWithMatch({ isDynamic: true })).to.be.true;
 
     byocComponentStub.restore();
     byocWrapperStub.restore();

--- a/packages/react/src/components/Placeholder.test.tsx
+++ b/packages/react/src/components/Placeholder.test.tsx
@@ -401,6 +401,33 @@ describe('BYOC fallback', () => {
     byocComponentStub.restore();
     byocWrapperStub.restore();
   });
+
+  it('should render ErrorBoundary without Suspense for byoc wrapper', () => {Add commentMore actions
+      const component = byocWrapperData.sitecore.route as RouteData;
+      const phKey = 'main';
+
+      byocComponentStub = stub(BYOCComponent, 'BYOCComponent').callsFake(() => (
+        <p className="byoc-component">Foo</p>
+      ));
+
+      byocWrapperStub = stub(BYOCWrapper, 'BYOCWrapper').callsFake(() => (
+        <div className="byoc-wrapper">
+          <BYOCComponent.BYOCComponent />
+        </div>
+      ));
+
+      const renderedComponent = mount(
+        <SitecoreContext componentFactory={componentFactory}>
+          <Placeholder name={phKey} rendering={component} />
+        </SitecoreContext>
+      );
+
+      expect(renderedComponent.find('ErrorBoundary').length).to.equal(2);
+      expect(renderedComponent.find('Suspense').length).to.equal(1);
+
+      byocComponentStub.restore();
+      byocWrapperStub.restore();
+    });
 });
 
 describe('FEaaS fallback', () => {

--- a/packages/react/src/components/PlaceholderCommon.tsx
+++ b/packages/react/src/components/PlaceholderCommon.tsx
@@ -239,15 +239,21 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         if (!isEmpty) {
           // assign type based on passed element - type='text/sitecore' should be ignored when renderEach Placeholder prop function is being used
           const type = rendered.props.type === 'text/sitecore' ? rendered.props.type : '';
+
           // wrapping with error boundary could cause problems in case where parent component uses withPlaceholder HOC and tries to access its children props
           // that's why we need to expose element's props here
+          const isByocWrapper = componentRendering.componentName === BYOC_WRAPPER_RENDERING_NAME;
+
+          // all dynamic elements will have a separate render prop
+          const isDynamicComponent = !!(component as LazyComponentType).render?.preload;
+
           rendered = (
             <ErrorBoundary
               key={rendered.type + '-' + index}
               errorComponent={this.props.errorComponent}
               componentLoadingMessage={this.props.componentLoadingMessage}
               type={type}
-              isDynamic={(component as LazyComponentType).render?.preload ? true : false}
+              isDynamic={isDynamicComponent || isByocWrapper}
               {...rendered.props}
             >
               {rendered}


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Migrate the work from JSS for: https://github.com/Sitecore/jss/pull/2071

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
