### PR TITLE
[core][nextjs][templates/nextjs] Update and improve environment variable naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Our versioning strategy is as follows:
 * `[core]` `[nextjs]` [DesignLibrary] Include metadata in the Design Library rendering mechanism ([#118](https://github.com/Sitecore/content-sdk/pull/118))
 * `[core]` `[nextjs]` `[cli]` Add automatic component map generation ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#128](https://github.com/Sitecore/content-sdk/pull/128) [#130](https://github.com/Sitecore/content-sdk/pull/130))
 * `[create-sitecore-jss]` Remove graphql introspection sample and scripts folder from next starter application ([#135](https://github.com/Sitecore/content-sdk/pull/135))
+* `[core]` [Content SDK] Update environment variable naming ([#120](https://github.com/Sitecore/content-sdk/pull/120))
 
 ### 🛠 Breaking Changes
 
@@ -70,6 +71,10 @@ Our versioning strategy is as follows:
 * `[nextjs]` `defineCliConfig` import has been moved to `@sitecore-content-sdk/nextjs/config-cli` submodule ([#128](https://github.com/Sitecore/content-sdk/pull/128)).
 * `[core][nextjs][cli]` Re-introduce component map generation logic ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#139](https://github.com/Sitecore/content-sdk/pull/139))
 * `[create-content-sdk-app]` Remove SXA components and style files from default `nextjs` template ([#139](https://github.com/Sitecore/content-sdk/pull/139))
+* `[core]` `[nextjs]` `[templates/nextjs]` Environment variables' naming has been updated ([#120](https://github.com/Sitecore/content-sdk/pull/120))
+  * `JSS_EDITING_SECRET` → `SITECORE_EDITING_SECRET`
+  * `NEXT_PUBLIC_SITECORE_SITE_NAME` → `NEXT_PUBLIC_DEFAULT_SITE_NAME`
+  * `DISABLE_SSG_FETCH` → `GENERATE_STATIC_PATHS`
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Our versioning strategy is as follows:
 * `[core]` `[nextjs]` [DesignLibrary] Include metadata in the Design Library rendering mechanism ([#118](https://github.com/Sitecore/content-sdk/pull/118))
 * `[core]` `[nextjs]` `[cli]` Add automatic component map generation ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#128](https://github.com/Sitecore/content-sdk/pull/128) [#130](https://github.com/Sitecore/content-sdk/pull/130))
 * `[create-sitecore-jss]` Remove graphql introspection sample and scripts folder from next starter application ([#135](https://github.com/Sitecore/content-sdk/pull/135))
-* `[core]` [Content SDK] Update environment variable naming ([#120](https://github.com/Sitecore/content-sdk/pull/120))
+* `[core]` [Content SDK] Update environment variable naming ([#143](https://github.com/Sitecore/content-sdk/pull/143))
 
 ### 🛠 Breaking Changes
 
@@ -71,7 +71,7 @@ Our versioning strategy is as follows:
 * `[nextjs]` `defineCliConfig` import has been moved to `@sitecore-content-sdk/nextjs/config-cli` submodule ([#128](https://github.com/Sitecore/content-sdk/pull/128)).
 * `[core][nextjs][cli]` Re-introduce component map generation logic ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#139](https://github.com/Sitecore/content-sdk/pull/139))
 * `[create-content-sdk-app]` Remove SXA components and style files from default `nextjs` template ([#139](https://github.com/Sitecore/content-sdk/pull/139))
-* `[core]` `[nextjs]` `[templates/nextjs]` Environment variables' naming has been updated ([#120](https://github.com/Sitecore/content-sdk/pull/120))
+* `[core]` `[nextjs]` `[templates/nextjs]` Environment variables' naming has been updated ([#143](https://github.com/Sitecore/content-sdk/pull/143))
   * `JSS_EDITING_SECRET` → `SITECORE_EDITING_SECRET`
   * `NEXT_PUBLIC_SITECORE_SITE_NAME` → `NEXT_PUBLIC_DEFAULT_SITE_NAME`
   * `DISABLE_SSG_FETCH` → `GENERATE_STATIC_PATHS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Our versioning strategy is as follows:
 * `[core]` `[nextjs]` [DesignLibrary] Include metadata in the Design Library rendering mechanism ([#118](https://github.com/Sitecore/content-sdk/pull/118))
 * `[core]` `[nextjs]` `[cli]` Add automatic component map generation ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#128](https://github.com/Sitecore/content-sdk/pull/128) [#130](https://github.com/Sitecore/content-sdk/pull/130))
 * `[create-sitecore-jss]` Remove graphql introspection sample and scripts folder from next starter application ([#135](https://github.com/Sitecore/content-sdk/pull/135))
-* `[core]` [Content SDK] Update environment variable naming ([#143](https://github.com/Sitecore/content-sdk/pull/143))
+* `[core]` [Content SDK] Update environment variable naming and associated config property ([#143](https://github.com/Sitecore/content-sdk/pull/143))
 
 ### 🛠 Breaking Changes
 
@@ -75,6 +75,7 @@ Our versioning strategy is as follows:
   * `JSS_EDITING_SECRET` → `SITECORE_EDITING_SECRET`
   * `NEXT_PUBLIC_SITECORE_SITE_NAME` → `NEXT_PUBLIC_DEFAULT_SITE_NAME`
   * `DISABLE_SSG_FETCH` → `GENERATE_STATIC_PATHS`
+  * `disableStaticPaths` config property → `generateStaticPaths` (with inverted logic for clarity)
 
 ### 🐛 Bug Fixes
 

--- a/packages/core/src/config/define-config.test.ts
+++ b/packages/core/src/config/define-config.test.ts
@@ -160,7 +160,7 @@ describe('define-config', () => {
 
       process.env.SITECORE_EDGE_CONTEXT_ID = contextId;
       process.env.SITECORE_EDGE_URL = edgeUrl;
-      process.env.JSS_EDITING_SECRET = contentSdkEditingSecret;
+      process.env.SITECORE_EDITING_SECRET = contentSdkEditingSecret;
       process.env.PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT = personalizeMiddlewareEdgeTimeout.toString();
       process.env.PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT = personalizeMiddlewareCdpTimeout.toString();
 
@@ -175,7 +175,7 @@ describe('define-config', () => {
     it('should use falback values when env variables are not present', () => {
       delete process.env.SITECORE_EDGE_CONTEXT_ID;
       delete process.env.SITECORE_EDGE_URL;
-      delete process.env.JSS_EDITING_SECRET;
+      delete process.env.SITECORE_EDITING_SECRET;
       delete process.env.PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT;
       delete process.env.PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT;
 

--- a/packages/core/src/config/define-config.ts
+++ b/packages/core/src/config/define-config.ts
@@ -19,7 +19,7 @@ export const getFallbackConfig = (): SitecoreConfig => ({
       path: '/sitecore/api/graph/edge',
     },
   },
-  editingSecret: process.env.JSS_EDITING_SECRET || 'editing-secret-missing',
+  editingSecret: process.env.SITECORE_EDITING_SECRET || 'editing-secret-missing',
   retries: {
     count: 3,
     retryStrategy: new DefaultRetryStrategy({

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -77,7 +77,7 @@ export type SitecoreConfigInput = {
   defaultSite?: string;
   /**
    * Editing secret required to support Sitecore editing and preview functionality.
-   * by default set by the JSS_EDITING_SECRET environment variable
+   * by default set by the SITECORE_EDITING_SECRET environment variable
    */
   editingSecret?: string;
   /**

--- a/packages/create-content-sdk-app/src/templates/nextjs/.env.container.example
+++ b/packages/create-content-sdk-app/src/templates/nextjs/.env.container.example
@@ -2,11 +2,11 @@
 
 # To secure the Sitecore editor endpoint exposed by your Next.js app
 # (`/api/editing/render` by default), a secret token is used. This (client-side)
-JSS_EDITING_SECRET=
+SITECORE_EDITING_SECRET=
 
 # Your Sitecore site name.
 # The value of the variable represents the default/configured site.
-NEXT_PUBLIC_SITECORE_SITE_NAME=
+NEXT_PUBLIC_DEFAULT_SITE_NAME=
 
 # Your default app language.
 NEXT_PUBLIC_DEFAULT_LANGUAGE=

--- a/packages/create-content-sdk-app/src/templates/nextjs/.env.remote.example
+++ b/packages/create-content-sdk-app/src/templates/nextjs/.env.remote.example
@@ -2,11 +2,11 @@
 
 # To secure the Sitecore editor endpoint exposed by your Next.js app
 # (`/api/editing/render` by default), a secret token is used. This (client-side)
-JSS_EDITING_SECRET=
+SITECORE_EDITING_SECRET=
 
 # Your Sitecore site name.
 # The value of the variable represents the default/configured site.
-NEXT_PUBLIC_SITECORE_SITE_NAME=
+NEXT_PUBLIC_DEFAULT_SITE_NAME=
 
 # Your default app language.
 NEXT_PUBLIC_DEFAULT_LANGUAGE=

--- a/packages/create-content-sdk-app/src/templates/nextjs/sitecore.config.ts.example
+++ b/packages/create-content-sdk-app/src/templates/nextjs/sitecore.config.ts.example
@@ -19,9 +19,9 @@ export default defineConfig({
       apiHost: process.env.NEXT_PUBLIC_SITECORE_API_HOST || '',
     },
   },
-  defaultSite: process.env.NEXT_PUBLIC_SITECORE_SITE_NAME,
+  defaultSite: process.env.NEXT_PUBLIC_DEFAULT_SITE_NAME,
   defaultLanguage: process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE || 'en',
-  editingSecret: process.env.JSS_EDITING_SECRET,
+  editingSecret: process.env.SITECORE_EDITING_SECRET,
   redirects: {
     enabled: true,
     locales: ['en'],

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/404.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/404.tsx
@@ -20,10 +20,10 @@ const Custom404 = (props: SitecorePageProps): JSX.Element => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async (context) => {
+export const getStaticProps: GetStaticProps = async context => {
   let resultErrorPages: ErrorPages | null = null;
 
-  if (!scConfig.disableStaticPaths) {
+  if (!scConfig.generateStaticPaths) {
     try {
       resultErrorPages = await client.getErrorPages({
         site: config.defaultSite,

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/404.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/404.tsx
@@ -23,7 +23,7 @@ const Custom404 = (props: SitecorePageProps): JSX.Element => {
 export const getStaticProps: GetStaticProps = async context => {
   let resultErrorPages: ErrorPages | null = null;
 
-  if (!scConfig.generateStaticPaths) {
+  if (scConfig.generateStaticPaths) {
     try {
       resultErrorPages = await client.getErrorPages({
         site: config.defaultSite,

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
@@ -38,7 +38,7 @@ const Custom500 = (props: SitecorePageProps): JSX.Element => {
 export const getStaticProps: GetStaticProps = async context => {
   let resultErrorPages: ErrorPages | null = null;
 
-  if (!scConfig.generateStaticPaths) {
+  if (scConfig.generateStaticPaths) {
     try {
       resultErrorPages = await client.getErrorPages({
         site: scConfig.defaultSite,

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
@@ -35,10 +35,10 @@ const Custom500 = (props: SitecorePageProps): JSX.Element => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async (context) => {
+export const getStaticProps: GetStaticProps = async context => {
   let resultErrorPages: ErrorPages | null = null;
 
-  if (!scConfig.disableStaticPaths) {
+  if (!scConfig.generateStaticPaths) {
     try {
       resultErrorPages = await client.getErrorPages({
         site: scConfig.defaultSite,

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -60,7 +60,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
   let paths: StaticPath[] = [];
   let fallback: boolean | 'blocking' = 'blocking';
 
-  if (process.env.NODE_ENV !== 'development' && !scConfig.disableStaticPaths) {
+  if (process.env.NODE_ENV !== 'development' && !scConfig.generateStaticPaths) {
     try {
       paths = await client.getPagePaths(context?.locales || []);
     } catch (error) {

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -60,7 +60,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
   let paths: StaticPath[] = [];
   let fallback: boolean | 'blocking' = 'blocking';
 
-  if (process.env.NODE_ENV !== 'development' && !scConfig.generateStaticPaths) {
+  if (process.env.NODE_ENV !== 'development' && scConfig.generateStaticPaths) {
     try {
       paths = await client.getPagePaths(context?.locales || []);
     } catch (error) {

--- a/packages/nextjs/src/config/define-config.test.ts
+++ b/packages/nextjs/src/config/define-config.test.ts
@@ -252,11 +252,11 @@ describe('defineConfig', () => {
 
     describe('environment variable is set', () => {
       before(() => {
-        process.env.NEXT_PUBLIC_SITECORE_SITE_NAME = 'next-public-sitecore-site-name';
+        process.env.NEXT_PUBLIC_DEFAULT_SITE_NAME = 'next-public-sitecore-site-name';
       });
 
       after(() => {
-        delete process.env.NEXT_PUBLIC_SITECORE_SITE_NAME;
+        delete process.env.NEXT_PUBLIC_DEFAULT_SITE_NAME;
       });
 
       it('should use the value from the config if present', () => {
@@ -431,11 +431,11 @@ describe('defineConfig', () => {
 
     describe('environment variable is set', () => {
       afterEach(() => {
-        delete process.env.DISABLE_SSG_FETCH;
+        delete process.env.GENERATE_STATIC_PATHS;
       });
 
-      it('should return true when DISABLE_SSG_FETCH is set to true', () => {
-        process.env.DISABLE_SSG_FETCH = 'true';
+      it('should return true when GENERATE_STATIC_PATHS is set to false', () => {
+        process.env.GENERATE_STATIC_PATHS = 'false';
 
         defineConfigModule.defineConfig({
           disableStaticPaths: false,
@@ -445,8 +445,8 @@ describe('defineConfig', () => {
         expect(resultConfig.disableStaticPaths).to.equal(true);
       });
 
-      it('should return false when DISABLE_SSG_FETCH is set to false', () => {
-        process.env.DISABLE_SSG_FETCH = 'false';
+      it('should return false when GENERATE_STATIC_PATHS is set to true', () => {
+        process.env.GENERATE_STATIC_PATHS = 'true';
 
         defineConfigModule.defineConfig({
           disableStaticPaths: true,
@@ -456,8 +456,8 @@ describe('defineConfig', () => {
         expect(resultConfig.disableStaticPaths).to.equal(false);
       });
 
-      it('should return false when DISABLE_SSG_FETCH is set to any other value', () => {
-        process.env.DISABLE_SSG_FETCH = 'some-other-value';
+      it('should return true when GENERATE_STATIC_PATHS is set to any other value', () => {
+        process.env.GENERATE_STATIC_PATHS = 'some-other-value';
 
         defineConfigModule.defineConfig({
           disableStaticPaths: true,

--- a/packages/nextjs/src/config/define-config.test.ts
+++ b/packages/nextjs/src/config/define-config.test.ts
@@ -456,7 +456,7 @@ describe('defineConfig', () => {
         expect(resultConfig.disableStaticPaths).to.equal(false);
       });
 
-      it('should return true when GENERATE_STATIC_PATHS is set to any other value', () => {
+      it('should return false when GENERATE_STATIC_PATHS is set to any other value', () => {
         process.env.GENERATE_STATIC_PATHS = 'some-other-value';
 
         defineConfigModule.defineConfig({

--- a/packages/nextjs/src/config/define-config.test.ts
+++ b/packages/nextjs/src/config/define-config.test.ts
@@ -411,21 +411,21 @@ describe('defineConfig', () => {
     });
   });
 
-  describe('config.disableStaticPaths', () => {
+  describe('config.generateStaticPaths', () => {
     describe('environment variable is not set', () => {
-      it('should default to false', () => {
+      it('should default to true', () => {
         defineConfigModule.defineConfig(defaultConfig());
         const resultConfig = defineConfigCoreStub.getCalls()[0].args[0];
-        expect(resultConfig.disableStaticPaths).to.equal(false);
+        expect(resultConfig.generateStaticPaths).to.equal(true);
       });
 
       it('should use the value from the config', () => {
         defineConfigModule.defineConfig({
-          disableStaticPaths: true,
+          generateStaticPaths: false,
           ...defaultConfig(),
         });
         const resultConfig = defineConfigCoreStub.getCalls()[0].args[0];
-        expect(resultConfig.disableStaticPaths).to.equal(true);
+        expect(resultConfig.generateStaticPaths).to.equal(false);
       });
     });
 
@@ -434,37 +434,37 @@ describe('defineConfig', () => {
         delete process.env.GENERATE_STATIC_PATHS;
       });
 
-      it('should return true when GENERATE_STATIC_PATHS is set to false', () => {
+      it('should return false when GENERATE_STATIC_PATHS is set to false', () => {
         process.env.GENERATE_STATIC_PATHS = 'false';
 
         defineConfigModule.defineConfig({
-          disableStaticPaths: false,
+          generateStaticPaths: true,
           ...defaultConfig(),
         });
         const resultConfig = defineConfigCoreStub.getCalls()[0].args[0];
-        expect(resultConfig.disableStaticPaths).to.equal(true);
+        expect(resultConfig.generateStaticPaths).to.equal(false);
       });
 
-      it('should return false when GENERATE_STATIC_PATHS is set to true', () => {
+      it('should return true when GENERATE_STATIC_PATHS is set to true', () => {
         process.env.GENERATE_STATIC_PATHS = 'true';
 
         defineConfigModule.defineConfig({
-          disableStaticPaths: true,
+          generateStaticPaths: false,
           ...defaultConfig(),
         });
         const resultConfig = defineConfigCoreStub.getCalls()[0].args[0];
-        expect(resultConfig.disableStaticPaths).to.equal(false);
+        expect(resultConfig.generateStaticPaths).to.equal(true);
       });
 
       it('should return false when GENERATE_STATIC_PATHS is set to any other value', () => {
         process.env.GENERATE_STATIC_PATHS = 'some-other-value';
 
         defineConfigModule.defineConfig({
-          disableStaticPaths: true,
+          generateStaticPaths: true,
           ...defaultConfig(),
         });
         const resultConfig = defineConfigCoreStub.getCalls()[0].args[0];
-        expect(resultConfig.disableStaticPaths).to.equal(false);
+        expect(resultConfig.generateStaticPaths).to.equal(false);
       });
     });
   });

--- a/packages/nextjs/src/config/define-config.ts
+++ b/packages/nextjs/src/config/define-config.ts
@@ -39,10 +39,10 @@ export const getNextFallbackConfig = (config?: SitecoreConfigInput): SitecoreCon
       ...config?.personalize,
       scope: config?.personalize?.scope || process.env.NEXT_PUBLIC_PERSONALIZE_SCOPE,
     },
-    disableStaticPaths:
+    generateStaticPaths:
       process.env.GENERATE_STATIC_PATHS !== undefined
-        ? process.env.GENERATE_STATIC_PATHS.toLowerCase() === 'false'
-        : config?.disableStaticPaths ?? false,
+        ? process.env.GENERATE_STATIC_PATHS.toLowerCase() === 'true'
+        : config?.generateStaticPaths ?? true,
   };
 };
 
@@ -53,14 +53,14 @@ export type SitecoreConfigInput = SitecoreConfigInputCore & {
   /**
    * Indicates whether SSG `getStaticPaths` pre-render any pages.
    *
-   * Set the environment variable `GENERATE_STATIC_PATHS=false`
-   * to disable static paths generation and enable full ISR (Incremental Static Regeneration) flow.
+   * Set the environment variable `GENERATE_STATIC_PATHS=true`
+   * to enable static paths generation.
    *
-   * By default, this is set to `false`.
+   * By default, this is set to `true`.
    *
-   * This is set to `true` when the application is deployed and used as editing host in Sitecore.
+   * This is set to `false` when the application is deployed and used as editing host in Sitecore.
    */
-  disableStaticPaths?: boolean;
+  generateStaticPaths?: boolean;
 };
 
 /**

--- a/packages/nextjs/src/config/define-config.ts
+++ b/packages/nextjs/src/config/define-config.ts
@@ -41,7 +41,7 @@ export const getNextFallbackConfig = (config?: SitecoreConfigInput): SitecoreCon
     },
     disableStaticPaths:
       process.env.GENERATE_STATIC_PATHS !== undefined
-        ? process.env.GENERATE_STATIC_PATHS.toLowerCase() !== 'true'
+        ? process.env.GENERATE_STATIC_PATHS.toLowerCase() === 'false'
         : config?.disableStaticPaths ?? false,
   };
 };

--- a/packages/nextjs/src/config/define-config.ts
+++ b/packages/nextjs/src/config/define-config.ts
@@ -28,7 +28,7 @@ export const getNextFallbackConfig = (config?: SitecoreConfigInput): SitecoreCon
         apiHost: config?.api?.local?.apiHost || process.env.NEXT_PUBLIC_SITECORE_API_HOST || '',
       },
     },
-    defaultSite: config?.defaultSite || process.env.NEXT_PUBLIC_SITECORE_SITE_NAME || '',
+    defaultSite: config?.defaultSite || process.env.NEXT_PUBLIC_DEFAULT_SITE_NAME || '',
     defaultLanguage: config?.defaultLanguage || process.env.NEXT_PUBLIC_DEFAULT_LANGUAGE || 'en',
     multisite: {
       ...config?.multisite,
@@ -40,8 +40,8 @@ export const getNextFallbackConfig = (config?: SitecoreConfigInput): SitecoreCon
       scope: config?.personalize?.scope || process.env.NEXT_PUBLIC_PERSONALIZE_SCOPE,
     },
     disableStaticPaths:
-      process.env.DISABLE_SSG_FETCH !== undefined
-        ? process.env.DISABLE_SSG_FETCH.toLowerCase() === 'true'
+      process.env.GENERATE_STATIC_PATHS !== undefined
+        ? process.env.GENERATE_STATIC_PATHS.toLowerCase() !== 'true'
         : config?.disableStaticPaths ?? false,
   };
 };
@@ -53,7 +53,7 @@ export type SitecoreConfigInput = SitecoreConfigInputCore & {
   /**
    * Indicates whether SSG `getStaticPaths` pre-render any pages.
    *
-   * Set the environment variable `DISABLE_SSG_FETCH=true`
+   * Set the environment variable `GENERATE_STATIC_PATHS=false`
    * to disable static paths generation and enable full ISR (Incremental Static Regeneration) flow.
    *
    * By default, this is set to `false`.

--- a/packages/nextjs/src/editing/editing-config-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-config-middleware.test.ts
@@ -59,12 +59,12 @@ describe('EditingConfigMiddleware', () => {
   const secret = 'jss-editing-secret-mock';
 
   beforeEach(() => {
-    process.env.JSS_EDITING_SECRET = secret;
+    process.env.SITECORE_EDITING_SECRET = secret;
     process.env.JSS_ALLOWED_ORIGINS = allowedOrigin;
   });
 
   after(() => {
-    delete process.env.JSS_EDITING_SECRET;
+    delete process.env.SITECORE_EDITING_SECRET;
     delete process.env.JSS_ALLOWED_ORIGINS;
   });
 

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -75,13 +75,13 @@ describe('EditingRenderMiddleware', () => {
   const secret = 'secret1234';
 
   beforeEach(() => {
-    process.env.JSS_EDITING_SECRET = secret;
+    process.env.SITECORE_EDITING_SECRET = secret;
     process.env.JSS_ALLOWED_ORIGINS = allowedOrigin;
     delete process.env.VERCEL;
   });
 
   after(() => {
-    delete process.env.JSS_EDITING_SECRET;
+    delete process.env.SITECORE_EDITING_SECRET;
     delete process.env.VERCEL;
     delete process.env.JSS_ALLOWED_ORIGINS;
   });

--- a/packages/nextjs/src/editing/feaas-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/feaas-render-middleware.test.ts
@@ -61,12 +61,12 @@ describe('FEAASRenderMiddleware', () => {
   const secret = 'secret1234';
 
   beforeEach(() => {
-    process.env.JSS_EDITING_SECRET = secret;
+    process.env.SITECORE_EDITING_SECRET = secret;
     process.env.JSS_ALLOWED_ORIGINS = allowedOrigin;
   });
 
   after(() => {
-    delete process.env.JSS_EDITING_SECRET;
+    delete process.env.SITECORE_EDITING_SECRET;
     delete process.env.JSS_ALLOWED_ORIGINS;
   });
 

--- a/packages/nextjs/src/utils/utils.test.ts
+++ b/packages/nextjs/src/utils/utils.test.ts
@@ -5,7 +5,7 @@ import { getEditingSecret } from './utils';
 describe('utils', () => {
   describe('getEditingSecret', () => {
     after(() => {
-      delete process.env.JSS_EDITING_SECRET;
+      delete process.env.SITECORE_EDITING_SECRET;
     });
 
     it('should throw if env variable missing', () => {
@@ -14,7 +14,7 @@ describe('utils', () => {
 
     it('should return env variable', () => {
       const secret = '1234abcd';
-      process.env.JSS_EDITING_SECRET = secret;
+      process.env.SITECORE_EDITING_SECRET = secret;
       const result = getEditingSecret();
       expect(result).to.equal(secret);
     });

--- a/packages/nextjs/src/utils/utils.ts
+++ b/packages/nextjs/src/utils/utils.ts
@@ -39,9 +39,9 @@ export const handleEditorFastRefresh = (forceReload = false): void => {
 };
 
 export const getEditingSecret = (): string => {
-  const secret = process.env.JSS_EDITING_SECRET;
+  const secret = process.env.SITECORE_EDITING_SECRET;
   if (!secret || secret.length === 0) {
-    throw new Error('The JSS_EDITING_SECRET environment variable is missing or invalid.');
+    throw new Error('The SITECORE_EDITING_SECRET environment variable is missing or invalid.');
   }
   return secret;
 };

--- a/ref-docs/core/config/type-aliases/SitecoreConfigInput.md
+++ b/ref-docs/core/config/type-aliases/SitecoreConfigInput.md
@@ -143,7 +143,7 @@ configure local memory caching for Dictionary Service requests
 Defined in: [packages/core/src/config/models.ts:82](https://github.com/Sitecore/content-sdk/blob/7e22e55dd6d6099199b3ecca0f822efd1793c967/packages/core/src/config/models.ts#L82)
 
 Editing secret required to support Sitecore editing and preview functionality.
-by default set by the JSS_EDITING_SECRET environment variable
+by default set by the SITECORE_EDITING_SECRET environment variable
 
 ***
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [x] Upgrade guide entry added

## Description / Motivation
- Updated references from `JSS_EDITING_SECRET` to `SITECORE_EDITING_SECRET` across configuration files and tests.
- Updated references from `NEXT_PUBLIC_SITECORE_SITE_NAME` to `NEXT_PUBLIC_DEFAULT_SITE_NAME` across files and tests.
- Changed `DISABLE_SSG_FETCH` to `GENERATE_STATIC_PATHS` in relevant configurations and tests.
- Updated documentation to reflect the new environment variable names.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Ran local tests)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
