### PR TITLE
[Chore] Add keytar dependency for GH actions

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -35,6 +35,12 @@ jobs:
           yarn cache clean --all
           yarn install --immutable
 
+      # Keytar requires libsecret-1 for native bindings. This step ensures it can be built/loaded in CI.
+      - name: Install system dependencies for keytar
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsecret-1-dev
+
       - name: Build packages
         run: npm run build
 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
PR for https://github.com/Sitecore/content-sdk/pull/116 introduces encryption for CLI command and adds an extra step for azure pipelines for the monorepo to build and test OK. This step was lost when migrating to GH actions, and this PR re-introduces it.

## Testing Details
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore
