### PR TITLE
[Design Library] Render endpoint throws "The site name must be a non-empty string"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ Our versioning strategy is as follows:
     * `GraphQLSitePathService` → `SitePathService`
     * `GraphQLSitePathServiceConfig` → `SitePathServiceConfig`
   * Removed `DictionaryService` interface
+* `[core]` `[nextjs]` `[templates/nextjs]` Refactor site resolution logic across packages ([#141](https://github.com/Sitecore/content-sdk/pull/141))([#155](https://github.com/Sitecore/content-sdk/pull/155))
+  * Removed `sites` parameter from `SitecoreClientInit` type
+  * Removed `SiteResolver` dependency and `resolveSite()` from `SitecoreClient`
+  * Removed support for passing a custom siteResolver to `SitecoreClient`
+  * Updated `SitecoreClient` to construct the `Page` using `siteName` instead of the full `SiteInfo`.
+  * Updated SitecoreClient's `getPagePaths()` to accept a `sites` parameter
+  * Modified the `getPagePaths` method in `SitecoreClient` to accept a `sites` parameter.
+  * Updated Next.js `SitemapMiddleware` and `RobotsMiddleware` to use their own instance of `SiteResolver` and accept a `sites` parameter via the constructor.
 
 ### 🐛 Bug Fixes
 
@@ -125,14 +133,6 @@ Our versioning strategy is as follows:
   * `NEXT_PUBLIC_SITECORE_SITE_NAME` → `NEXT_PUBLIC_DEFAULT_SITE_NAME`
   * `DISABLE_SSG_FETCH` → `GENERATE_STATIC_PATHS`
   * `disableStaticPaths` config property → `generateStaticPaths` (with inverted logic for clarity)
-* `[core]` `[nextjs]` `[templates/nextjs]` Refactor site resolution logic across packages ([#141](https://github.com/Sitecore/content-sdk/pull/141))
-  * Removed `sites` parameter from `SitecoreClientInit` type
-  * Removed `SiteResolver` dependency and `resolveSite()` from `SitecoreClient`
-  * Removed support for passing a custom siteResolver to `SitecoreClient`
-  * Updated `SitecoreClient` to construct the `Page` using `siteName` instead of the full `SiteInfo`.
-  * Updated SitecoreClient's `getPagePaths()` to accept a `sites` parameter
-  * Modified the `getPagePaths` method in `SitecoreClient` to accept a `sites` parameter.
-  * Updated Next.js `SitemapMiddleware` and `RobotsMiddleware` to use their own instance of `SiteResolver` and accept a `sites` parameter via the constructor.
 
 ### 🐛 Bug Fixes
 

--- a/packages/core/src/client/sitecore-client.test.ts
+++ b/packages/core/src/client/sitecore-client.test.ts
@@ -749,6 +749,7 @@ describe('SitecoreClient', () => {
         locale: componentLibData.language,
         layout: componentData,
         dictionary: dictionaryData,
+        siteName: componentData.sitecore.context.site?.name,
       });
 
       expect(

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -424,6 +424,7 @@ export class SitecoreClient implements BaseSitecoreClient {
       locale: designLibData.language,
       layout: componentData,
       dictionary: dictionaryData,
+      siteName: componentData.sitecore.context.site?.name || site,
     } as Page;
     return page;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
In "library" mode render endpoint throws "The site name must be a non-empty string"
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
