### PR TITLE
[Component Generation] Library mode for AI variant generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,59 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-`[nextjs]` Default static import-map for AI component generation ([#153](https://github.com/Sitecore/content-sdk/pull/153))
-`[cli]` Code Extraction for XM Cloud code generation ([#71](https://github.com/Sitecore/content-sdk/pull/71))([#113](https://github.com/Sitecore/content-sdk/pull/113))([#114](https://github.com/Sitecore/content-sdk/pull/114))([#154](https://github.com/Sitecore/content-sdk/pull/154))
+* `[core]` `[nextjs]` Integrated new Design Library _VariantGeneration_ mode ([#158](https://github.com/Sitecore/content-sdk/pull/158))
+* `[nextjs]` Default static import-map for AI component generation ([#153](https://github.com/Sitecore/content-sdk/pull/153))
+* `[cli]` Code Extraction for XM Cloud code generation ([#71](https://github.com/Sitecore/content-sdk/pull/71))([#113](https://github.com/Sitecore/content-sdk/pull/113))([#114](https://github.com/Sitecore/content-sdk/pull/114))([#154](https://github.com/Sitecore/content-sdk/pull/154))
 
 ### 🛠 Breaking Changes
+
+* Refactored `SitecoreProvider` and enhanced `SitecoreClient` ([#158](https://github.com/Sitecore/content-sdk/pull/158)):
+
+  #### Reworked `SitecoreProvider` and Context
+
+  - Refactored components that use `SitecoreProvider` and related utilities.
+  - `SitecoreProvider` now accepts a `page` prop (`Page` type from `SitecoreClient`) instead of `layoutData`.
+  - Context state updates:
+    - `pageContext` → renamed to `page`. `page` represents `Page` interface.
+    - `setContext` → renamed to `setPage`. The method updates the `page` state.
+  - Removed `SitecoreProviderPageContext` interface.
+    - Consumers should now access `page` via the `Page` interface.
+
+  #### Updated `withSitecore` and `useSitecore` APIs
+
+  - Updated naming for clarity and consistency:
+    - `pageContext` → `page`
+    - `updateContext` → `updatePage`
+
+  #### Improvements to `SitecoreClient`
+
+  - **Type cleanup and consistency**:
+    - Removed `NextjsPage` interface.
+    - All methods that generate page data now return a consistent `Page` object.
+    - Properties `componentProps` and `notFound` are now part of the `SitecorePageProps` interface and are treated as optional.
+    - `SitecorePageProps` now requires a standalone `page` field instead of merging all data into one props object.
+
+  - **New `getErrorPage()` method**:
+    - Replaces `getErrorPages()`, exposing only necessary data.
+    - Introduces a new `ErrorPage` enum to select specific error types (e.g., `ErrorPage.NotFound`)
+  
+  - **New `PageMode` Type**
+    - The `Page` type now includes a `mode` field of type `PageMode`, providing runtime context (e.g. editing, design library, preview).
+    - Replaces older properties like `pageState`, `pageEditing`, `componentType`.
+
+    ```ts
+    mode: {
+      isNormal: boolean;
+      isPreview: boolean;
+      isEditing: boolean;
+      isDesignLibrary: boolean;
+    }
+    ```
+
+  #### DesignLibrary Component
+
+  - The `DesignLibrary` component no longer accepts a `layoutData` prop.
+  - It now accesses `page` directly from `SitecoreProvider`.
 
 * Refactor and simplify service names ([#133](https://github.com/Sitecore/content-sdk/pull/133)):
 

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -9,6 +9,6 @@ export {
 export { DefaultRetryStrategy } from '../retries';
 export { RetryStrategy, PageInfo, FetchOptions } from '../models';
 export { getEdgeProxyContentUrl, getEdgeProxyFormsUrl } from './edge-proxy';
-export { SitecoreClient, Page, PageOptions, SitemapXmlOptions } from './sitecore-client';
+export { SitecoreClient, Page, PageOptions, SitemapXmlOptions, PageMode } from './sitecore-client';
 export { SitecoreClientInit } from './models';
 export { createGraphQLClientFactory, GraphQLClientOptions } from './utils';

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -9,6 +9,13 @@ export {
 export { DefaultRetryStrategy } from '../retries';
 export { RetryStrategy, PageInfo, FetchOptions } from '../models';
 export { getEdgeProxyContentUrl, getEdgeProxyFormsUrl } from './edge-proxy';
-export { SitecoreClient, Page, PageOptions, SitemapXmlOptions, PageMode } from './sitecore-client';
+export {
+  SitecoreClient,
+  Page,
+  PageOptions,
+  SitemapXmlOptions,
+  PageMode,
+  ErrorPage,
+} from './sitecore-client';
 export { SitecoreClientInit } from './models';
 export { createGraphQLClientFactory, GraphQLClientOptions } from './utils';

--- a/packages/core/src/client/sitecore-client.test.ts
+++ b/packages/core/src/client/sitecore-client.test.ts
@@ -254,7 +254,7 @@ describe('SitecoreClient', () => {
             name: 'home',
             placeholders: {},
           },
-          context: { site: siteInfo },
+          context: { site: siteInfo, pageState: LayoutServicePageState.Normal },
         },
       };
       layoutServiceStub.fetchLayoutData.returns(layoutData);
@@ -265,6 +265,10 @@ describe('SitecoreClient', () => {
         layout: layoutData,
         siteName: siteInfo.name,
         locale: locale,
+        mode: {
+          name: LayoutServicePageState.Normal,
+          isNormal: true,
+        },
       });
       expect(
         layoutServiceStub.fetchLayoutData.calledWithMatch(path, {
@@ -299,6 +303,10 @@ describe('SitecoreClient', () => {
         layout: layoutData,
         siteName: siteInfo.name,
         locale: locale,
+        mode: {
+          name: LayoutServicePageState.Normal,
+          isNormal: true,
+        },
       });
       expect(
         layoutServiceStub.fetchLayoutData.calledWithMatch(path, {
@@ -546,7 +554,7 @@ describe('SitecoreClient', () => {
   });
 
   describe('getPreview', () => {
-    it('should fetch and return preview data correctly', async () => {
+    it('should fetch and return preview data correctly in edit mode', async () => {
       const previewData = {
         site: 'default-site',
         itemId: 'test-item-id',
@@ -575,6 +583,60 @@ describe('SitecoreClient', () => {
         locale: previewData.language,
         layout: editingData.layoutData,
         dictionary: editingData.dictionary,
+        mode: {
+          name: LayoutServicePageState.Edit,
+          isEditing: true,
+          isPreview: false,
+        },
+      });
+
+      expect(editingServiceStub.fetchEditingData.calledOnce).to.be.true;
+      expect(
+        editingServiceStub.fetchEditingData.calledWith({
+          siteName: previewData.site,
+          itemId: previewData.itemId,
+          language: previewData.language,
+          version: previewData.version,
+          layoutKind: previewData.layoutKind,
+          mode: previewData.mode,
+        })
+      ).to.be.true;
+    });
+
+    it('should fetch and return preview data correctly in preview mode', async () => {
+      const previewData = {
+        site: 'default-site',
+        itemId: 'test-item-id',
+        mode: LayoutServicePageState.Preview,
+        language: 'en',
+        version: '1',
+        variantIds: ['variant1', 'comp_variant2'],
+        layoutKind: LayoutKind.Final,
+      };
+
+      const editingData = {
+        layoutData: {
+          sitecore: {
+            route: { name: 'home', placeholders: {} },
+            context: { site: { name: 'default-site' } },
+          },
+        },
+        dictionary: { key1: 'value1', key2: 'value2' },
+      };
+
+      editingServiceStub.fetchEditingData.resolves(editingData);
+
+      const result = await sitecoreClient.getPreview(previewData);
+
+      expect(result).to.deep.include({
+        locale: previewData.language,
+        layout: editingData.layoutData,
+        dictionary: editingData.dictionary,
+        mode: {
+          name: LayoutServicePageState.Preview,
+          isPreview: true,
+          isEditing: false,
+        },
       });
 
       expect(editingServiceStub.fetchEditingData.calledOnce).to.be.true;
@@ -750,6 +812,83 @@ describe('SitecoreClient', () => {
         layout: componentData,
         dictionary: dictionaryData,
         siteName: componentData.sitecore.context.site?.name,
+        mode: {
+          name: DesignLibraryMode.Normal,
+          isDesignLibrary: true,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
+        },
+      });
+
+      expect(
+        editingServiceStub.fetchDictionaryData.calledWithMatch({
+          siteName: componentLibData.site,
+          language: componentLibData.language,
+        })
+      ).to.be.true;
+
+      expect(
+        restComponentServiceStub.fetchComponentData.calledWith({
+          itemId: componentLibData.itemId,
+          componentUid: componentLibData.componentUid,
+          siteName: componentLibData.site,
+          language: componentLibData.language,
+          renderingId: componentLibData.renderingId,
+          dataSourceId: componentLibData.dataSourceId,
+          version: componentLibData.version,
+          mode: componentLibData.mode,
+        })
+      ).to.be.true;
+    });
+
+    it('should fetch component library data', async () => {
+      const componentLibData = {
+        itemId: 'item-id',
+        componentUid: 'comp-uid',
+        site: 'test-site',
+        language: 'en',
+        renderingId: 'rendering-id',
+        dataSourceId: 'datasource-id',
+        version: '1',
+        pageState: LayoutServicePageState.Normal,
+        mode: DesignLibraryMode.VariantGeneration,
+      };
+
+      const componentData = {
+        sitecore: {
+          route: { name: 'home', placeholders: {} },
+          context: {
+            site: {
+              name: 'test-site',
+              hostName: 'example.com',
+              language: 'en',
+            },
+          },
+        },
+      };
+      const dictionaryData = { key: 'value' };
+
+      restComponentServiceStub.fetchComponentData.resolves(componentData);
+
+      editingServiceStub.fetchDictionaryData
+        .withArgs({ siteName: componentLibData.site, language: componentLibData.language })
+        .resolves(dictionaryData);
+
+      const result = await sitecoreClient.getDesignLibraryData(componentLibData);
+
+      expect(result).to.deep.include({
+        locale: componentLibData.language,
+        layout: componentData,
+        dictionary: dictionaryData,
+        siteName: componentData.sitecore.context.site?.name,
+        mode: {
+          name: DesignLibraryMode.VariantGeneration,
+          isDesignLibrary: true,
+          designLibrary: {
+            isVariantGeneration: true,
+          },
+        },
       });
 
       expect(

--- a/packages/core/src/client/sitecore-client.test.ts
+++ b/packages/core/src/client/sitecore-client.test.ts
@@ -1,7 +1,8 @@
-﻿import chai, { expect } from 'chai';
+﻿/* eslint-disable dot-notation */
+import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
-import { SitecoreClient } from './sitecore-client';
+import { ErrorPage, SitecoreClient } from './sitecore-client';
 import { LayoutKind, DesignLibraryMode } from '../../editing';
 import { LayoutServiceData } from '../../layout';
 import { DefaultRetryStrategy } from '../retries';
@@ -32,6 +33,7 @@ describe('SitecoreClient', () => {
     defaultLanguage: 'en',
     layout: { formatLayoutQuery: sandbox.stub() },
     dictionary: { caching: { enabled: true, timeout: 60000 } },
+    disableCodeGeneration: false,
   };
 
   let sitecoreClient = new SitecoreClient(defaultInitOptions);
@@ -268,6 +270,12 @@ describe('SitecoreClient', () => {
         mode: {
           name: LayoutServicePageState.Normal,
           isNormal: true,
+          isPreview: false,
+          isEditing: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
         },
       });
       expect(
@@ -306,6 +314,12 @@ describe('SitecoreClient', () => {
         mode: {
           name: LayoutServicePageState.Normal,
           isNormal: true,
+          isPreview: false,
+          isEditing: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
         },
       });
       expect(
@@ -423,6 +437,144 @@ describe('SitecoreClient', () => {
           fetchOptions
         )
       ).to.be.true;
+    });
+  });
+
+  describe('getErrorPage', () => {
+    it('should fetch error page with default site and language', async () => {
+      const errorPage = {
+        notFoundPage: { rendered: { sitecore: { route: { name: 'home' } } } },
+      };
+
+      errorPagesServiceStub.fetchErrorPages.resolves(errorPage);
+
+      const result = await sitecoreClient.getErrorPage(ErrorPage.NotFound);
+
+      expect(result).to.deep.equal({
+        layout: errorPage.notFoundPage?.rendered,
+        locale: defaultInitOptions.defaultLanguage,
+        siteName: defaultInitOptions.defaultSite,
+        mode: {
+          name: LayoutServicePageState.Normal,
+          isNormal: true,
+          isPreview: false,
+          isEditing: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
+        },
+      });
+
+      expect(
+        errorPagesServiceStub.fetchErrorPages.calledWith(
+          defaultInitOptions.defaultSite,
+          defaultInitOptions.defaultLanguage
+        )
+      ).to.be.true;
+      expect(errorPagesServiceStub.fetchErrorPages.calledOnce).to.be.true;
+    });
+
+    it('should return null when unknown error page is requested', async () => {
+      const result = await sitecoreClient.getErrorPage('unknown' as ErrorPage, {
+        site: 'test-site',
+        locale: 'fr-FR',
+      });
+      expect(result).to.be.null;
+    });
+
+    describe('404 page', () => {
+      it('should return not found page', async () => {
+        const site = 'test-site';
+        const locale = 'fr-FR';
+        const errorPage = {
+          notFoundPage: { rendered: { sitecore: { route: { name: 'home' } } } },
+        };
+
+        errorPagesServiceStub.fetchErrorPages.resolves(errorPage);
+
+        const result = await sitecoreClient.getErrorPage(ErrorPage.NotFound, { site, locale });
+
+        expect(result).to.deep.equal({
+          layout: errorPage.notFoundPage?.rendered,
+          locale,
+          siteName: site,
+          mode: {
+            name: LayoutServicePageState.Normal,
+            isNormal: true,
+            isPreview: false,
+            isEditing: false,
+            isDesignLibrary: false,
+            designLibrary: {
+              isVariantGeneration: false,
+            },
+          },
+        });
+      });
+
+      it('should return null when not found page is not found', async () => {
+        const site = 'test-site';
+        const locale = 'fr-FR';
+        const errorPage = {
+          notFoundPage: null,
+        };
+
+        errorPagesServiceStub.fetchErrorPages.resolves(errorPage);
+
+        const result = await sitecoreClient.getErrorPage(ErrorPage.NotFound, { site, locale });
+
+        expect(result).to.be.null;
+      });
+    });
+
+    describe('500 page', () => {
+      it('should return server error page', async () => {
+        const site = 'test-site';
+        const locale = 'fr-FR';
+        const errorPage = {
+          serverErrorPage: { rendered: { sitecore: { route: { name: 'home' } } } },
+        };
+
+        errorPagesServiceStub.fetchErrorPages.resolves(errorPage);
+
+        const result = await sitecoreClient.getErrorPage(ErrorPage.InternalServerError, {
+          site,
+          locale,
+        });
+
+        expect(result).to.deep.equal({
+          layout: errorPage.serverErrorPage?.rendered,
+          locale,
+          siteName: site,
+          mode: {
+            name: LayoutServicePageState.Normal,
+            isNormal: true,
+            isPreview: false,
+            isEditing: false,
+            isDesignLibrary: false,
+            designLibrary: {
+              isVariantGeneration: false,
+            },
+          },
+        });
+      });
+
+      it('should return null when server error page is not found', async () => {
+        const site = 'test-site';
+        const locale = 'fr-FR';
+        const errorPage = {
+          serverErrorPage: null,
+        };
+
+        errorPagesServiceStub.fetchErrorPages.resolves(errorPage);
+
+        const result = await sitecoreClient.getErrorPage(ErrorPage.InternalServerError, {
+          site,
+          locale,
+        });
+
+        expect(result).to.be.null;
+      });
     });
   });
 
@@ -586,7 +738,12 @@ describe('SitecoreClient', () => {
         mode: {
           name: LayoutServicePageState.Edit,
           isEditing: true,
+          isNormal: false,
           isPreview: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
         },
       });
 
@@ -634,8 +791,13 @@ describe('SitecoreClient', () => {
         dictionary: editingData.dictionary,
         mode: {
           name: LayoutServicePageState.Preview,
+          isNormal: false,
           isPreview: true,
           isEditing: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
         },
       });
 
@@ -815,6 +977,9 @@ describe('SitecoreClient', () => {
         mode: {
           name: DesignLibraryMode.Normal,
           isDesignLibrary: true,
+          isNormal: false,
+          isPreview: false,
+          isEditing: false,
           designLibrary: {
             isVariantGeneration: false,
           },
@@ -885,6 +1050,9 @@ describe('SitecoreClient', () => {
         mode: {
           name: DesignLibraryMode.VariantGeneration,
           isDesignLibrary: true,
+          isNormal: false,
+          isPreview: false,
+          isEditing: false,
           designLibrary: {
             isVariantGeneration: true,
           },
@@ -998,6 +1166,98 @@ describe('SitecoreClient', () => {
           fetchOptions
         )
       ).to.be.true;
+    });
+  });
+
+  describe('getPageMode', () => {
+    it('should return the correct page mode for a given mode name', () => {
+      expect(sitecoreClient['getPageMode'](LayoutServicePageState.Normal)).to.deep.equal({
+        name: LayoutServicePageState.Normal,
+        isNormal: true,
+        isPreview: false,
+        isEditing: false,
+        isDesignLibrary: false,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+      });
+
+      expect(sitecoreClient['getPageMode'](LayoutServicePageState.Preview)).to.deep.equal({
+        name: LayoutServicePageState.Preview,
+        isNormal: false,
+        isPreview: true,
+        isEditing: false,
+        isDesignLibrary: false,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+      });
+
+      expect(sitecoreClient['getPageMode'](LayoutServicePageState.Edit)).to.deep.equal({
+        name: LayoutServicePageState.Edit,
+        isNormal: false,
+        isPreview: false,
+        isEditing: true,
+        isDesignLibrary: false,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+      });
+
+      expect(sitecoreClient['getPageMode'](DesignLibraryMode.Normal)).to.deep.equal({
+        name: DesignLibraryMode.Normal,
+        isNormal: false,
+        isPreview: false,
+        isEditing: false,
+        isDesignLibrary: true,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+      });
+
+      expect(sitecoreClient['getPageMode'](DesignLibraryMode.Metadata)).to.deep.equal({
+        name: DesignLibraryMode.Metadata,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+        isNormal: false,
+        isPreview: false,
+        isEditing: false,
+        isDesignLibrary: true,
+      });
+
+      expect(sitecoreClient['getPageMode'](DesignLibraryMode.VariantGeneration)).to.deep.equal({
+        name: DesignLibraryMode.VariantGeneration,
+        designLibrary: {
+          isVariantGeneration: true,
+        },
+        isNormal: false,
+        isPreview: false,
+        isEditing: false,
+        isDesignLibrary: true,
+      });
+
+      expect(sitecoreClient['getPageMode'](DesignLibraryMode.Normal)).to.deep.equal({
+        name: DesignLibraryMode.Normal,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+        isNormal: false,
+        isPreview: false,
+        isEditing: false,
+        isDesignLibrary: true,
+      });
+
+      expect(sitecoreClient['getPageMode']('invalid-mode' as any)).to.deep.equal({
+        name: 'invalid-mode',
+        isNormal: false,
+        isPreview: false,
+        isEditing: false,
+        isDesignLibrary: false,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+      });
     });
   });
 

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -25,17 +25,30 @@ import { NativeDataFetcher } from '../native-fetcher';
 import { RobotsService } from '../site/robots-service';
 
 /**
+ * Error page codes
+ */
+export enum ErrorPage {
+  NotFound = '404',
+  InternalServerError = '500',
+}
+
+/**
+ * Page mode name
+ */
+type PageModeName = LayoutServicePageState | DesignLibraryMode;
+
+/**
  * Represents the mode of the page
  */
 export type PageMode = {
   /**
-   * Page mode name
+   * Page mode. Defines the specific identifiers for the page.
    */
-  name: LayoutServicePageState | DesignLibraryMode;
+  name: PageModeName;
   /**
    * Design Library related properties. Only available in Design Library mode.
    */
-  designLibrary?: {
+  designLibrary: {
     /**
      * Whether the page is in variant generation mode
      */
@@ -44,19 +57,19 @@ export type PageMode = {
   /**
    * Whether the page is in normal mode
    */
-  isNormal?: boolean;
+  isNormal: boolean;
   /**
    * Whether the page is in preview mode
    */
-  isPreview?: boolean;
+  isPreview: boolean;
   /**
    * Whether the page is in editing mode
    */
-  isEditing?: boolean;
+  isEditing: boolean;
   /**
    * Whether the page is in Design Library mode
    */
-  isDesignLibrary?: boolean;
+  isDesignLibrary: boolean;
 };
 
 /**
@@ -125,7 +138,6 @@ export interface BaseSitecoreClient {
     pageOptions?: PageOptions,
     fetchOptions?: FetchOptions
   ): Promise<Page | null>;
-
   /**
    * Retrieves the robots.txt content for a given site name.
    * @param {string} siteName - The name of the site for which to fetch robots.txt content.
@@ -159,6 +171,18 @@ export interface BaseSitecoreClient {
    */
   getPreview(
     previewData: EditingPreviewData | undefined,
+    fetchOptions?: FetchOptions
+  ): Promise<Page | null>;
+  /**
+   * Get error page details for a given error code
+   * @param {ErrorPage} code - The error code to get the error page for
+   * @param {Partial<RouteOptions>} [pageOptions] - The page options to get the error page for
+   * @param {FetchOptions} [fetchOptions] - Additional fetch fetch options to override GraphQL requests
+   * @returns {Promise<Page | null>} A promise that resolves to the error page details or null if not found
+   */
+  getErrorPage(
+    code: ErrorPage,
+    pageOptions?: Partial<RouteOptions>,
     fetchOptions?: FetchOptions
   ): Promise<Page | null>;
   /**
@@ -300,10 +324,7 @@ export class SitecoreClient implements BaseSitecoreClient {
         layout,
         siteName: layout.sitecore.context.site?.name || site,
         locale,
-        mode: {
-          name: layout.sitecore.context.pageState || LayoutServicePageState.Normal,
-          isNormal: true,
-        },
+        mode: this.getPageMode(LayoutServicePageState.Normal),
       };
     }
   }
@@ -411,11 +432,7 @@ export class SitecoreClient implements BaseSitecoreClient {
       layout: data.layoutData,
       dictionary: data.dictionary,
       siteName: data.layoutData.sitecore.context.site?.name || site,
-      mode: {
-        name: mode,
-        isPreview: mode === LayoutServicePageState.Preview,
-        isEditing: mode === LayoutServicePageState.Edit,
-      },
+      mode: this.getPageMode(mode),
     } as Page;
     const personalizeData = getGroomedVariantIds(variantIds);
     personalizeLayout(page.layout, personalizeData.variantId, personalizeData.componentVariantIds);
@@ -475,15 +492,57 @@ export class SitecoreClient implements BaseSitecoreClient {
       layout: componentData,
       dictionary: dictionaryData,
       siteName: componentData.sitecore.context.site?.name || site,
-      mode: {
-        name: mode,
-        isDesignLibrary: true,
-        designLibrary: {
-          isVariantGeneration: mode === DesignLibraryMode.VariantGeneration,
-        },
-      },
+      mode: this.getPageMode(mode),
     } as Page;
     return page;
+  }
+
+  /**
+   * Get error page details for a given error code
+   * @param {ErrorPage} code - The error code to get the error page for
+   * @param {Partial<RouteOptions>} pageOptions - The page options to get the error page for
+   * @param {FetchOptions} [fetchOptions] - Additional fetch fetch options to override GraphQL requests
+   * @returns {Promise<Page | null>} A promise that resolves to the error page details or null if not found
+   */
+  async getErrorPage(
+    code: ErrorPage,
+    pageOptions?: Partial<RouteOptions>,
+    fetchOptions?: FetchOptions
+  ): Promise<Page | null> {
+    const locale = pageOptions?.locale || this.initOptions.defaultLanguage;
+    const site = pageOptions?.site || this.initOptions.defaultSite;
+
+    const result = await this.getErrorPages(
+      {
+        site,
+        locale,
+      },
+      fetchOptions
+    );
+
+    let layout = null;
+
+    switch (code) {
+      case ErrorPage.NotFound:
+        layout = result?.notFoundPage?.rendered || null;
+        break;
+      case ErrorPage.InternalServerError:
+        layout = result?.serverErrorPage?.rendered || null;
+        break;
+      default:
+        return null;
+    }
+
+    if (!layout) {
+      return null;
+    }
+
+    return {
+      layout,
+      locale,
+      mode: this.getPageMode(LayoutServicePageState.Normal),
+      siteName: site,
+    };
   }
 
   /**
@@ -592,6 +651,48 @@ export class SitecoreClient implements BaseSitecoreClient {
       clientFactory: this.clientFactory,
       retries: this.initOptions.retries,
     };
+  }
+
+  /**
+   * Get page mode based on mode name
+   * @param {PageModeName} mode - The mode name to get the page mode for
+   * @returns {PageMode} The page mode
+   */
+  private getPageMode(mode: PageModeName): PageMode {
+    const pageMode: PageMode = {
+      name: mode,
+      isNormal: false,
+      isPreview: false,
+      isEditing: false,
+      isDesignLibrary: false,
+      designLibrary: {
+        isVariantGeneration: false,
+      },
+    };
+
+    switch (mode) {
+      case LayoutServicePageState.Normal:
+        pageMode.isNormal = true;
+        break;
+      case LayoutServicePageState.Preview:
+        pageMode.isPreview = true;
+        break;
+      case LayoutServicePageState.Edit:
+        pageMode.isEditing = true;
+        break;
+      case DesignLibraryMode.Normal:
+      case DesignLibraryMode.Metadata:
+        pageMode.isDesignLibrary = true;
+        break;
+      case DesignLibraryMode.VariantGeneration:
+        pageMode.isDesignLibrary = true;
+        pageMode.designLibrary.isVariantGeneration = true;
+        break;
+      default:
+        break;
+    }
+
+    return pageMode;
   }
 
   private getClientFactory(): GraphQLRequestClientFactory {

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -42,7 +42,7 @@ type PageModeName = LayoutServicePageState | DesignLibraryMode;
  */
 export type PageMode = {
   /**
-   * Page mode. Defines the specific identifiers for the page.
+   * Page mode name.
    */
   name: PageModeName;
   /**

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -3,6 +3,7 @@ import {
   EditingPreviewData,
   EditingService,
   ComponentLayoutService,
+  DesignLibraryMode,
 } from '../editing';
 import { GraphQLRequestClientFactory } from '../graphql-request-client';
 import { DictionaryPhrases, DictionaryService } from '../i18n';
@@ -12,6 +13,7 @@ import {
   LayoutService,
   LayoutServiceData,
   RouteOptions,
+  LayoutServicePageState,
 } from '../layout';
 import { HTMLLink, FetchOptions, StaticPath, RetryStrategy } from '../models';
 import { getGroomedVariantIds, PersonalizedRewriteData } from '../personalize/utils';
@@ -21,6 +23,41 @@ import { SitecoreClientInit } from './models';
 import { createGraphQLClientFactory, GraphQLClientOptions } from './utils';
 import { NativeDataFetcher } from '../native-fetcher';
 import { RobotsService } from '../site/robots-service';
+
+/**
+ * Represents the mode of the page
+ */
+export type PageMode = {
+  /**
+   * Page mode name
+   */
+  name: LayoutServicePageState | DesignLibraryMode;
+  /**
+   * Design Library related properties. Only available in Design Library mode.
+   */
+  designLibrary?: {
+    /**
+     * Whether the page is in variant generation mode
+     */
+    isVariantGeneration: boolean;
+  };
+  /**
+   * Whether the page is in normal mode
+   */
+  isNormal?: boolean;
+  /**
+   * Whether the page is in preview mode
+   */
+  isPreview?: boolean;
+  /**
+   * Whether the page is in editing mode
+   */
+  isEditing?: boolean;
+  /**
+   * Whether the page is in Design Library mode
+   */
+  isDesignLibrary?: boolean;
+};
 
 /**
  * Represent a Page model returned from Edge endpoint
@@ -38,6 +75,10 @@ export type Page = {
    * Route locale
    */
   locale: string;
+  /**
+   * Page mode
+   */
+  mode: PageMode;
 };
 
 export type PageOptions = Partial<RouteOptions> & {
@@ -259,6 +300,10 @@ export class SitecoreClient implements BaseSitecoreClient {
         layout,
         siteName: layout.sitecore.context.site?.name || site,
         locale,
+        mode: {
+          name: layout.sitecore.context.pageState || LayoutServicePageState.Normal,
+          isNormal: true,
+        },
       };
     }
   }
@@ -366,6 +411,11 @@ export class SitecoreClient implements BaseSitecoreClient {
       layout: data.layoutData,
       dictionary: data.dictionary,
       siteName: data.layoutData.sitecore.context.site?.name || site,
+      mode: {
+        name: mode,
+        isPreview: mode === LayoutServicePageState.Preview,
+        isEditing: mode === LayoutServicePageState.Edit,
+      },
     } as Page;
     const personalizeData = getGroomedVariantIds(variantIds);
     personalizeLayout(page.layout, personalizeData.variantId, personalizeData.componentVariantIds);
@@ -425,6 +475,13 @@ export class SitecoreClient implements BaseSitecoreClient {
       layout: componentData,
       dictionary: dictionaryData,
       siteName: componentData.sitecore.context.site?.name || site,
+      mode: {
+        name: mode,
+        isDesignLibrary: true,
+        designLibrary: {
+          isVariantGeneration: mode === DesignLibraryMode.VariantGeneration,
+        },
+      },
     } as Page;
     return page;
   }

--- a/packages/core/src/editing/design-library.test.ts
+++ b/packages/core/src/editing/design-library.test.ts
@@ -7,6 +7,9 @@ import {
   DesignLibraryStatus,
   getDesignLibraryScriptLink,
   isDesignLibraryMode,
+  getDesignLibraryComponentPropsEvent,
+  getDesignLibraryImportMapEvent,
+  addComponentPreviewHandler,
 } from './design-library';
 import testComponent from '../test-data/component-editing-data';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
@@ -152,6 +155,148 @@ describe('component library utils', () => {
       });
       updateComponentHandler(message, changedComponent, callbackStub);
       expect(callbackStub.called).to.be.true;
+    });
+  });
+
+  describe('addComponentPreviewHandler', () => {
+    let windowSpy: sinon.SinonSpy;
+    let addEventListenerSpy: sinon.SinonSpy;
+    let removeEventListenerSpy: sinon.SinonSpy;
+    let callbackStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      addEventListenerSpy = sinon.spy();
+      removeEventListenerSpy = sinon.spy();
+      global.window = {} as any;
+      windowSpy = sinon.stub(global, 'window' as any).value({
+        addEventListener: addEventListenerSpy,
+        removeEventListener: removeEventListenerSpy,
+      });
+      callbackStub = sinon.stub();
+    });
+
+    afterEach(() => {
+      windowSpy.restore();
+    });
+
+    it('should add event listener for message events', () => {
+      const unsubscribe = addComponentPreviewHandler(callbackStub);
+      expect(addEventListenerSpy.calledOnce).to.be.true;
+      expect(addEventListenerSpy.calledWith('message')).to.be.true;
+      expect(typeof unsubscribe).to.equal('function');
+    });
+
+    it('should ignore events without origin', () => {
+      addComponentPreviewHandler(callbackStub);
+      const handler = addEventListenerSpy.getCall(0).args[1];
+      const message = new MessageEvent('message', {
+        data: { name: 'component:generation:component-preview' },
+      });
+      handler(message);
+      expect(callbackStub.called).to.be.false;
+    });
+
+    it('should ignore events with wrong event name', () => {
+      addComponentPreviewHandler(callbackStub);
+      const handler = addEventListenerSpy.getCall(0).args[1];
+      const message = new MessageEvent('message', {
+        origin: 'http://localhost',
+        data: { name: 'component:test' },
+      });
+      handler(message);
+      expect(callbackStub.called).to.be.false;
+    });
+
+    it('should ignore events without data', () => {
+      addComponentPreviewHandler(callbackStub);
+      const handler = addEventListenerSpy.getCall(0).args[1];
+      const message = new MessageEvent('message', {
+        origin: 'http://localhost',
+        data: null,
+      });
+      handler(message);
+      expect(callbackStub.called).to.be.false;
+    });
+
+    it('should handle valid component preview events', () => {
+      addComponentPreviewHandler(callbackStub);
+      const handler = addEventListenerSpy.getCall(0).args[1];
+      const eventData = {
+        name: 'component:generation:component-preview',
+        message: {
+          uid: 'test-uid',
+          code: {},
+          styles: {},
+          imports: {},
+        },
+      };
+      const message = new MessageEvent('message', {
+        origin: 'http://localhost',
+        data: eventData,
+      });
+
+      handler(message);
+
+      expect(debugSpy.calledWith('Component Library: message received', eventData)).to.be.true;
+      expect(callbackStub.calledOnce).to.be.true;
+      expect(callbackStub.calledWith(null)).to.be.true;
+    });
+
+    it('should unsubscribe from component preview event', () => {
+      const unsubscribe = addComponentPreviewHandler(callbackStub);
+
+      if (unsubscribe) {
+        unsubscribe();
+      }
+
+      expect(removeEventListenerSpy.calledOnce).to.be.true;
+      expect(removeEventListenerSpy.calledWith('message')).to.be.true;
+    });
+  });
+
+  describe('getDesignLibraryImportMapEvent', () => {
+    it('should return a valid import map event', () => {
+      const importMapEvent = getDesignLibraryImportMapEvent('uid-1', [
+        {
+          module: 'react',
+          exports: [{ name: 'default', value: 'React' }],
+        },
+      ]);
+
+      expect(importMapEvent).to.deep.equal({
+        name: 'component:generation:import-map',
+        message: {
+          uid: 'uid-1',
+          importsMap: [{ module: 'react', exports: [{ name: 'default', value: 'React' }] }],
+        },
+      });
+    });
+  });
+
+  describe('getDesignLibraryComponentPropsEvent', () => {
+    it('should return a valid component props event', () => {
+      const componentPropsEvent = getDesignLibraryComponentPropsEvent(
+        'uid-1',
+        {
+          content: { value: 'test' },
+        },
+        {
+          param1: 'value1',
+        }
+      );
+
+      expect(componentPropsEvent).to.deep.equal({
+        name: 'component:generation:component-props',
+        message: {
+          uid: 'uid-1',
+          fields: {
+            content: { value: 'test' },
+          },
+          parameters: {
+            param1: 'value1',
+          },
+        },
+      });
     });
   });
 

--- a/packages/core/src/editing/design-library.ts
+++ b/packages/core/src/editing/design-library.ts
@@ -1,4 +1,10 @@
-import { ComponentRendering, Field, GenericFieldValue } from '../layout/models';
+import {
+  ComponentFields,
+  ComponentParams,
+  ComponentRendering,
+  Field,
+  GenericFieldValue,
+} from '../layout/models';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 import { normalizeUrl } from '../utils/normalize-url';
 import { DesignLibraryMode } from './models';
@@ -7,6 +13,26 @@ import { DesignLibraryMode } from './models';
  * Event to be sent when report status to design library
  */
 export const DESIGN_LIBRARY_STATUS_EVENT_NAME = 'component:status';
+
+/**
+ * Event to send import map to design library
+ */
+export const DESIGN_LIBRARY_IMPORT_MAP_EVENT_NAME = 'component:generation:import-map';
+
+/**
+ * Event to send component props to design library
+ */
+export const DESIGN_LIBRARY_COMPONENT_PROPS_EVENT_NAME = 'component:generation:component-props';
+
+/**
+ * Event to receive component data from design library
+ */
+export const DESIGN_LIBRARY_COMPONENT_PREVIEW_EVENT_NAME = 'component:generation:component-preview';
+
+export interface ImportEntry {
+  module: string;
+  exports: { name: string | 'default' | '*'; value: unknown }[];
+}
 
 /**
  * Represents an event indicating the status of a component in the library.
@@ -20,11 +46,61 @@ export interface DesignLibraryStatusEvent {
 }
 
 /**
+ * Represents an event indicating the import map to be sent to design library
+ */
+export interface DesignLibraryImportMapEvent {
+  name: typeof DESIGN_LIBRARY_IMPORT_MAP_EVENT_NAME;
+  message: {
+    uid: string;
+    importsMap: ImportEntry[];
+  };
+}
+
+/**
+ * Represents an event indicating the component props to be sent to design library
+ */
+export interface DesignLibraryComponentPropsEvent {
+  name: typeof DESIGN_LIBRARY_COMPONENT_PROPS_EVENT_NAME;
+  message: {
+    uid: string;
+    fields: ComponentFields;
+    parameters: ComponentParams;
+  };
+}
+
+/**
  * Enumeration of statuses for the design library.
  */
 export enum DesignLibraryStatus {
   READY = 'ready',
   RENDERED = 'rendered',
+}
+
+/**
+ * Represents an component preview event data sent from design library
+ */
+export interface ComponentPreviewEventArgs {
+  name: typeof DESIGN_LIBRARY_COMPONENT_PREVIEW_EVENT_NAME;
+  message: {
+    uid: string;
+    code: {
+      type: 'function';
+      content: string;
+    };
+    styles: {
+      type: 'style-element';
+      content: string;
+      styleImport: {
+        name: string;
+        content: unknown;
+      };
+    };
+    imports: {
+      module: string;
+      export: string;
+      alias: string;
+    };
+  };
 }
 
 /**
@@ -129,6 +205,68 @@ export const updateComponentHandler = (
 };
 
 /**
+ * Adds the browser-side event handler for 'component:generation:component-preview' message used in Design Library
+ * The event should contain the component code, styles and imports.
+ * @param {Function} callback callback to be called after component is received
+ */
+export const addComponentPreviewHandler = (callback: (Component: unknown) => void) => {
+  if (!window) return;
+
+  const handler = (e: MessageEvent) => {
+    const eventArgs: ComponentPreviewEventArgs = e.data;
+    if (!e.origin || !eventArgs || eventArgs.name !== DESIGN_LIBRARY_COMPONENT_PREVIEW_EVENT_NAME) {
+      // avoid extra noise in logs
+      if (!validateOrigin(e)) {
+        console.debug(
+          'Component Library: event skipped: message %s from origin %s',
+          eventArgs.name,
+          e.origin
+        );
+      }
+      return;
+    }
+
+    console.debug('Component Library: message received', eventArgs);
+
+    const exports: { [key: string]: unknown } = { Component: null };
+
+    // Component resolution will be done here
+
+    callback(exports.Component);
+  };
+
+  window.addEventListener('message', handler);
+
+  const unsubscribe = () => {
+    window.removeEventListener('message', handler);
+  };
+
+  return unsubscribe;
+};
+
+/**
+ * Generates a DesignLibraryComponentPropsEvent with the given uid, fields and parameters.
+ * @param {string} uid - The unique identifier for the event.
+ * @param {ComponentFields} fields - The fields of the component.
+ * @param {ComponentParams} parameters - The parameters of the component.
+ * @returns An object representing the DesignLibraryComponentPropsEvent.
+ */
+export function getDesignLibraryComponentPropsEvent(
+  uid: string,
+  fields: ComponentFields,
+  parameters: ComponentParams
+): DesignLibraryComponentPropsEvent {
+  return {
+    name: DESIGN_LIBRARY_COMPONENT_PROPS_EVENT_NAME,
+    message: {
+      uid,
+      fields,
+      parameters,
+    },
+  };
+}
+
+/**
  * Generates a DesignLibraryStatusEvent with the given status and uid.
  * @param {DesignLibraryStatus} status - The status of rendering.
  * @param {string} uid - The unique identifier for the event.
@@ -148,6 +286,25 @@ export function getDesignLibraryStatusEvent(
 }
 
 /**
+ * Generates a DesignLibraryImportMapEvent with the given uid and importsMap.
+ * @param {string} uid - The unique identifier for the event.
+ * @param {ImportEntry[]} importsMap - The imports map to be sent.
+ * @returns An object representing the DesignLibraryImportMapEvent.
+ */
+export function getDesignLibraryImportMapEvent(
+  uid: string,
+  importsMap: ImportEntry[]
+): DesignLibraryImportMapEvent {
+  return {
+    name: DESIGN_LIBRARY_IMPORT_MAP_EVENT_NAME,
+    message: {
+      uid,
+      importsMap,
+    },
+  };
+}
+
+/**
  * Generates the URL for the design library script link.
  * @param {string} [sitecoreEdgeUrl] Sitecore Edge Platform URL. Default is https://edge-platform.sitecorecloud.io
  * @returns The full URL to the design library script.
@@ -162,5 +319,9 @@ export function getDesignLibraryScriptLink(sitecoreEdgeUrl = SITECORE_EDGE_URL_D
  * @returns {boolean} True if the mode is a Design Library mode, false otherwise.
  */
 export function isDesignLibraryMode(mode: unknown): mode is DesignLibraryMode {
-  return mode === DesignLibraryMode.Normal || mode === DesignLibraryMode.Metadata;
+  return (
+    mode === DesignLibraryMode.Normal ||
+    mode === DesignLibraryMode.Metadata ||
+    mode === DesignLibraryMode.VariantGeneration
+  );
 }

--- a/packages/core/src/editing/design-library.ts
+++ b/packages/core/src/editing/design-library.ts
@@ -77,7 +77,7 @@ export enum DesignLibraryStatus {
 }
 
 /**
- * Represents an component preview event data sent from design library
+ * Represents a component preview event data sent from design library
  */
 export interface ComponentPreviewEventArgs {
   name: typeof DESIGN_LIBRARY_COMPONENT_PREVIEW_EVENT_NAME;

--- a/packages/core/src/editing/design-library.ts
+++ b/packages/core/src/editing/design-library.ts
@@ -12,22 +12,22 @@ import { DesignLibraryMode } from './models';
 /**
  * Event to be sent when report status to design library
  */
-export const DESIGN_LIBRARY_STATUS_EVENT_NAME = 'component:status';
+const DESIGN_LIBRARY_STATUS_EVENT_NAME = 'component:status';
 
 /**
  * Event to send import map to design library
  */
-export const DESIGN_LIBRARY_IMPORT_MAP_EVENT_NAME = 'component:generation:import-map';
+const DESIGN_LIBRARY_IMPORT_MAP_EVENT_NAME = 'component:generation:import-map';
 
 /**
  * Event to send component props to design library
  */
-export const DESIGN_LIBRARY_COMPONENT_PROPS_EVENT_NAME = 'component:generation:component-props';
+const DESIGN_LIBRARY_COMPONENT_PROPS_EVENT_NAME = 'component:generation:component-props';
 
 /**
  * Event to receive component data from design library
  */
-export const DESIGN_LIBRARY_COMPONENT_PREVIEW_EVENT_NAME = 'component:generation:component-preview';
+const DESIGN_LIBRARY_COMPONENT_PREVIEW_EVENT_NAME = 'component:generation:component-preview';
 
 export interface ImportEntry {
   module: string;
@@ -214,7 +214,7 @@ export const addComponentPreviewHandler = (callback: (Component: unknown) => voi
 
   const handler = (e: MessageEvent) => {
     const eventArgs: ComponentPreviewEventArgs = e.data;
-    if (!e.origin || !eventArgs || eventArgs.name !== DESIGN_LIBRARY_COMPONENT_PREVIEW_EVENT_NAME) {
+    if (!e.origin || !eventArgs || eventArgs.name !== 'component:generation:component-preview') {
       // avoid extra noise in logs
       if (!validateOrigin(e)) {
         console.debug(

--- a/packages/core/src/editing/index.ts
+++ b/packages/core/src/editing/index.ts
@@ -26,6 +26,12 @@ export {
   DesignLibraryStatus,
   DesignLibraryStatusEvent,
   getDesignLibraryStatusEvent,
+  addComponentPreviewHandler,
+  DesignLibraryImportMapEvent,
+  DesignLibraryComponentPropsEvent,
+  getDesignLibraryComponentPropsEvent,
+  getDesignLibraryImportMapEvent,
+  ImportEntry,
   getDesignLibraryScriptLink,
   isDesignLibraryMode,
 } from './design-library';

--- a/packages/core/src/editing/models.ts
+++ b/packages/core/src/editing/models.ts
@@ -87,7 +87,7 @@ export interface DesignLibraryRenderPreviewData {
   renderingId: string;
   componentUid: string;
   language: string;
-  mode?: DesignLibraryMode;
+  mode: DesignLibraryMode;
   variant?: string;
   version?: string;
   dataSourceId?: string;

--- a/packages/core/src/editing/models.ts
+++ b/packages/core/src/editing/models.ts
@@ -74,6 +74,8 @@ export enum DesignLibraryMode {
   Normal = 'library',
   /** Metadata mode */
   Metadata = 'library-metadata',
+  /** Variant generation mode */
+  VariantGeneration = 'library-variant-generation',
 }
 
 /**

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/Bootstrap.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/Bootstrap.tsx
@@ -1,17 +1,24 @@
 ﻿import { useEffect, JSX } from 'react';
 import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
+import { SitecorePageProps } from '@sitecore-content-sdk/nextjs';
 import '@sitecore-cloudsdk/events/browser';
 import config from 'sitecore.config';
-import { SitecorePageProps } from '@sitecore-content-sdk/nextjs';
 
 /**
  * The Bootstrap component is the entry point for performing any initialization logic
  * that needs to happen early in the application's lifecycle.
  */
 const Bootstrap = (props: SitecorePageProps): JSX.Element | null => {
+  const { page } = props;
+
   // Browser ClientSDK init allows for page view events to be tracked
+
   useEffect(() => {
-    const mode = props.mode;
+    if (!page) {
+      return;
+    }
+
+    const mode = page.mode;
     if (process.env.NODE_ENV === 'development')
       console.debug('Browser Events SDK is not initialized in development environment');
     else if (!mode.isNormal)
@@ -21,7 +28,7 @@ const Bootstrap = (props: SitecorePageProps): JSX.Element | null => {
         CloudSDK({
           sitecoreEdgeUrl: config.api.edge.edgeUrl,
           sitecoreEdgeContextId: config.api.edge.clientContextId,
-          siteName: props.siteName || config.defaultSite,
+          siteName: page.siteName || config.defaultSite,
           enableBrowserCookie: true,
           // Replace with the top level cookie domain of the website that is being integrated e.g ".example.com" and not "www.example.com"
           cookieDomain: window.location.hostname.replace(/^www\./, ''),
@@ -33,7 +40,7 @@ const Bootstrap = (props: SitecorePageProps): JSX.Element | null => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.siteName]);
+  }, [page?.siteName]);
 
   return null;
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/Bootstrap.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/Bootstrap.tsx
@@ -2,11 +2,7 @@
 import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
 import '@sitecore-cloudsdk/events/browser';
 import config from 'sitecore.config';
-import {
-  LayoutServicePageState,
-  SitecorePageProps,
-  RenderingType,
-} from '@sitecore-content-sdk/nextjs';
+import { SitecorePageProps } from '@sitecore-content-sdk/nextjs';
 
 /**
  * The Bootstrap component is the entry point for performing any initialization logic
@@ -15,14 +11,10 @@ import {
 const Bootstrap = (props: SitecorePageProps): JSX.Element | null => {
   // Browser ClientSDK init allows for page view events to be tracked
   useEffect(() => {
-    const pageState = props.layout?.sitecore?.context.pageState;
-    const renderingType = props.layout?.sitecore?.context.renderingType;
+    const mode = props.mode;
     if (process.env.NODE_ENV === 'development')
       console.debug('Browser Events SDK is not initialized in development environment');
-    else if (
-      pageState !== LayoutServicePageState.Normal ||
-      renderingType === RenderingType.Component
-    )
+    else if (!mode.isNormal)
       console.debug('Browser Events SDK is not initialized in edit and preview modes');
     else {
       if (config.api.edge?.clientContextId) {

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/Layout.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/Layout.tsx
@@ -8,13 +8,14 @@ import {
   LayoutServiceData,
   Field,
   DesignLibrary,
-  RenderingType,
+  PageMode,
 } from '@sitecore-content-sdk/nextjs';
 import Scripts from 'src/Scripts';
 import SitecoreStyles from 'src/components/content-sdk/SitecoreStyles';
 
 interface LayoutProps {
   layoutData: LayoutServiceData;
+  mode: PageMode;
 }
 
 interface RouteFields {
@@ -22,11 +23,10 @@ interface RouteFields {
   Title?: Field;
 }
 
-const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
+const Layout = ({ layoutData, mode }: LayoutProps): JSX.Element => {
   const { route } = layoutData.sitecore;
   const fields = route?.fields as RouteFields;
-  const isPageEditing = layoutData.sitecore.context.pageEditing;
-  const mainClassPageEditing = isPageEditing ? 'editing-mode' : 'prod-mode';
+  const mainClassPageEditing = mode.isEditing ? 'editing-mode' : 'prod-mode';
 
   return (
     <>
@@ -39,8 +39,8 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
 
       {/* root placeholder for the app, which we add components to using route data */}
       <div className={mainClassPageEditing}>
-        {layoutData.sitecore.context.renderingType === RenderingType.Component ? (
-          <DesignLibrary {...layoutData} />
+        {mode.isDesignLibrary ? (
+          <DesignLibrary />
         ) : (
           <>
             <header>

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/Layout.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/Layout.tsx
@@ -3,19 +3,12 @@
  */
 import React, { JSX } from 'react';
 import Head from 'next/head';
-import {
-  Placeholder,
-  LayoutServiceData,
-  Field,
-  DesignLibrary,
-  PageMode,
-} from '@sitecore-content-sdk/nextjs';
+import { Placeholder, Field, DesignLibrary, Page } from '@sitecore-content-sdk/nextjs';
 import Scripts from 'src/Scripts';
 import SitecoreStyles from 'src/components/content-sdk/SitecoreStyles';
 
 interface LayoutProps {
-  layoutData: LayoutServiceData;
-  mode: PageMode;
+  page: Page;
 }
 
 interface RouteFields {
@@ -23,15 +16,16 @@ interface RouteFields {
   Title?: Field;
 }
 
-const Layout = ({ layoutData, mode }: LayoutProps): JSX.Element => {
-  const { route } = layoutData.sitecore;
+const Layout = ({ page }: LayoutProps): JSX.Element => {
+  const { layout, mode } = page;
+  const { route } = layout.sitecore;
   const fields = route?.fields as RouteFields;
   const mainClassPageEditing = mode.isEditing ? 'editing-mode' : 'prod-mode';
 
   return (
     <>
       <Scripts />
-      <SitecoreStyles layoutData={layoutData} />
+      <SitecoreStyles layoutData={layout} />
       <Head>
         <title>{fields?.Title?.value?.toString() || 'Page'}</title>
         <link rel="icon" href="/favicon.ico" />

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/byoc/index.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/byoc/index.tsx
@@ -1,13 +1,10 @@
 ﻿import React, { JSX } from 'react';
 import * as FEAAS from '@sitecore-feaas/clientside/react';
 import * as Events from '@sitecore-cloudsdk/events/browser';
+import { LayoutServicePageState, SitecoreProviderReactContext } from '@sitecore-content-sdk/nextjs';
 import '@sitecore/components/context';
 import dynamic from 'next/dynamic';
 import config from 'sitecore.config';
-import {
-  LayoutServicePageState,
-  SitecoreProviderReactContext,
-} from '@sitecore-content-sdk/nextjs';
 /**
  * This is an out-of-box bundler for External components (BYOC) (see Sitecore documentation for more details)
  * It enables registering components in client-only or SSR/hybrid contexts
@@ -27,13 +24,14 @@ FEAAS.enableNextClientsideComponents(dynamic, ClientBundle);
 import './index.hybrid';
 
 const BYOCInit = (): JSX.Element | null => {
-  const pageContext = React.useContext(SitecoreProviderReactContext).pageContext;
+  const { page } = React.useContext(SitecoreProviderReactContext);
+  const { pageState } = page.layout.sitecore.context;
   // Set context properties to be available within BYOC components
   FEAAS.setContextProperties({
     sitecoreEdgeUrl: config.api.edge?.edgeUrl,
     sitecoreEdgeContextId: config.api.edge?.contextId,
-    pageState: pageContext?.pageState || LayoutServicePageState.Normal,
-    siteName: pageContext?.site?.name || config.defaultSite,
+    pageState: pageState || LayoutServicePageState.Normal,
+    siteName: page.siteName || config.defaultSite,
     eventsSDK: Events,
   });
 

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/components/content-sdk/CdpPageView.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/components/content-sdk/CdpPageView.tsx
@@ -12,8 +12,9 @@ import { JSX } from 'react';
  */
 const CdpPageView = (): JSX.Element => {
   const {
-    pageContext: { route, variantId, site, mode },
+    page: { layout, siteName, mode },
   } = useSitecore();
+  const { route, context } = layout.sitecore;
 
   /**
    * Determines if the page view events should be turned off.
@@ -40,7 +41,7 @@ const CdpPageView = (): JSX.Element => {
     const pageVariantId = CdpHelper.getPageVariantId(
       route.itemId,
       language,
-      variantId as string,
+      context.variantId as string,
       scope
     );
     // there can be cases where Events are not initialized which are expected to reject
@@ -50,8 +51,8 @@ const CdpPageView = (): JSX.Element => {
       page: route.name,
       pageVariantId,
       language,
-    }).catch(e => console.debug(e));
-  }, [mode, route, variantId, site]);
+    }).catch((e) => console.debug(e));
+  }, [mode, route, context.variantId, siteName]);
 
   return <></>;
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/components/content-sdk/CdpPageView.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/components/content-sdk/CdpPageView.tsx
@@ -1,4 +1,4 @@
-﻿import { CdpHelper, LayoutServicePageState, useSitecore } from '@sitecore-content-sdk/nextjs';
+﻿import { CdpHelper, useSitecore } from '@sitecore-content-sdk/nextjs';
 import { useEffect } from 'react';
 import { pageView } from '@sitecore-cloudsdk/events/browser';
 import config from 'sitecore.config';
@@ -12,7 +12,7 @@ import { JSX } from 'react';
  */
 const CdpPageView = (): JSX.Element => {
   const {
-    pageContext: { pageState, route, variantId, site },
+    pageContext: { route, variantId, site, mode },
   } = useSitecore();
 
   /**
@@ -26,7 +26,7 @@ const CdpPageView = (): JSX.Element => {
 
   useEffect(() => {
     // Do not create events in editing or preview mode or if missing route data
-    if (pageState !== LayoutServicePageState.Normal || !route?.itemId) {
+    if (!mode.isNormal || !route?.itemId) {
       return;
     }
     // Do not create events if disabled (e.g. we don't have consent)
@@ -51,7 +51,7 @@ const CdpPageView = (): JSX.Element => {
       pageVariantId,
       language,
     }).catch(e => console.debug(e));
-  }, [pageState, route, variantId, site]);
+  }, [mode, route, variantId, site]);
 
   return <></>;
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/lib/component-props/index.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/lib/component-props/index.ts
@@ -1,8 +1,4 @@
-﻿import {
-  ComponentParams,
-  ComponentRendering,
-  SitecoreProviderPageContext,
-} from '@sitecore-content-sdk/nextjs';
+﻿import { ComponentParams, ComponentRendering, Page } from '@sitecore-content-sdk/nextjs';
 
 /**
  * Shared component props
@@ -28,10 +24,10 @@ export type ComponentProps = {
 
 /**
  * Component props with context
- * You can access `pageContext` by withSitecore/useSitecore
+ * You can access `page` by withSitecore/useSitecore
  * @example withSitecore()(ContentBlock)
- * @example const { pageContext } = useSitecore()
+ * @example const { page } = useSitecore()
  */
 export type ComponentWithContextProps = ComponentProps & {
-  pageContext: SitecoreProviderPageContext;
+  page: Page;
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/404.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/404.tsx
@@ -1,5 +1,10 @@
 import config from 'sitecore.config';
-import { SitecoreProvider, ErrorPages, SitecorePageProps } from '@sitecore-content-sdk/nextjs';
+import {
+  SitecoreProvider,
+  ErrorPages,
+  SitecorePageProps,
+  LayoutServicePageState,
+} from '@sitecore-content-sdk/nextjs';
 import NotFound from 'src/NotFound';
 import Layout from 'src/Layout';
 import { GetStaticProps } from 'next';
@@ -14,8 +19,13 @@ const Custom404 = (props: SitecorePageProps): JSX.Element => {
   }
 
   return (
-    <SitecoreProvider api={scConfig.api} componentMap={components} layoutData={props.layout}>
-      <Layout layoutData={props.layout} />
+    <SitecoreProvider
+      api={scConfig.api}
+      componentMap={components}
+      layoutData={props.layout}
+      mode={props.mode}
+    >
+      <Layout layoutData={props.layout} mode={props.mode} />
     </SitecoreProvider>
   );
 };
@@ -38,6 +48,10 @@ export const getStaticProps: GetStaticProps = async context => {
   return {
     props: {
       layout: resultErrorPages?.notFoundPage?.rendered || null,
+      mode: {
+        name: LayoutServicePageState.Normal,
+        isNormal: true,
+      },
     },
   };
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/404.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/404.tsx
@@ -1,10 +1,4 @@
-import config from 'sitecore.config';
-import {
-  SitecoreProvider,
-  ErrorPages,
-  SitecorePageProps,
-  LayoutServicePageState,
-} from '@sitecore-content-sdk/nextjs';
+import { SitecoreProvider, SitecorePageProps, ErrorPage, Page } from '@sitecore-content-sdk/nextjs';
 import NotFound from 'src/NotFound';
 import Layout from 'src/Layout';
 import { GetStaticProps } from 'next';
@@ -14,30 +8,25 @@ import components from '.sitecore/component-map';
 import { JSX } from 'react';
 
 const Custom404 = (props: SitecorePageProps): JSX.Element => {
-  if (!(props && props.layout)) {
+  if (!(props && props.page)) {
     return <NotFound />;
   }
 
   return (
-    <SitecoreProvider
-      api={scConfig.api}
-      componentMap={components}
-      layoutData={props.layout}
-      mode={props.mode}
-    >
-      <Layout layoutData={props.layout} mode={props.mode} />
+    <SitecoreProvider api={scConfig.api} componentMap={components} page={props.page}>
+      <Layout page={props.page} />
     </SitecoreProvider>
   );
 };
 
-export const getStaticProps: GetStaticProps = async context => {
-  let resultErrorPages: ErrorPages | null = null;
+export const getStaticProps: GetStaticProps = async (context) => {
+  let page: Page | null = null;
 
   if (scConfig.generateStaticPaths) {
     try {
-      resultErrorPages = await client.getErrorPages({
-        site: config.defaultSite,
-        locale: context.locale || context.defaultLocale || config.defaultLanguage,
+      page = await client.getErrorPage(ErrorPage.NotFound, {
+        site: scConfig.defaultSite,
+        locale: context.locale || context.defaultLocale || scConfig.defaultLanguage,
       });
     } catch (error) {
       console.log('Error occurred while fetching error pages');
@@ -47,11 +36,7 @@ export const getStaticProps: GetStaticProps = async context => {
 
   return {
     props: {
-      layout: resultErrorPages?.notFoundPage?.rendered || null,
-      mode: {
-        name: LayoutServicePageState.Normal,
-        isNormal: true,
-      },
+      page,
     },
   };
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
@@ -1,5 +1,10 @@
 ﻿import Head from 'next/head';
-import { SitecoreProvider, ErrorPages, SitecorePageProps } from '@sitecore-content-sdk/nextjs';
+import {
+  SitecoreProvider,
+  ErrorPages,
+  SitecorePageProps,
+  LayoutServicePageState,
+} from '@sitecore-content-sdk/nextjs';
 import Layout from 'src/Layout';
 import { GetStaticProps } from 'next';
 import scConfig from 'sitecore.config';
@@ -29,8 +34,13 @@ const Custom500 = (props: SitecorePageProps): JSX.Element => {
   }
 
   return (
-    <SitecoreProvider api={scConfig.api} componentMap={components} layoutData={props.layout}>
-      <Layout layoutData={props.layout} />
+    <SitecoreProvider
+      api={scConfig.api}
+      componentMap={components}
+      layoutData={props.layout}
+      mode={props.mode}
+    >
+      <Layout layoutData={props.layout} mode={props.mode} />
     </SitecoreProvider>
   );
 };
@@ -53,6 +63,10 @@ export const getStaticProps: GetStaticProps = async context => {
   return {
     props: {
       layout: resultErrorPages?.serverErrorPage?.rendered || null,
+      mode: {
+        name: LayoutServicePageState.Normal,
+        isNormal: true,
+      },
     },
   };
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
@@ -1,10 +1,5 @@
 ﻿import Head from 'next/head';
-import {
-  SitecoreProvider,
-  ErrorPages,
-  SitecorePageProps,
-  LayoutServicePageState,
-} from '@sitecore-content-sdk/nextjs';
+import { SitecoreProvider, SitecorePageProps, Page, ErrorPage } from '@sitecore-content-sdk/nextjs';
 import Layout from 'src/Layout';
 import { GetStaticProps } from 'next';
 import scConfig from 'sitecore.config';
@@ -29,28 +24,23 @@ const ServerError = (): JSX.Element => (
 );
 
 const Custom500 = (props: SitecorePageProps): JSX.Element => {
-  if (!(props && props.layout)) {
+  if (!(props && props.page)) {
     return <ServerError />;
   }
 
   return (
-    <SitecoreProvider
-      api={scConfig.api}
-      componentMap={components}
-      layoutData={props.layout}
-      mode={props.mode}
-    >
-      <Layout layoutData={props.layout} mode={props.mode} />
+    <SitecoreProvider api={scConfig.api} componentMap={components} page={props.page}>
+      <Layout page={props.page} />
     </SitecoreProvider>
   );
 };
 
-export const getStaticProps: GetStaticProps = async context => {
-  let resultErrorPages: ErrorPages | null = null;
+export const getStaticProps: GetStaticProps = async (context) => {
+  let page: Page | null = null;
 
   if (scConfig.generateStaticPaths) {
     try {
-      resultErrorPages = await client.getErrorPages({
+      page = await client.getErrorPage(ErrorPage.InternalServerError, {
         site: scConfig.defaultSite,
         locale: context.locale || context.defaultLocale || scConfig.defaultLanguage,
       });
@@ -62,11 +52,7 @@ export const getStaticProps: GetStaticProps = async context => {
 
   return {
     props: {
-      layout: resultErrorPages?.serverErrorPage?.rendered || null,
-      mode: {
-        name: LayoutServicePageState.Normal,
-        isNormal: true,
-      },
+      page,
     },
   };
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -22,27 +22,21 @@ import client from 'lib/sitecore-client';
 import components from '.sitecore/component-map';
 import scConfig from 'sitecore.config';
 
-
-const SitecorePage = ({ notFound, componentProps, layout, mode }: SitecorePageProps): JSX.Element => {
+const SitecorePage = ({ page, notFound, componentProps }: SitecorePageProps): JSX.Element => {
   useEffect(() => {
     // Since Sitecore Editor does not support Fast Refresh, need to refresh editor chromes after Fast Refresh finished
     handleEditorFastRefresh();
   }, []);
 
-  if (notFound || !layout.sitecore.route) {
+  if (notFound || !page) {
     // Shouldn't hit this (as long as 'notFound' is being returned below), but just to be safe
     return <NotFound />;
   }
 
   return (
     <ComponentPropsContext value={componentProps || {}}>
-      <SitecoreProvider
-        componentMap={components}
-        layoutData={layout}
-        api={scConfig.api}
-        mode={mode}
-      >
-        <Layout layoutData={layout} mode={mode} />
+      <SitecoreProvider componentMap={components} api={scConfig.api} page={page}>
+        <Layout page={page} />
       </SitecoreProvider>
     </ComponentPropsContext>
   );
@@ -104,7 +98,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
   if (page) {
     props = {
-      ...page,
+      page,
       dictionary: await client.getDictionary({
         site: page.siteName,
         locale: page.locale,

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -23,7 +23,7 @@ import components from '.sitecore/component-map';
 import scConfig from 'sitecore.config';
 
 
-const SitecorePage = ({ notFound, componentProps, layout }: SitecorePageProps): JSX.Element => {
+const SitecorePage = ({ notFound, componentProps, layout, mode }: SitecorePageProps): JSX.Element => {
   useEffect(() => {
     // Since Sitecore Editor does not support Fast Refresh, need to refresh editor chromes after Fast Refresh finished
     handleEditorFastRefresh();
@@ -40,8 +40,9 @@ const SitecorePage = ({ notFound, componentProps, layout }: SitecorePageProps): 
         componentMap={components}
         layoutData={layout}
         api={scConfig.api}
+        mode={mode}
       >
-        <Layout layoutData={layout} />
+        <Layout layoutData={layout} mode={mode} />
       </SitecoreProvider>
     </ComponentPropsContext>
   );

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/_app.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/_app.tsx
@@ -1,9 +1,10 @@
+import { JSX } from 'react';
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
 import Bootstrap from 'src/Bootstrap';
-import 'assets/main.scss';
 import { SitecorePageProps } from '@sitecore-content-sdk/nextjs';
-import { JSX } from 'react';
+import scConfig from 'sitecore.config';
+import 'assets/main.scss';
 
 function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
@@ -16,7 +17,10 @@ function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element
         // Note Next.js does not (currently) provide anything for translation, only i18n routing.
         // If your app is not multilingual, next-localization and references to it can be removed.
       */}
-      <I18nProvider lngDict={dictionary} locale={pageProps.locale}>
+      <I18nProvider
+        lngDict={dictionary}
+        locale={pageProps.page?.locale || scConfig.defaultLanguage}
+      >
         <Component {...rest} />
       </I18nProvider>
     </>

--- a/packages/nextjs/global.d.ts
+++ b/packages/nextjs/global.d.ts
@@ -11,7 +11,6 @@ declare module 'sync-disk-cache' {
 
 declare namespace NodeJS {
   export interface Global {
-    [x: string]: {};
     [key: string]: unknown;
     requestAnimationFrame: (callback: () => void) => void;
     window: Window;

--- a/packages/nextjs/global.d.ts
+++ b/packages/nextjs/global.d.ts
@@ -11,6 +11,7 @@ declare module 'sync-disk-cache' {
 
 declare namespace NodeJS {
   export interface Global {
+    [x: string]: {};
     [key: string]: unknown;
     requestAnimationFrame: (callback: () => void) => void;
     window: Window;

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -9,4 +9,4 @@
   createGraphQLClientFactory,
   SitecoreClientInit,
 } from '@sitecore-content-sdk/core/client';
-export { SitecoreNextjsClient as SitecoreClient, NextjsPage } from './sitecore-nextjs-client';
+export { SitecoreNextjsClient as SitecoreClient } from './sitecore-nextjs-client';

--- a/packages/nextjs/src/client/sitecore-nextjs-client.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.ts
@@ -21,11 +21,6 @@ import {
 } from '@sitecore-content-sdk/core/personalize';
 import { ComponentMap } from '@sitecore-content-sdk/react';
 
-export type NextjsPage = Page & {
-  componentProps?: ComponentPropsCollection;
-  notFound?: boolean;
-};
-
 export class SitecoreNextjsClient extends SitecoreClient {
   protected componentPropsService: ComponentPropsService;
   constructor(protected initOptions: SitecoreClientInit) {
@@ -59,7 +54,7 @@ export class SitecoreNextjsClient extends SitecoreClient {
     path: string | string[],
     pageOptions: PageOptions,
     options?: FetchOptions
-  ): Promise<NextjsPage | null> {
+  ): Promise<Page | null> {
     const resolvedPath = this.parsePath(path);
     // Get variant(s) for personalization (from path), must ensure path is of type string
     const personalizeData =
@@ -83,10 +78,7 @@ export class SitecoreNextjsClient extends SitecoreClient {
    * @param {PreviewData} previewData - The editing preview data for metadata mode.
    * @param {FetchOptions} [fetchOptions] Additional fetch fetch options to override GraphQL requests (like retries and fetch)
    */
-  async getPreview(
-    previewData: PreviewData,
-    fetchOptions?: FetchOptions
-  ): Promise<NextjsPage | null> {
+  async getPreview(previewData: PreviewData, fetchOptions?: FetchOptions): Promise<Page | null> {
     return super.getPreview(previewData as EditingPreviewData, fetchOptions);
   }
 

--- a/packages/nextjs/src/components/NextImage.test.tsx
+++ b/packages/nextjs/src/components/NextImage.test.tsx
@@ -10,11 +10,11 @@ import {
   LayoutServicePageState,
   SitecoreProviderReactContext,
 } from '@sitecore-content-sdk/react';
-import { RenderingType } from '@sitecore-content-sdk/core/layout';
 import { ImageLoader } from 'next/image';
 import { spy, match } from 'sinon';
 import sinonChai from 'sinon-chai';
 import { SinonSpy } from 'sinon';
+import { DesignLibraryMode } from '@sitecore-content-sdk/core/editing';
 
 use(sinonChai);
 const setContext = spy();
@@ -22,6 +22,10 @@ const expect = chai.use(chaiString).expect;
 const testContextProps = {
   pageContext: {
     pageState: LayoutServicePageState.Normal,
+    mode: {
+      name: LayoutServicePageState.Normal,
+      isNormal: true,
+    },
   },
   setContext,
 };
@@ -356,7 +360,10 @@ describe('<NextImage />', () => {
     const testEditingContext = {
       ...testContextProps,
       pageContext: {
-        pageState: LayoutServicePageState.Edit,
+        mode: {
+          name: LayoutServicePageState.Edit,
+          isEditing: true,
+        },
       },
     };
     const testMetadata = {
@@ -538,7 +545,10 @@ describe('<NextImage />', () => {
       const testEditingContext = {
         ...testContextProps,
         pageContext: {
-          pageState: LayoutServicePageState.Edit,
+          mode: {
+            name: LayoutServicePageState.Edit,
+            isEditing: true,
+          },
         },
       };
       const rendered = render(
@@ -553,7 +563,10 @@ describe('<NextImage />', () => {
       const testEditingContext = {
         ...testContextProps,
         pageContext: {
-          pageState: LayoutServicePageState.Preview,
+          mode: {
+            name: LayoutServicePageState.Preview,
+            isPreview: true,
+          },
         },
       };
       const rendered = render(
@@ -564,12 +577,15 @@ describe('<NextImage />', () => {
       expect(rendered?.getAttribute('data-unoptimized')).to.equal('true');
     });
 
-    it('should render unoptimized image in component rendering type', () => {
+    it('should render unoptimized image in Design Library mode', () => {
       const testEditingContext = {
         ...testContextProps,
         pageContext: {
           ...testContextProps.pageContext,
-          renderingType: RenderingType.Component,
+          mode: {
+            name: DesignLibraryMode.Normal,
+            isDesignLibrary: true,
+          },
         },
       };
       const rendered = render(

--- a/packages/nextjs/src/components/NextImage.test.tsx
+++ b/packages/nextjs/src/components/NextImage.test.tsx
@@ -17,17 +17,17 @@ import { SinonSpy } from 'sinon';
 import { DesignLibraryMode } from '@sitecore-content-sdk/core/editing';
 
 use(sinonChai);
-const setContext = spy();
+const setPage = spy();
 const expect = chai.use(chaiString).expect;
 const testContextProps = {
-  pageContext: {
+  page: {
     pageState: LayoutServicePageState.Normal,
     mode: {
       name: LayoutServicePageState.Normal,
       isNormal: true,
     },
   },
-  setContext,
+  setPage,
 };
 
 describe('<NextImage />', () => {
@@ -359,7 +359,7 @@ describe('<NextImage />', () => {
   describe('editMode metadata', () => {
     const testEditingContext = {
       ...testContextProps,
-      pageContext: {
+      page: {
         mode: {
           name: LayoutServicePageState.Edit,
           isEditing: true,
@@ -544,7 +544,7 @@ describe('<NextImage />', () => {
     it('should render unoptimized image in edit mode', () => {
       const testEditingContext = {
         ...testContextProps,
-        pageContext: {
+        page: {
           mode: {
             name: LayoutServicePageState.Edit,
             isEditing: true,
@@ -562,7 +562,7 @@ describe('<NextImage />', () => {
     it('should render unoptimized image in preview mode', () => {
       const testEditingContext = {
         ...testContextProps,
-        pageContext: {
+        page: {
           mode: {
             name: LayoutServicePageState.Preview,
             isPreview: true,
@@ -580,8 +580,8 @@ describe('<NextImage />', () => {
     it('should render unoptimized image in Design Library mode', () => {
       const testEditingContext = {
         ...testContextProps,
-        pageContext: {
-          ...testContextProps.pageContext,
+        page: {
+          ...testContextProps.page,
           mode: {
             name: DesignLibraryMode.Normal,
             isDesignLibrary: true,

--- a/packages/nextjs/src/components/NextImage.tsx
+++ b/packages/nextjs/src/components/NextImage.tsx
@@ -10,11 +10,7 @@ import {
   withEmptyFieldEditingComponent,
 } from '@sitecore-content-sdk/react';
 import Image, { ImageProps as NextImageProperties } from 'next/image';
-import {
-  isFieldValueEmpty,
-  LayoutServicePageState,
-  RenderingType,
-} from '@sitecore-content-sdk/core/layout';
+import { isFieldValueEmpty } from '@sitecore-content-sdk/core/layout';
 
 type NextImageProps = ImageProps & Partial<NextImageProperties>;
 export const NextImage: React.FC<NextImageProps> = withFieldMetadata<NextImageProps>(
@@ -42,10 +38,7 @@ export const NextImage: React.FC<NextImageProps> = withFieldMetadata<NextImagePr
       }
 
       // disable image optimization for Edit / Preview / Component rendering, but preserve original value if true
-      const unoptimized =
-        otherProps.unoptimized ||
-        context.pageContext?.renderingType === RenderingType.Component ||
-        context.pageContext?.pageState !== LayoutServicePageState.Normal;
+      const unoptimized = otherProps.unoptimized || !context.pageContext.mode.isNormal;
 
       const attrs = {
         ...img,

--- a/packages/nextjs/src/components/NextImage.tsx
+++ b/packages/nextjs/src/components/NextImage.tsx
@@ -38,7 +38,7 @@ export const NextImage: React.FC<NextImageProps> = withFieldMetadata<NextImagePr
       }
 
       // disable image optimization for Edit / Preview / Component rendering, but preserve original value if true
-      const unoptimized = otherProps.unoptimized || !context.pageContext.mode.isNormal;
+      const unoptimized = otherProps.unoptimized || !context.page.mode.isNormal;
 
       const attrs = {
         ...img,

--- a/packages/nextjs/src/import-map/default-import-map.ts
+++ b/packages/nextjs/src/import-map/default-import-map.ts
@@ -23,6 +23,7 @@ import React, {
   memo,
   Suspense,
 } from 'react';
+import { ImportEntry } from '@sitecore-content-sdk/core/editing';
 import {
   Link,
   Text,
@@ -37,11 +38,6 @@ import {
   CdpHelper,
   withSitecore,
 } from '..';
-
-export interface ImportEntry {
-  module: string;
-  exports: { name: string | 'default' | '*'; value: unknown }[];
-}
 
 export const defaultImportEntries: ImportEntry[] = [
   /* -------------------- React -------------------- */

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -34,7 +34,7 @@ export {
   EditMode,
   RenderingType,
 } from '@sitecore-content-sdk/core/layout';
-export { PageMode } from '@sitecore-content-sdk/core/client';
+export { PageMode, ErrorPage, Page } from '@sitecore-content-sdk/core/client';
 export { ComponentLayoutService } from '@sitecore-content-sdk/core/editing';
 export { mediaApi } from '@sitecore-content-sdk/core/media';
 export {
@@ -139,7 +139,6 @@ export {
   PlaceholderComponentProps,
   SitecoreProvider,
   SitecoreProviderState,
-  SitecoreProviderPageContext,
   SitecoreProviderReactContext,
   withSitecore,
   useSitecore,

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -34,6 +34,7 @@ export {
   EditMode,
   RenderingType,
 } from '@sitecore-content-sdk/core/layout';
+export { PageMode } from '@sitecore-content-sdk/core/client';
 export { ComponentLayoutService } from '@sitecore-content-sdk/core/editing';
 export { mediaApi } from '@sitecore-content-sdk/core/media';
 export {

--- a/packages/nextjs/src/sharedTypes/sitecore-page-props.ts
+++ b/packages/nextjs/src/sharedTypes/sitecore-page-props.ts
@@ -1,6 +1,10 @@
 import { DictionaryPhrases } from '@sitecore-content-sdk/core/i18n';
-import { NextjsPage } from '../client';
+import { Page } from '@sitecore-content-sdk/core/client';
+import { ComponentPropsCollection } from './component-props';
 
-export type SitecorePageProps = NextjsPage & {
-  dictionary: DictionaryPhrases;
+export type SitecorePageProps = {
+  page: Page | null;
+  dictionary?: DictionaryPhrases;
+  componentProps?: ComponentPropsCollection;
+  notFound?: boolean;
 };

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -1,233 +1,429 @@
-﻿/* eslint-disable no-unused-expressions */
+﻿/* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable no-unused-expressions */
 /* eslint-disable react/prop-types */
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { PageMode } from '@sitecore-content-sdk/core/client';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { DesignLibrary } from './DesignLibrary';
 import { getTestLayoutData } from '../test-data/component-editing-data';
 import { SitecoreProvider } from './SitecoreProvider';
 import { RichText } from './RichText';
 import { Text } from './Text';
 import { Placeholder } from '..';
+
 import {
   DesignLibraryStatus,
   ComponentUpdateEventArgs,
   getDesignLibraryStatusEvent,
+  DesignLibraryMode,
 } from '@sitecore-content-sdk/core/editing';
+import { __mockDependencies } from './DesignLibrary';
 
 describe('<DesignLibrary />', () => {
   const postMessageSpy = sinon.spy(global.window, 'postMessage');
   const components = new Map<string, React.FC>();
 
-  const ContentBlock: React.FC<{
-    [prop: string]: unknown;
-    fields?: { content: { value: string }; heading: { value: string } };
-  }> = (props) => (
-    <div className="test">
-      <RichText field={props.fields?.content} />
-      <Placeholder name="inner" rendering={props.rendering} />
-    </div>
-  );
+  const mode: PageMode = {
+    name: DesignLibraryMode.Normal,
+    isDesignLibrary: true,
+    designLibrary: {
+      isVariantGeneration: false,
+    },
+  };
 
-  const InnerBlock: React.FC<{
-    [prop: string]: unknown;
-    fields?: { text: { value: string } };
-  }> = (props) => (
-    <div className="inner">
-      <Text field={props.fields?.text} />
-    </div>
-  );
+  const variantGenerationMode: PageMode = {
+    name: DesignLibraryMode.VariantGeneration,
+    isDesignLibrary: true,
+    designLibrary: {
+      isVariantGeneration: true,
+    },
+  };
 
-  components.set('ContentBlock', ContentBlock);
-  components.set('InnerBlock', InnerBlock);
+  const api = {
+    edge: {
+      contextId: 'test-context-id',
+      clientContextId: 'test-client-context-id',
+      edgeUrl: 'https://test-edge-url.com',
+    },
+    local: {
+      apiKey: 'test-api-key',
+      apiHost: 'https://test-api-host.com',
+      path: '/test-path',
+    },
+  };
 
-  // eslint-disable-next-line jsdoc/require-jsdoc
-  async function sendUpdateEvent(
-    eventDataDetails: ComponentUpdateEventArgs['details']
-  ): Promise<void> {
-    // jsdom performs postMessage without origin. We work around, ugly (https://github.com/jsdom/jsdom/issues/2745)
-    // jsdom also doesn't consider `new MessageEvent()` to be of class Event - so we go very much around to get it working
-    const updateEvent = document.createEvent('Event');
-    const updateEventData: ComponentUpdateEventArgs = {
-      name: 'component:update',
-      details: eventDataDetails,
+  it('should render null if not in design library mode', () => {
+    const mode = {
+      name: DesignLibraryMode.Normal,
+      isDesignLibrary: false,
+      designLibrary: {
+        isVariantGeneration: false,
+      },
     };
-    updateEvent.initEvent('message', false, true);
-    (updateEvent as any).origin = window.location.origin;
-    (updateEvent as any).data = updateEventData;
-    await fireEvent(window, updateEvent);
-  }
-
-  it('should render', () => {
-    const basicPage = getTestLayoutData();
-    // don't wrap the content in divs
     const rendered = render(
-      <SitecoreProvider componentMap={components}>
-        <DesignLibrary {...basicPage.layoutData} />
+      <SitecoreProvider
+        componentMap={components}
+        layoutData={getTestLayoutData().layoutData}
+        api={api}
+        mode={mode}
+      >
+        <DesignLibrary />
       </SitecoreProvider>,
       { container: document.body }
     );
-    expect(rendered.baseElement.innerHTML).to.equal(
-      [
-        '<main><div id="editing-component">',
-        '<div class="test"><div>',
-        '<p>This is a live set of examples of how to use Content SDK</p>\n',
-        '</div></div></div></main>',
-      ].join('')
-    );
+    expect(rendered.baseElement.innerHTML).to.equal('');
   });
 
-  it('should render component with placeholders', () => {
-    const placeholderPage = getTestLayoutData(true);
-    const rendered = render(
-      <SitecoreProvider componentMap={components} layoutData={placeholderPage.layoutData}>
-        <DesignLibrary {...placeholderPage.layoutData} />
-      </SitecoreProvider>,
-      { container: document.body }
+  describe('Preview', () => {
+    const ContentBlock: React.FC<{
+      [prop: string]: unknown;
+      fields?: { content: { value: string }; heading: { value: string } };
+    }> = (props) => (
+      <div className="test">
+        <RichText field={props.fields?.content} />
+        <Placeholder name="inner" rendering={props.rendering} />
+      </div>
     );
 
-    expect(rendered.baseElement.innerHTML).to.contain(
-      [
-        '<main><div id="editing-component">',
-        '<div class="test"><div>',
-        '<p>This is a live set of examples of how to use Content SDK</p>\n',
-        '</div>',
-        '<div class="inner">',
-        'Its an inner component',
-        '</div></div></div>',
-        '</main>',
-      ].join('')
-    );
-  });
-
-  it('should fire component:ready event', () => {
-    const basicPage = getTestLayoutData();
-    const expectedReadyMessage = getDesignLibraryStatusEvent(
-      DesignLibraryStatus.READY,
-      'test-content'
-    );
-    const rendered = render(
-      <SitecoreProvider componentMap={components} layoutData={basicPage.layoutData}>
-        <DesignLibrary {...basicPage.layoutData} />
-      </SitecoreProvider>,
-      { container: document.body }
+    const InnerBlock: React.FC<{
+      [prop: string]: unknown;
+      fields?: { text: { value: string } };
+    }> = (props) => (
+      <div className="inner">
+        <Text field={props.fields?.text} />
+      </div>
     );
 
-    expect(rendered.baseElement.innerHTML).to.contain(
-      [
-        '<main><div id="editing-component">',
-        '<div class="test"><div>',
-        '<p>This is a live set of examples of how to use Content SDK</p>\n',
-        '</div></div></div></main>',
-      ].join('')
-    );
+    components.set('ContentBlock', ContentBlock);
+    components.set('InnerBlock', InnerBlock);
 
-    expect(
-      postMessageSpy
-        .getCalls()
-        .some((call) => JSON.stringify(call.args[0]) === JSON.stringify(expectedReadyMessage))
-    ).to.be.true;
-  });
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    async function sendUpdateEvent(
+      eventDataDetails: ComponentUpdateEventArgs['details']
+    ): Promise<void> {
+      // jsdom performs postMessage without origin. We work around, ugly (https://github.com/jsdom/jsdom/issues/2745)
+      // jsdom also doesn't consider `new MessageEvent()` to be of class Event - so we go very much around to get it working
+      const updateEvent = document.createEvent('Event');
+      const updateEventData: ComponentUpdateEventArgs = {
+        name: 'component:update',
+        details: eventDataDetails,
+      };
+      updateEvent.initEvent('message', false, true);
+      (updateEvent as any).origin = window.location.origin;
+      (updateEvent as any).data = updateEventData;
+      await fireEvent(window, updateEvent);
+    }
 
-  it('should update root component', async () => {
-    const basicPage = getTestLayoutData();
-    const rendered = render(
-      <SitecoreProvider componentMap={components} layoutData={basicPage.layoutData}>
-        <DesignLibrary {...basicPage.layoutData} />
-      </SitecoreProvider>,
-      { container: document.body }
-    );
-
-    expect(rendered.baseElement.innerHTML).to.contain(
-      [
-        '<main><div id="editing-component">',
-        '<div class="test"><div>',
-        '<p>This is a live set of examples of how to use Content SDK</p>\n',
-        '</div></div></div></main>',
-      ].join('')
-    );
-
-    await sendUpdateEvent({
-      uid: 'test-content',
-      fields: { content: { value: 'new content!' } },
+    it('should render', () => {
+      const basicPage = getTestLayoutData();
+      // don't wrap the content in divs
+      const rendered = render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={basicPage.layoutData}
+          api={api}
+          mode={mode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+      expect(rendered.baseElement.innerHTML).to.equal(
+        [
+          '<main><div id="editing-component">',
+          '<div class="test"><div>',
+          '<p>This is a live set of examples of how to use Content SDK</p>\n',
+          '</div></div></div></main>',
+        ].join('')
+      );
     });
 
-    expect(rendered.baseElement.innerHTML).to.contain(
-      [
-        '<main><div id="editing-component">',
-        '<div class="test"><div>',
-        'new content!',
-        '</div></div></div></main>',
-      ].join('')
-    );
-  });
+    it('should render component with placeholders', () => {
+      const placeholderPage = getTestLayoutData(true);
+      const rendered = render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={placeholderPage.layoutData}
+          api={api}
+          mode={mode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
 
-  it('should update nested component', async () => {
-    const basicPage = getTestLayoutData();
-    const placeholderPage = getTestLayoutData(true);
-    const rendered = render(
-      <SitecoreProvider componentMap={components} layoutData={basicPage.layoutData}>
-        <DesignLibrary {...placeholderPage.layoutData} />
-      </SitecoreProvider>,
-      { container: document.body }
-    );
-
-    expect(rendered.baseElement.innerHTML).to.contain(
-      [
-        '<main><div id="editing-component">',
-        '<div class="test"><div>',
-        '<p>This is a live set of examples of how to use Content SDK</p>\n',
-        '</div>',
-        '<div class="inner">',
-        'Its an inner component',
-        '</div></div></div>',
-        '</main>',
-      ].join('')
-    );
-
-    await sendUpdateEvent({
-      uid: 'test-inner',
-      fields: { text: { value: 'new inner content!' } },
+      expect(rendered.baseElement.innerHTML).to.contain(
+        [
+          '<main><div id="editing-component">',
+          '<div class="test"><div>',
+          '<p>This is a live set of examples of how to use Content SDK</p>\n',
+          '</div>',
+          '<div class="inner">',
+          'Its an inner component',
+          '</div></div></div>',
+          '</main>',
+        ].join('')
+      );
     });
 
-    expect(rendered.baseElement.innerHTML).to.contain(
-      [
-        '<main><div id="editing-component">',
-        '<div class="test"><div>',
-        '<p>This is a live set of examples of how to use Content SDK</p>\n',
-        '</div>',
-        '<div class="inner">',
-        'new inner content!',
-        '</div></div></div>',
-        '</main>',
-      ].join('')
-    );
-  });
+    it('should fire component:ready event', () => {
+      const basicPage = getTestLayoutData();
+      const expectedReadyMessage = getDesignLibraryStatusEvent(
+        DesignLibraryStatus.READY,
+        'test-content'
+      );
+      const rendered = render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={basicPage.layoutData}
+          api={api}
+          mode={mode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
 
-  it('should send render event when component is updated', async () => {
-    const basicPage = getTestLayoutData();
-    const rendered = render(
-      <SitecoreProvider componentMap={components}>
-        <DesignLibrary {...basicPage.layoutData} />
-      </SitecoreProvider>
-    );
+      expect(rendered.baseElement.innerHTML).to.contain(
+        [
+          '<main><div id="editing-component">',
+          '<div class="test"><div>',
+          '<p>This is a live set of examples of how to use Content SDK</p>\n',
+          '</div></div></div></main>',
+        ].join('')
+      );
 
-    await sendUpdateEvent({
-      uid: 'test-content',
-      fields: { content: { value: 'new content!' } },
+      expect(
+        postMessageSpy
+          .getCalls()
+          .some((call) => JSON.stringify(call.args[0]) === JSON.stringify(expectedReadyMessage))
+      ).to.be.true;
     });
 
-    expect(
-      postMessageSpy
-        .getCalls()
-        .some((call) =>
-          JSON.stringify(call.args[0]).includes(
-            JSON.stringify(
-              getDesignLibraryStatusEvent(DesignLibraryStatus.RENDERED, 'test-content')
+    it('should update root component', async () => {
+      const basicPage = getTestLayoutData();
+      const rendered = render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={basicPage.layoutData}
+          api={api}
+          mode={mode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+
+      expect(rendered.baseElement.innerHTML).to.contain(
+        [
+          '<main><div id="editing-component">',
+          '<div class="test"><div>',
+          '<p>This is a live set of examples of how to use Content SDK</p>\n',
+          '</div></div></div></main>',
+        ].join('')
+      );
+
+      await sendUpdateEvent({
+        uid: 'test-content',
+        fields: { content: { value: 'new content!' } },
+      });
+
+      expect(rendered.baseElement.innerHTML).to.contain(
+        [
+          '<main><div id="editing-component">',
+          '<div class="test"><div>',
+          'new content!',
+          '</div></div></div></main>',
+        ].join('')
+      );
+    });
+
+    it('should update nested component', async () => {
+      // const basicPage = getTestLayoutData();
+      const placeholderPage = getTestLayoutData(true);
+      const rendered = render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={placeholderPage.layoutData}
+          api={api}
+          mode={mode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+
+      expect(rendered.baseElement.innerHTML).to.contain(
+        [
+          '<main><div id="editing-component">',
+          '<div class="test"><div>',
+          '<p>This is a live set of examples of how to use Content SDK</p>\n',
+          '</div>',
+          '<div class="inner">',
+          'Its an inner component',
+          '</div></div></div>',
+          '</main>',
+        ].join('')
+      );
+
+      await sendUpdateEvent({
+        uid: 'test-inner',
+        fields: { text: { value: 'new inner content!' } },
+      });
+
+      expect(rendered.baseElement.innerHTML).to.contain(
+        [
+          '<main><div id="editing-component">',
+          '<div class="test"><div>',
+          '<p>This is a live set of examples of how to use Content SDK</p>\n',
+          '</div>',
+          '<div class="inner">',
+          'new inner content!',
+          '</div></div></div>',
+          '</main>',
+        ].join('')
+      );
+    });
+
+    it('should send render event when component is updated', async () => {
+      const basicPage = getTestLayoutData();
+      render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={basicPage.layoutData}
+          api={api}
+          mode={mode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>
+      );
+
+      await sendUpdateEvent({
+        uid: 'test-content',
+        fields: { content: { value: 'new content!' } },
+      });
+
+      expect(
+        postMessageSpy
+          .getCalls()
+          .some((call) =>
+            JSON.stringify(call.args[0]).includes(
+              JSON.stringify(
+                getDesignLibraryStatusEvent(DesignLibraryStatus.RENDERED, 'test-content')
+              )
             )
           )
-        )
-    ).to.be.true;
+      ).to.be.true;
+    });
+  });
+
+  describe('VariantGeneration', () => {
+    const TestComponent = () => <div>TestComponent</div>;
+    const unsubscribeSpy = sinon.spy();
+    let addComponentPreviewHandlerSpy: sinon.SinonStub;
+
+    beforeEach(() => {
+      addComponentPreviewHandlerSpy = sinon.stub().callsFake((callback) => {
+        callback(TestComponent);
+
+        return unsubscribeSpy;
+      });
+
+      __mockDependencies({ addComponentPreviewHandler: addComponentPreviewHandlerSpy });
+    });
+
+    afterEach(() => {
+      postMessageSpy.resetHistory();
+      addComponentPreviewHandlerSpy.resetHistory();
+      unsubscribeSpy.resetHistory();
+    });
+
+    it('should render component when provided', async () => {
+      const basicPage = getTestLayoutData();
+      const rendered = render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={basicPage.layoutData}
+          api={api}
+          mode={variantGenerationMode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+
+      // Wait for the useEffect to complete and component to render
+      await waitFor(() => {
+        expect(rendered.baseElement.innerHTML).to.contain('TestComponent');
+      });
+    });
+
+    it('should render loading preview when no component is provided', () => {
+      const basicPage = getTestLayoutData();
+
+      addComponentPreviewHandlerSpy.callsFake((callback) => {
+        callback(null);
+
+        return unsubscribeSpy;
+      });
+
+      const rendered = render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={basicPage.layoutData}
+          api={api}
+          mode={variantGenerationMode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+
+      // Check that we are in variant generation mode and rendering loading state
+      expect(rendered.baseElement.innerHTML).to.contain('Loading preview...');
+    });
+
+    it('should render error message when no rendering is found', () => {
+      const emptyPage = getTestLayoutData();
+      // Set to empty array to simulate no rendering found
+      emptyPage.layoutData.sitecore.route.placeholders['editing-componentmode-placeholder'] = [];
+
+      const rendered = render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={emptyPage.layoutData}
+          api={api}
+          mode={variantGenerationMode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+
+      expect(rendered.baseElement.innerHTML).to.contain(
+        'No component found in layout data. Please check your layout data.'
+      );
+    });
+
+    it('should send postMessage events for import-map and component-props', () => {
+      const basicPage = getTestLayoutData();
+      render(
+        <SitecoreProvider
+          componentMap={components}
+          layoutData={basicPage.layoutData}
+          api={api}
+          mode={variantGenerationMode}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+
+      // Check that postMessage was called (we can't easily mock the event functions)
+      expect(postMessageSpy.called).to.be.true;
+      expect(postMessageSpy.callCount).to.be.greaterThan(0);
+    });
   });
 });

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { PageMode } from '@sitecore-content-sdk/core/client';
+import { Page, PageMode } from '@sitecore-content-sdk/core/client';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { DesignLibrary } from './DesignLibrary';
 import { getTestLayoutData } from '../test-data/component-editing-data';
@@ -41,6 +41,17 @@ describe('<DesignLibrary />', () => {
     },
   };
 
+  const getPage = (): Page => ({
+    locale: 'en',
+    layout: {
+      sitecore: {
+        context: {},
+        route: null,
+      },
+    },
+    mode,
+  });
+
   const api = {
     edge: {
       contextId: 'test-context-id',
@@ -55,20 +66,20 @@ describe('<DesignLibrary />', () => {
   };
 
   it('should render null if not in design library mode', () => {
-    const mode = {
+    const page = getPage();
+
+    page.mode = {
       name: DesignLibraryMode.Normal,
       isDesignLibrary: false,
       designLibrary: {
         isVariantGeneration: false,
       },
+      isNormal: false,
+      isPreview: false,
+      isEditing: false,
     };
     const rendered = render(
-      <SitecoreProvider
-        componentMap={components}
-        layoutData={getTestLayoutData().layoutData}
-        api={api}
-        mode={mode}
-      >
+      <SitecoreProvider componentMap={components} api={api} page={page}>
         <DesignLibrary />
       </SitecoreProvider>,
       { container: document.body }
@@ -117,15 +128,14 @@ describe('<DesignLibrary />', () => {
     }
 
     it('should render', () => {
+      const page = getPage();
       const basicPage = getTestLayoutData();
+
+      page.layout = basicPage.layoutData;
+
       // don't wrap the content in divs
       const rendered = render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={basicPage.layoutData}
-          api={api}
-          mode={mode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }
@@ -141,14 +151,11 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should render component with placeholders', () => {
+      const page = getPage();
       const placeholderPage = getTestLayoutData(true);
+      page.layout = placeholderPage.layoutData;
       const rendered = render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={placeholderPage.layoutData}
-          api={api}
-          mode={mode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }
@@ -169,18 +176,15 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should fire component:ready event', () => {
+      const page = getPage();
       const basicPage = getTestLayoutData();
       const expectedReadyMessage = getDesignLibraryStatusEvent(
         DesignLibraryStatus.READY,
         'test-content'
       );
+      page.layout = basicPage.layoutData;
       const rendered = render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={basicPage.layoutData}
-          api={api}
-          mode={mode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }
@@ -203,14 +207,11 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should update root component', async () => {
+      const page = getPage();
       const basicPage = getTestLayoutData();
+      page.layout = basicPage.layoutData;
       const rendered = render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={basicPage.layoutData}
-          api={api}
-          mode={mode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }
@@ -241,15 +242,11 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should update nested component', async () => {
-      // const basicPage = getTestLayoutData();
+      const page = getPage();
       const placeholderPage = getTestLayoutData(true);
+      page.layout = placeholderPage.layoutData;
       const rendered = render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={placeholderPage.layoutData}
-          api={api}
-          mode={mode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }
@@ -288,14 +285,11 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should send render event when component is updated', async () => {
+      const page = getPage();
       const basicPage = getTestLayoutData();
+      page.layout = basicPage.layoutData;
       render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={basicPage.layoutData}
-          api={api}
-          mode={mode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>
       );
@@ -341,14 +335,12 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should render component when provided', async () => {
+      const page = getPage();
       const basicPage = getTestLayoutData();
+      page.layout = basicPage.layoutData;
+      page.mode = variantGenerationMode;
       const rendered = render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={basicPage.layoutData}
-          api={api}
-          mode={variantGenerationMode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }
@@ -361,8 +353,10 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should render loading preview when no component is provided', () => {
+      const page = getPage();
       const basicPage = getTestLayoutData();
-
+      page.layout = basicPage.layoutData;
+      page.mode = variantGenerationMode;
       addComponentPreviewHandlerSpy.callsFake((callback) => {
         callback(null);
 
@@ -370,12 +364,7 @@ describe('<DesignLibrary />', () => {
       });
 
       const rendered = render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={basicPage.layoutData}
-          api={api}
-          mode={variantGenerationMode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }
@@ -386,17 +375,15 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should render error message when no rendering is found', () => {
+      const page = getPage();
       const emptyPage = getTestLayoutData();
+      page.layout = emptyPage.layoutData;
+      page.mode = variantGenerationMode;
       // Set to empty array to simulate no rendering found
       emptyPage.layoutData.sitecore.route.placeholders['editing-componentmode-placeholder'] = [];
 
       const rendered = render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={emptyPage.layoutData}
-          api={api}
-          mode={variantGenerationMode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }
@@ -408,14 +395,11 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should send postMessage events for import-map and component-props', () => {
+      const page = getPage();
       const basicPage = getTestLayoutData();
+      page.layout = basicPage.layoutData;
       render(
-        <SitecoreProvider
-          componentMap={components}
-          layoutData={basicPage.layoutData}
-          api={api}
-          mode={variantGenerationMode}
-        >
+        <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
         { container: document.body }

--- a/packages/react/src/components/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary.tsx
@@ -30,8 +30,12 @@ export const __mockDependencies = (mocks: any) => {
  * Reacts on the update event from the parent window and re-renders the component.
  */
 const Preview = (): JSX.Element => {
-  const { pageContext } = useSitecore();
-  const { route } = pageContext;
+  const { page } = useSitecore();
+  const {
+    layout: {
+      sitecore: { route },
+    },
+  } = page;
   const [renderKey, setRenderKey] = useState(0);
   const [rootUpdate, setRootUpdate] = useState(null);
   const rootComponent = route?.placeholders[EDITING_COMPONENT_PLACEHOLDER][0];
@@ -98,8 +102,13 @@ type DynamicComponent = React.ComponentType<{
  * It is used to send the import-map and component-props events to the parent window and render the dynamic component.
  */
 export const VariantGeneration = () => {
-  const { pageContext } = useSitecore();
-  const rendering = pageContext.route?.placeholders[EDITING_COMPONENT_PLACEHOLDER][0];
+  const { page } = useSitecore();
+  const {
+    layout: {
+      sitecore: { route },
+    },
+  } = page;
+  const rendering = route?.placeholders[EDITING_COMPONENT_PLACEHOLDER][0];
   const [Component, setComponent] = React.useState<DynamicComponent>(null);
 
   useEffect(() => {
@@ -146,9 +155,9 @@ export const VariantGeneration = () => {
 };
 
 export const DesignLibrary = (): JSX.Element => {
-  const { pageContext } = useSitecore();
-  const { isDesignLibrary } = pageContext.mode;
-  const isVariantGeneration = pageContext.mode.designLibrary?.isVariantGeneration;
+  const { page } = useSitecore();
+  const { isDesignLibrary } = page.mode;
+  const isVariantGeneration = page.mode.designLibrary?.isVariantGeneration;
 
   if (!isDesignLibrary) {
     return null;

--- a/packages/react/src/components/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary.tsx
@@ -1,22 +1,40 @@
-﻿import React, { useEffect, useMemo, useState, JSX } from 'react';
+﻿/* eslint-disable prefer-const */
+
+import React, { useEffect, useMemo, useState, JSX } from 'react';
 import { Placeholder } from './Placeholder';
 import {
-  ComponentRendering,
+  ComponentFields,
+  ComponentParams,
   EDITING_COMPONENT_ID,
   EDITING_COMPONENT_PLACEHOLDER,
-  LayoutServiceData,
 } from '@sitecore-content-sdk/core/layout';
-import {
+import * as editing from '@sitecore-content-sdk/core/editing';
+import { useSitecore } from '../enhancers/withSitecore';
+
+let {
   DesignLibraryStatus,
   getDesignLibraryStatusEvent,
   addComponentUpdateHandler,
-} from '@sitecore-content-sdk/core/editing';
+  getDesignLibraryImportMapEvent,
+  getDesignLibraryComponentPropsEvent,
+  addComponentPreviewHandler,
+} = editing;
 
-export const DesignLibrary = (layoutData: LayoutServiceData): JSX.Element => {
-  const { route } = layoutData.sitecore;
+export const __mockDependencies = (mocks: any) => {
+  addComponentPreviewHandler = mocks.addComponentPreviewHandler;
+};
+
+/**
+ * This component is used to render the component in preview mode.
+ * It is used to send the rendered event to the parent window and render the component.
+ * Reacts on the update event from the parent window and re-renders the component.
+ */
+const Preview = (): JSX.Element => {
+  const { pageContext } = useSitecore();
+  const { route } = pageContext;
   const [renderKey, setRenderKey] = useState(0);
   const [rootUpdate, setRootUpdate] = useState(null);
-  const rootComponent = route?.placeholders[EDITING_COMPONENT_PLACEHOLDER][0] as ComponentRendering;
+  const rootComponent = route?.placeholders[EDITING_COMPONENT_PLACEHOLDER][0];
   // useEffect may execute multiple times on single render (i.e. in dev) - but we only want to fire ready event once
   let componentReady = false;
 
@@ -67,4 +85,78 @@ export const DesignLibrary = (layoutData: LayoutServiceData): JSX.Element => {
       </main>
     </>
   );
+};
+
+type DynamicComponent = React.ComponentType<{
+  [key: string]: unknown;
+  fields: ComponentFields;
+  params: ComponentParams;
+}>;
+
+/**
+ * This component is used to render the component in variant generation mode.
+ * It is used to send the import-map and component-props events to the parent window and render the dynamic component.
+ */
+export const VariantGeneration = () => {
+  const { pageContext } = useSitecore();
+  const rendering = pageContext.route?.placeholders[EDITING_COMPONENT_PLACEHOLDER][0];
+  const [Component, setComponent] = React.useState<DynamicComponent>(null);
+
+  useEffect(() => {
+    if (!rendering) {
+      return () => {};
+    }
+
+    const unsubscribe = addComponentPreviewHandler((Component) => {
+      setComponent(() => Component as DynamicComponent);
+    });
+
+    const importMap: editing.ImportEntry[] = [];
+
+    const importMapEvent = getDesignLibraryImportMapEvent(rendering.uid, importMap);
+
+    console.debug('Component Library: sending import-map event', importMapEvent);
+
+    window.top.postMessage(importMapEvent, '*');
+
+    const componentPropsEvent = getDesignLibraryComponentPropsEvent(
+      rendering.uid,
+      rendering.fields,
+      rendering.params
+    );
+
+    console.debug('Component Library: sending component-props event', componentPropsEvent);
+
+    window.top.postMessage(componentPropsEvent, '*');
+
+    return unsubscribe;
+  }, []);
+
+  if (!rendering) {
+    return <div>No component found in layout data. Please check your layout data.</div>;
+  }
+
+  return Component ? (
+    <div>
+      <Component fields={rendering.fields} params={rendering.params} />
+    </div>
+  ) : (
+    <div>Loading preview...</div>
+  );
+};
+
+export const DesignLibrary = (): JSX.Element => {
+  const { pageContext } = useSitecore();
+  const { isDesignLibrary } = pageContext.mode;
+  const isVariantGeneration = pageContext.mode.designLibrary?.isVariantGeneration;
+
+  if (!isDesignLibrary) {
+    return null;
+  }
+
+  if (isVariantGeneration) {
+    return <VariantGeneration />;
+  }
+
+  return <Preview />;
 };

--- a/packages/react/src/components/EditingScripts.test.tsx
+++ b/packages/react/src/components/EditingScripts.test.tsx
@@ -76,10 +76,27 @@ describe('<EditingScripts />', () => {
     const mode: PageMode = {
       name: LayoutServicePageState.Normal,
       isNormal: true,
+      isPreview: false,
+      isEditing: false,
+      isDesignLibrary: false,
+      designLibrary: {
+        isVariantGeneration: false,
+      },
+    };
+
+    const page = {
+      locale: 'en',
+      layout: {
+        sitecore: {
+          context: {},
+          route: null,
+        },
+      },
+      mode,
     };
 
     const component = render(
-      <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData} mode={mode}>
+      <SitecoreProvider componentMap={mockComponentMap} page={page}>
         <EditingScripts />
       </SitecoreProvider>,
       { container: document.body }
@@ -96,8 +113,14 @@ describe('<EditingScripts />', () => {
         pageEditing: true,
       });
 
+      const page = {
+        locale: 'en',
+        layout: layoutData,
+        mode,
+      };
+
       const component = render(
-        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData} mode={mode}>
+        <SitecoreProvider componentMap={mockComponentMap} page={page}>
           <EditingScripts />
         </SitecoreProvider>
       );
@@ -136,8 +159,14 @@ describe('<EditingScripts />', () => {
         clientScripts: [],
       });
 
+      const page = {
+        locale: 'en',
+        layout: layoutData,
+        mode,
+      };
+
       const component = render(
-        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData} mode={mode}>
+        <SitecoreProvider componentMap={mockComponentMap} page={page}>
           <EditingScripts />
         </SitecoreProvider>
       );
@@ -166,8 +195,14 @@ describe('<EditingScripts />', () => {
         clientScripts: [],
       });
 
+      const page = {
+        locale: 'en',
+        layout: layoutData,
+        mode,
+      };
+
       const component = render(
-        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData} mode={mode}>
+        <SitecoreProvider componentMap={mockComponentMap} page={page}>
           <EditingScripts />
         </SitecoreProvider>
       );
@@ -187,14 +222,19 @@ describe('<EditingScripts />', () => {
         clientScripts: [],
       });
 
+      const page = {
+        locale: 'en',
+        layout: layoutData,
+        mode,
+      };
+
       const stagingEdgeUrl = 'http://edge-staging';
 
       const component = render(
         <SitecoreProvider
           componentMap={mockComponentMap}
-          layoutData={layoutData}
+          page={page}
           api={{ edge: { edgeUrl: stagingEdgeUrl, contextId: 'id' } }}
-          mode={mode}
         >
           <EditingScripts />
         </SitecoreProvider>

--- a/packages/react/src/components/EditingScripts.test.tsx
+++ b/packages/react/src/components/EditingScripts.test.tsx
@@ -12,10 +12,17 @@ import { SitecoreProvider } from './SitecoreProvider';
 import {
   getContentSdkPagesClientData,
   getDesignLibraryScriptLink,
+  DesignLibraryMode,
 } from '@sitecore-content-sdk/core/editing';
+import { PageMode } from '@sitecore-content-sdk/core/client';
 
 describe('<EditingScripts />', () => {
   const mockComponentMap = new Map();
+
+  const mode: PageMode = {
+    name: LayoutServicePageState.Edit,
+    isEditing: true,
+  };
 
   const getLayoutData = ({
     pageState,
@@ -66,25 +73,13 @@ describe('<EditingScripts />', () => {
       pageEditing: false,
     });
 
-    const component = render(
-      <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData}>
-        <EditingScripts />
-      </SitecoreProvider>,
-      { container: document.body }
-    );
-
-    expect(component.baseElement.innerHTML).to.be.empty;
-    expect(component.container.querySelectorAll('script')).to.have.length(0);
-  });
-
-  it('should render nothing when pageState is undefined', () => {
-    const layoutData = getLayoutData({
-      pageState: undefined,
-      pageEditing: false,
-    });
+    const mode: PageMode = {
+      name: LayoutServicePageState.Normal,
+      isNormal: true,
+    };
 
     const component = render(
-      <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData}>
+      <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData} mode={mode}>
         <EditingScripts />
       </SitecoreProvider>,
       { container: document.body }
@@ -102,7 +97,7 @@ describe('<EditingScripts />', () => {
       });
 
       const component = render(
-        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData}>
+        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData} mode={mode}>
           <EditingScripts />
         </SitecoreProvider>
       );
@@ -142,7 +137,7 @@ describe('<EditingScripts />', () => {
       });
 
       const component = render(
-        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData}>
+        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData} mode={mode}>
           <EditingScripts />
         </SitecoreProvider>
       );
@@ -157,6 +152,11 @@ describe('<EditingScripts />', () => {
   });
 
   describe('Design Library scripts', () => {
+    const mode: PageMode = {
+      name: DesignLibraryMode.Normal,
+      isDesignLibrary: true,
+    };
+
     it('should render Design Library script when rendering type is component', () => {
       const layoutData = getLayoutData({
         pageEditing: false,
@@ -167,7 +167,7 @@ describe('<EditingScripts />', () => {
       });
 
       const component = render(
-        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData}>
+        <SitecoreProvider componentMap={mockComponentMap} layoutData={layoutData} mode={mode}>
           <EditingScripts />
         </SitecoreProvider>
       );
@@ -194,6 +194,7 @@ describe('<EditingScripts />', () => {
           componentMap={mockComponentMap}
           layoutData={layoutData}
           api={{ edge: { edgeUrl: stagingEdgeUrl, contextId: 'id' } }}
+          mode={mode}
         >
           <EditingScripts />
         </SitecoreProvider>

--- a/packages/react/src/components/EditingScripts.test.tsx
+++ b/packages/react/src/components/EditingScripts.test.tsx
@@ -68,11 +68,6 @@ describe('<EditingScripts />', () => {
   });
 
   it('should render nothing when not in editing', () => {
-    const layoutData = getLayoutData({
-      pageState: LayoutServicePageState.Normal,
-      pageEditing: false,
-    });
-
     const mode: PageMode = {
       name: LayoutServicePageState.Normal,
       isNormal: true,

--- a/packages/react/src/components/EditingScripts.tsx
+++ b/packages/react/src/components/EditingScripts.tsx
@@ -1,32 +1,26 @@
 ﻿import React, { JSX } from 'react';
-import { LayoutServicePageState, RenderingType } from '@sitecore-content-sdk/core/layout';
 import { useSitecore } from '../enhancers/withSitecore';
 import { getContentSdkPagesClientData } from '@sitecore-content-sdk/core/editing';
 import { getDesignLibraryScriptLink } from '@sitecore-content-sdk/core/editing';
 
 /**
  * Renders client scripts and data for editing/preview mode for Pages.
- * Renders script required for the Design Library (when RenderingType is `component`).
+ * Renders script required for the Design Library (when mode.isDesignLibrary is true).
  * @returns A JSX element containing the editing scripts or an empty fragment if not in editing/preview mode.
  */
 export const EditingScripts = (): JSX.Element => {
   const {
-    pageContext: { pageState, clientData, clientScripts, renderingType },
+    pageContext: { mode, clientData, clientScripts },
     api,
   } = useSitecore();
 
   // Don't render anything if not in editing/preview mode and rendering type is not component
-  if (
-    renderingType !== RenderingType.Component &&
-    (pageState === LayoutServicePageState.Normal ||
-      pageState === LayoutServicePageState.Preview ||
-      !pageState)
-  ) {
+  if (mode.isNormal) {
     return <></>;
   }
 
-  // In case of RenderingType.Component - render only the script for Design Libnrary
-  if (renderingType === RenderingType.Component) {
+  // In case of Design Library - render only the script for Design Library
+  if (mode.isDesignLibrary) {
     // Add cache buster to the script URL
     const scriptUrl = `${getDesignLibraryScriptLink(api?.edge?.edgeUrl)}?cb=${Date.now()}`;
 

--- a/packages/react/src/components/EditingScripts.tsx
+++ b/packages/react/src/components/EditingScripts.tsx
@@ -10,9 +10,11 @@ import { getDesignLibraryScriptLink } from '@sitecore-content-sdk/core/editing';
  */
 export const EditingScripts = (): JSX.Element => {
   const {
-    pageContext: { mode, clientData, clientScripts },
+    page: { mode, layout },
     api,
   } = useSitecore();
+
+  const { clientData, clientScripts } = layout.sitecore.context;
 
   // Don't render anything if not in editing/preview mode and rendering type is not component
   if (mode.isNormal) {

--- a/packages/react/src/components/EditingScripts.tsx
+++ b/packages/react/src/components/EditingScripts.tsx
@@ -16,8 +16,8 @@ export const EditingScripts = (): JSX.Element => {
 
   const { clientData, clientScripts } = layout.sitecore.context;
 
-  // Don't render anything if not in editing/preview mode and rendering type is not component
-  if (mode.isNormal) {
+  // Don't render anything if not in editing mode and rendering type is not component
+  if (mode.isNormal || mode.isPreview) {
     return <></>;
   }
 

--- a/packages/react/src/components/ErrorBoundary.test.tsx
+++ b/packages/react/src/components/ErrorBoundary.test.tsx
@@ -4,7 +4,7 @@ import { render, waitFor } from '@testing-library/react';
 import { spy } from 'sinon';
 import ErrorBoundary from './ErrorBoundary';
 import { SitecoreProviderReactContext } from '../components/SitecoreProvider';
-import { ComponentRendering, LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
+import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
 
 describe('ErrorBoundary', () => {
   describe('when in page editing or preview mode', () => {
@@ -12,8 +12,8 @@ describe('ErrorBoundary', () => {
       const setContext = spy();
 
       const testComponentProps = {
-        context: {
-          pageState: LayoutServicePageState.Preview,
+        pageContext: {
+          mode: { isPreview: true },
         },
         setContext,
       };
@@ -49,7 +49,7 @@ describe('ErrorBoundary', () => {
 
       const testComponentProps = {
         pageContext: {
-          pageState: LayoutServicePageState.Edit,
+          mode: { isEditing: true },
         },
         setContext,
       };
@@ -82,7 +82,7 @@ describe('ErrorBoundary', () => {
 
       const testComponentProps = {
         pageContext: {
-          pageState: LayoutServicePageState.Preview,
+          mode: { isPreview: true },
         },
         setContext,
       };
@@ -146,7 +146,7 @@ describe('ErrorBoundary', () => {
 
       const testComponentProps = {
         pageContext: {
-          pageEditing: true,
+          mode: { isEditing: true },
         },
         setContext,
       };

--- a/packages/react/src/components/ErrorBoundary.test.tsx
+++ b/packages/react/src/components/ErrorBoundary.test.tsx
@@ -3,20 +3,48 @@ import { expect } from 'chai';
 import { render, waitFor } from '@testing-library/react';
 import { spy } from 'sinon';
 import ErrorBoundary from './ErrorBoundary';
-import { SitecoreProviderReactContext } from '../components/SitecoreProvider';
-import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
+import {
+  SitecoreProvider,
+  SitecoreProviderReactContext,
+  SitecoreProviderState,
+} from '../components/SitecoreProvider';
+import { ComponentRendering, LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
+import { Page } from '@sitecore-content-sdk/core/client';
 
 describe('ErrorBoundary', () => {
+  const setPage = spy();
+  const testComponentProps: SitecoreProviderState = {
+    page: {
+      locale: 'en',
+      layout: {
+        sitecore: {
+          context: {},
+          route: null,
+        },
+      },
+      mode: {
+        name: LayoutServicePageState.Normal,
+        isPreview: false,
+        isNormal: false,
+        isEditing: false,
+        isDesignLibrary: false,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+      },
+    },
+    setPage,
+  };
+
+  afterEach(() => {
+    setPage.resetHistory();
+  });
+
   describe('when in page editing or preview mode', () => {
     it('Should render custom error component when custom error component is provided and error is thrown', () => {
-      const setContext = spy();
+      const previewContext = { ...testComponentProps };
 
-      const testComponentProps = {
-        pageContext: {
-          mode: { isPreview: true },
-        },
-        setContext,
-      };
+      previewContext.page.mode.isPreview = true;
 
       const testComponentName = 'Test component Name';
       const rendering: ComponentRendering = { componentName: testComponentName };
@@ -31,7 +59,7 @@ describe('ErrorBoundary', () => {
       };
 
       const rendered = render(
-        <SitecoreProviderReactContext.Provider value={testComponentProps}>
+        <SitecoreProviderReactContext.Provider value={previewContext}>
           <ErrorBoundary rendering={rendering} errorComponent={CustomErrorComponent}>
             <TestErrorComponent />
           </ErrorBoundary>
@@ -45,14 +73,11 @@ describe('ErrorBoundary', () => {
     });
 
     it('Should render errors message and errored component name when error is thrown in edit mode', () => {
-      const setContext = spy();
-
-      const testComponentProps = {
-        pageContext: {
-          mode: { isEditing: true },
-        },
-        setContext,
+      const editingContext = {
+        ...testComponentProps,
       };
+
+      editingContext.page.mode.isEditing = true;
 
       const testComponentName = 'Test component Name';
       const rendering: ComponentRendering = { componentName: testComponentName };
@@ -63,7 +88,7 @@ describe('ErrorBoundary', () => {
       };
 
       const rendered = render(
-        <SitecoreProviderReactContext.Provider value={testComponentProps}>
+        <SitecoreProviderReactContext.Provider value={editingContext}>
           <ErrorBoundary rendering={rendering}>
             <TestErrorComponent />
           </ErrorBoundary>
@@ -78,14 +103,9 @@ describe('ErrorBoundary', () => {
     });
 
     it('Should render errors message and errored component name when error is thrown in preview mode', () => {
-      const setContext = spy();
+      const previewContext = { ...testComponentProps };
 
-      const testComponentProps = {
-        pageContext: {
-          mode: { isPreview: true },
-        },
-        setContext,
-      };
+      previewContext.page.mode.isPreview = true;
 
       const testComponentName = 'Test component Name';
       const rendering: ComponentRendering = { componentName: testComponentName };
@@ -142,14 +162,10 @@ describe('ErrorBoundary', () => {
     });
 
     it('Should render errors message and errored component name when error is thrown and is in page editing mode', () => {
-      const setContext = spy();
-
-      const testComponentProps = {
-        pageContext: {
-          mode: { isEditing: true },
-        },
-        setContext,
+      const editingContext = {
+        ...testComponentProps,
       };
+      editingContext.page.mode.isEditing = true;
 
       const testComponentName = 'Test component Name';
       const rendering: ComponentRendering = { componentName: testComponentName };
@@ -160,7 +176,7 @@ describe('ErrorBoundary', () => {
       };
 
       const rendered = render(
-        <SitecoreProviderReactContext.Provider value={testComponentProps}>
+        <SitecoreProviderReactContext.Provider value={editingContext}>
           <ErrorBoundary rendering={rendering}>
             <TestErrorComponent />
           </ErrorBoundary>
@@ -175,14 +191,9 @@ describe('ErrorBoundary', () => {
     });
 
     it('Should render errors message and errored component name when error is thrown and is not in page editing mode', () => {
-      const setContext = spy();
+      const normalContext = { ...testComponentProps };
 
-      const testComponentProps = {
-        pageContext: {
-          pageEditing: false,
-        },
-        setContext,
-      };
+      normalContext.page.mode.isNormal = true;
 
       const testComponentName = 'Test component Name';
       const rendering: ComponentRendering = { componentName: testComponentName };
@@ -193,7 +204,7 @@ describe('ErrorBoundary', () => {
       };
 
       const rendered = render(
-        <SitecoreProviderReactContext.Provider value={testComponentProps}>
+        <SitecoreProviderReactContext.Provider value={normalContext}>
           <ErrorBoundary rendering={rendering}>
             <TestErrorComponent />
           </ErrorBoundary>
@@ -261,10 +272,32 @@ describe('ErrorBoundary', () => {
         return <div>This is a custom error component!</div>;
       };
 
+      const page: Page = {
+        locale: 'en',
+        layout: {
+          sitecore: {
+            context: {},
+            route: null,
+          },
+        },
+        mode: {
+          name: LayoutServicePageState.Normal,
+          isNormal: false,
+          isPreview: false,
+          isEditing: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
+        },
+      };
+
       const rendered = render(
-        <ErrorBoundary errorComponent={CustomErrorComponent}>
-          <TestErrorComponent />
-        </ErrorBoundary>
+        <SitecoreProvider page={page}>
+          <ErrorBoundary errorComponent={CustomErrorComponent}>
+            <TestErrorComponent />
+          </ErrorBoundary>
+        </SitecoreProvider>
       );
       expect(rendered.container.querySelectorAll('div').length).to.equal(1);
       expect(rendered.container.querySelector('div')?.textContent).to.equal(
@@ -278,10 +311,32 @@ describe('ErrorBoundary', () => {
         throw Error(errorMessage);
       };
 
+      const page: Page = {
+        locale: 'en',
+        layout: {
+          sitecore: {
+            context: {},
+            route: null,
+          },
+        },
+        mode: {
+          name: LayoutServicePageState.Normal,
+          isNormal: false,
+          isPreview: false,
+          isEditing: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
+        },
+      };
+
       const rendered = render(
-        <ErrorBoundary>
-          <TestErrorComponent />
-        </ErrorBoundary>
+        <SitecoreProvider page={page}>
+          <ErrorBoundary>
+            <TestErrorComponent />
+          </ErrorBoundary>
+        </SitecoreProvider>
       );
 
       expect(rendered.baseElement.innerHTML).to.contain('class="sc-content-sdk-placeholder-error"');

--- a/packages/react/src/components/ErrorBoundary.tsx
+++ b/packages/react/src/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 ﻿import React, { ReactNode, Suspense } from 'react';
+import { Page } from '@sitecore-content-sdk/core/client';
 import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
 import { withSitecore } from '../enhancers/withSitecore';
-import { SitecoreProviderPageContext } from './SitecoreProvider';
 
 type ErrorComponentProps = {
   [prop: string]: unknown;
@@ -9,7 +9,7 @@ type ErrorComponentProps = {
 
 export type ErrorBoundaryProps = {
   children: ReactNode;
-  pageContext: SitecoreProviderPageContext;
+  page: Page;
   type: string;
   isDynamic?: boolean;
   errorComponent?: React.ComponentClass<ErrorComponentProps> | React.FC<ErrorComponentProps>;
@@ -47,11 +47,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
   }
 
   showErrorDetails(): boolean {
-    return (
-      this.isInDevMode() ||
-      this.props.pageContext?.mode.isEditing ||
-      this.props.pageContext?.mode.isPreview
-    );
+    return this.isInDevMode() || this.props.page.mode.isEditing || this.props.page.mode.isPreview;
   }
 
   render() {

--- a/packages/react/src/components/ErrorBoundary.tsx
+++ b/packages/react/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { ReactNode, Suspense } from 'react';
-import { ComponentRendering, LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
+import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
 import { withSitecore } from '../enhancers/withSitecore';
 import { SitecoreProviderPageContext } from './SitecoreProvider';
 
@@ -49,8 +49,8 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
   showErrorDetails(): boolean {
     return (
       this.isInDevMode() ||
-      this.props.pageContext?.pageState === LayoutServicePageState.Edit ||
-      this.props.pageContext?.pageState === LayoutServicePageState.Preview
+      this.props.pageContext?.mode.isEditing ||
+      this.props.pageContext?.mode.isPreview
     );
   }
 

--- a/packages/react/src/components/Form.test.tsx
+++ b/packages/react/src/components/Form.test.tsx
@@ -16,9 +16,45 @@ describe('Form', () => {
         edgeUrl: 'edge-url',
       },
     },
-    layoutData: {
-      normal: { sitecore: { context: { pageEditing: false } } },
-      editing: { sitecore: { context: { pageEditing: true } } },
+    page: {
+      normal: {
+        locale: 'en',
+        layout: {
+          sitecore: {
+            context: { pageEditing: false },
+            route: null,
+          },
+        },
+        mode: {
+          name: LayoutServicePageState.Normal,
+          isNormal: true,
+          isPreview: false,
+          isEditing: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
+        },
+      },
+      editing: {
+        locale: 'en',
+        layout: {
+          sitecore: {
+            context: { pageEditing: true },
+            route: null,
+          },
+        },
+        mode: {
+          name: LayoutServicePageState.Edit,
+          isEditing: true,
+          isNormal: false,
+          isPreview: false,
+          isDesignLibrary: false,
+          designLibrary: {
+            isVariantGeneration: false,
+          },
+        },
+      },
     },
   };
 
@@ -29,11 +65,6 @@ describe('Form', () => {
       styles: 'form-class',
       RenderingIdentifier: 'form-id',
     },
-  };
-
-  const mode: PageMode = {
-    name: LayoutServicePageState.Normal,
-    isNormal: true,
   };
 
   it('renders form using clientContextId when both IDs are present', async () => {
@@ -55,7 +86,7 @@ describe('Form', () => {
     });
 
     const rendered = await render(
-      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.normal} mode={mode}>
+      <SitecoreProvider api={ctx.api} page={ctx.page.normal}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>,
       { container: document.body }
@@ -91,7 +122,7 @@ describe('Form', () => {
     });
 
     const rendered = await render(
-      <SitecoreProvider api={apiNoClientId} layoutData={ctx.layoutData.normal} mode={mode}>
+      <SitecoreProvider api={apiNoClientId} page={ctx.page.normal}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>
     );
@@ -121,7 +152,7 @@ describe('Form', () => {
     });
 
     const rendered = await render(
-      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing} mode={mode}>
+      <SitecoreProvider api={ctx.api} page={ctx.page.editing}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>
     );
@@ -143,7 +174,7 @@ describe('Form', () => {
     });
 
     const rendered = await render(
-      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.normal} mode={mode}>
+      <SitecoreProvider api={ctx.api} page={ctx.page.normal}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>
     );
@@ -166,7 +197,7 @@ describe('Form', () => {
     };
 
     const rendered = await render(
-      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing} mode={mode}>
+      <SitecoreProvider api={ctx.api} page={ctx.page.editing}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>,
       { container: document.body }
@@ -174,7 +205,7 @@ describe('Form', () => {
 
     await waitFor(() => {
       rendered.rerender(
-        <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing} mode={mode}>
+        <SitecoreProvider api={ctx.api} page={ctx.page.editing}>
           <Form rendering={rendering} params={rendering.params} />
         </SitecoreProvider>
       );

--- a/packages/react/src/components/Form.test.tsx
+++ b/packages/react/src/components/Form.test.tsx
@@ -4,6 +4,8 @@ import { expect } from 'chai';
 import { SitecoreProvider } from './SitecoreProvider';
 import { Form, mockFormModule } from './Form';
 import sinon from 'sinon';
+import { PageMode } from '@sitecore-content-sdk/core/client';
+import { LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
 
 describe('Form', () => {
   const ctx = {
@@ -29,6 +31,11 @@ describe('Form', () => {
     },
   };
 
+  const mode: PageMode = {
+    name: LayoutServicePageState.Normal,
+    isNormal: true,
+  };
+
   it('renders form using clientContextId when both IDs are present', async () => {
     const loadFormSpy = sinon.spy((edgeId: string, formId: string, edgeUrl?: string) => {
       expect(edgeId).to.equal('client-id');
@@ -48,7 +55,7 @@ describe('Form', () => {
     });
 
     const rendered = await render(
-      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.normal}>
+      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.normal} mode={mode}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>,
       { container: document.body }
@@ -84,7 +91,7 @@ describe('Form', () => {
     });
 
     const rendered = await render(
-      <SitecoreProvider api={apiNoClientId} layoutData={ctx.layoutData.normal}>
+      <SitecoreProvider api={apiNoClientId} layoutData={ctx.layoutData.normal} mode={mode}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>
     );
@@ -102,6 +109,11 @@ describe('Form', () => {
     const subscribeSpy = sinon.spy();
     const execSpy = sinon.spy();
 
+    const mode: PageMode = {
+      name: LayoutServicePageState.Edit,
+      isEditing: true,
+    };
+
     mockFormModule({
       loadForm: loadFormSpy,
       subscribeToFormSubmitEvent: subscribeSpy,
@@ -109,7 +121,7 @@ describe('Form', () => {
     });
 
     const rendered = await render(
-      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing}>
+      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing} mode={mode}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>
     );
@@ -131,7 +143,7 @@ describe('Form', () => {
     });
 
     const rendered = await render(
-      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.normal}>
+      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.normal} mode={mode}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>
     );
@@ -148,8 +160,13 @@ describe('Form', () => {
       executeScriptElements: sinon.spy(),
     });
 
+    const mode: PageMode = {
+      name: LayoutServicePageState.Edit,
+      isEditing: true,
+    };
+
     const rendered = await render(
-      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing}>
+      <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing} mode={mode}>
         <Form rendering={rendering} params={rendering.params} />
       </SitecoreProvider>,
       { container: document.body }
@@ -157,7 +174,7 @@ describe('Form', () => {
 
     await waitFor(() => {
       rendered.rerender(
-        <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing}>
+        <SitecoreProvider api={ctx.api} layoutData={ctx.layoutData.editing} mode={mode}>
           <Form rendering={rendering} params={rendering.params} />
         </SitecoreProvider>
       );

--- a/packages/react/src/components/Form.tsx
+++ b/packages/react/src/components/Form.tsx
@@ -44,7 +44,7 @@ export const Form = ({ params, rendering }: FormProps) => {
   const context = useSitecore();
   const formRef = useRef<HTMLDivElement>(null);
 
-  const isEditing = context.pageContext.pageEditing;
+  const isEditing = context.pageContext.mode.isEditing;
 
   useEffect(() => {
     if (!content) {

--- a/packages/react/src/components/Form.tsx
+++ b/packages/react/src/components/Form.tsx
@@ -44,7 +44,7 @@ export const Form = ({ params, rendering }: FormProps) => {
   const context = useSitecore();
   const formRef = useRef<HTMLDivElement>(null);
 
-  const isEditing = context.pageContext.mode.isEditing;
+  const isEditing = context.page.mode.isEditing;
 
   useEffect(() => {
     if (!content) {

--- a/packages/react/src/components/Placeholder.test.tsx
+++ b/packages/react/src/components/Placeholder.test.tsx
@@ -2,7 +2,11 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react/prop-types */
-import { ComponentRendering, RouteData } from '@sitecore-content-sdk/core/layout';
+import {
+  ComponentRendering,
+  LayoutServicePageState,
+  RouteData,
+} from '@sitecore-content-sdk/core/layout';
 import { expect } from 'chai';
 import { findByText, render } from '@testing-library/react';
 import React from 'react';
@@ -30,9 +34,15 @@ import { MissingComponent, MissingComponentProps } from './MissingComponent';
 import { Placeholder } from './Placeholder';
 import { ComponentProps } from './PlaceholderCommon';
 import { SitecoreProvider } from './SitecoreProvider';
+import { PageMode } from '@sitecore-content-sdk/core/client';
 
 const componentMap = new Map<string, React.FC>();
 const dynamicComponent = React.lazy(() => import('../test-data/test-dynamic-component'));
+
+const mode: PageMode = {
+  name: LayoutServicePageState.Normal,
+  isNormal: true,
+};
 
 // pass otherProps to page-content to test property cascading through the Placeholder
 
@@ -82,7 +92,7 @@ describe('<Placeholder />', () => {
         const phKey = 'page-content';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap}>
+          <SitecoreProvider componentMap={componentMap} mode={mode}>
             <Placeholder name={phKey} rendering={component} />
           </SitecoreProvider>
         );
@@ -97,7 +107,7 @@ describe('<Placeholder />', () => {
         const phKey = 'main';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap}>
+          <SitecoreProvider componentMap={componentMap} mode={mode}>
             <Placeholder name={phKey} rendering={component} />
           </SitecoreProvider>
         );
@@ -112,7 +122,7 @@ describe('<Placeholder />', () => {
         const phKey = 'main';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap}>
+          <SitecoreProvider componentMap={componentMap} mode={mode}>
             <Placeholder
               name={phKey}
               rendering={component}
@@ -129,7 +139,7 @@ describe('<Placeholder />', () => {
         const phKey = 'main';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap}>
+          <SitecoreProvider componentMap={componentMap} mode={mode}>
             <Placeholder
               name={phKey}
               rendering={component}
@@ -146,7 +156,7 @@ describe('<Placeholder />', () => {
         const phKey = 'mainEmpty';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap}>
+          <SitecoreProvider componentMap={componentMap} mode={mode}>
             <Placeholder name={phKey} rendering={component} render={() => null} />
           </SitecoreProvider>
         );
@@ -171,7 +181,7 @@ describe('<Placeholder />', () => {
       const phKey = 'main';
 
       const renderedComponent = render(
-        <SitecoreProvider componentMap={componentMap}>
+        <SitecoreProvider componentMap={componentMap} mode={mode}>
           <Placeholder
             name={phKey}
             rendering={myComponent}
@@ -195,7 +205,7 @@ describe('<Placeholder />', () => {
         .fields.message;
 
       const renderedComponent = render(
-        <SitecoreProvider componentMap={componentMap}>
+        <SitecoreProvider componentMap={componentMap} mode={mode}>
           <Placeholder name={phKey} rendering={component} />
         </SitecoreProvider>
       );
@@ -225,7 +235,7 @@ describe('<Placeholder />', () => {
       };
 
       const renderedComponent = render(
-        <SitecoreProvider componentMap={componentMap}>
+        <SitecoreProvider componentMap={componentMap} mode={mode}>
           <Placeholder
             name={phKey}
             rendering={component}
@@ -247,6 +257,11 @@ describe('<Placeholder />', () => {
 describe('SXA rendering variants', () => {
   const componentMap = new Map();
 
+  const mode: PageMode = {
+    name: LayoutServicePageState.Normal,
+    isNormal: true,
+  };
+
   componentMap.set('RichText', SxaRichText);
 
   it('should render', () => {
@@ -254,7 +269,7 @@ describe('SXA rendering variants', () => {
     const phKey = 'main';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -280,7 +295,7 @@ describe('SXA rendering variants', () => {
     const phKey = 'container-1';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -302,7 +317,7 @@ describe('SXA rendering variants', () => {
     const phKey = 'richText';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -316,7 +331,7 @@ describe('SXA rendering variants', () => {
     const phKey = 'dynamic-1-{*}';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -338,7 +353,7 @@ describe('SXA rendering variants', () => {
     const phKey = 'main-second';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -357,7 +372,7 @@ describe('SXA rendering variants', () => {
     const phKey = 'column-1-{*}';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -373,6 +388,11 @@ describe('SXA rendering variants', () => {
 });
 
 describe('BYOC fallback', () => {
+  const mode: PageMode = {
+    name: LayoutServicePageState.Normal,
+    isNormal: true,
+  };
+
   let byocComponentStub;
   let byocWrapperStub;
 
@@ -393,7 +413,7 @@ describe('BYOC fallback', () => {
     ));
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -422,7 +442,7 @@ describe('BYOC fallback', () => {
     const errorBoundarySpy = spy(ErrorBoundary, 'default');
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -445,6 +465,11 @@ describe('BYOC fallback', () => {
 });
 
 describe('FEaaS fallback', () => {
+  const mode: PageMode = {
+    name: LayoutServicePageState.Normal,
+    isNormal: true,
+  };
+
   let feaasComponentStub;
   let feaasWrapperStub;
 
@@ -465,7 +490,7 @@ describe('FEaaS fallback', () => {
     ));
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -483,7 +508,7 @@ it('should render Suspense when disableSuspense is false', async () => {
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap}>
+    <SitecoreProvider componentMap={componentMap} mode={mode}>
       <Placeholder name={phKey} disableSuspense={false} rendering={component} />
     </SitecoreProvider>
   );
@@ -498,7 +523,7 @@ it('should not render Suspense when disableSuspense is true', async () => {
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap}>
+    <SitecoreProvider componentMap={componentMap} mode={mode}>
       <Placeholder name={phKey} disableSuspense={true} rendering={component} />
     </SitecoreProvider>
   );
@@ -521,7 +546,7 @@ it('should render null for unknown placeholder', () => {
   const phKey = 'unknown';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap}>
+    <SitecoreProvider componentMap={componentMap} mode={mode}>
       <Placeholder name={phKey} rendering={route} />
     </SitecoreProvider>
   );
@@ -554,7 +579,7 @@ it('should render error message on error', () => {
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={components}>
+    <SitecoreProvider componentMap={components} mode={mode}>
       <Placeholder name={phKey} rendering={route} />
     </SitecoreProvider>
   );
@@ -593,7 +618,7 @@ it('should render error message on error, only for the errored component', () =>
   const phKey = 'main';
 
   const renderedComponent = render(
-    <Placeholder name={phKey} rendering={route} componentMap={components} />
+    <Placeholder name={phKey} rendering={route} componentMap={components} mode={mode} />
   );
   expect(
     renderedComponent.container.querySelectorAll('.sc-content-sdk-placeholder-error').length
@@ -606,7 +631,7 @@ it('should render custom errorComponent on error, if provided', () => {
 
   const Home: React.FC<{ rendering?: RouteData }> = ({ rendering }) => (
     <div className="home-mock">
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name="main" rendering={rendering} />
       </SitecoreProvider>
     </div>
@@ -631,7 +656,7 @@ it('should render custom errorComponent on error, if provided', () => {
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={components}>
+    <SitecoreProvider componentMap={components} mode={mode}>
       <Placeholder name={phKey} rendering={route} errorComponent={CustomError} />
     </SitecoreProvider>
   );
@@ -657,7 +682,7 @@ it('should render MissingComponent for unknown rendering', () => {
   );
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap}>
+    <SitecoreProvider componentMap={componentMap} mode={mode}>
       <Placeholder
         name={phKey}
         rendering={route}
@@ -691,7 +716,7 @@ it('should render nothing for rendering without a name', () => {
 
   const renderedComponent = render(
     <div className="empty-test">
-      <SitecoreProvider componentMap={componentMap}>
+      <SitecoreProvider componentMap={componentMap} mode={mode}>
         <Placeholder name={phKey} rendering={route} />
       </SitecoreProvider>
     </div>
@@ -712,7 +737,7 @@ it('should render HiddenRendering when rendering is hidden', () => {
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap}>
+    <SitecoreProvider componentMap={componentMap} mode={mode}>
       <Placeholder name={phKey} rendering={route} />
     </SitecoreProvider>
   );
@@ -741,7 +766,7 @@ it('should render custom HiddenRendering when rendering is hidden', () => {
   );
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap}>
+    <SitecoreProvider componentMap={componentMap} mode={mode}>
       <Placeholder
         name={phKey}
         rendering={route}
@@ -765,6 +790,11 @@ describe('PlaceholderMetadata', () => {
     layoutDataWithUnknownComponent,
   } = metadataData;
 
+  const mode: PageMode = {
+    name: LayoutServicePageState.Edit,
+    isEditing: true,
+  };
+
   const componentMap = new Map<string, React.FC>();
 
   componentMap.set('Header', () => (
@@ -776,7 +806,7 @@ describe('PlaceholderMetadata', () => {
 
   it('should render <PlaceholderMetadata> with nested placeholder components', () => {
     const wrapper = render(
-      <SitecoreProvider componentMap={componentMap} layoutData={layoutData}>
+      <SitecoreProvider componentMap={componentMap} layoutData={layoutData} mode={mode}>
         <Placeholder name="main" rendering={layoutData.sitecore.route} />
       </SitecoreProvider>,
       { container: document.body }
@@ -803,7 +833,11 @@ describe('PlaceholderMetadata', () => {
 
   it('should render code blocks even if placeholder is empty', () => {
     const wrapper = render(
-      <SitecoreProvider componentMap={componentMap} layoutData={layoutDataWithEmptyPlaceholder}>
+      <SitecoreProvider
+        componentMap={componentMap}
+        layoutData={layoutDataWithEmptyPlaceholder}
+        mode={mode}
+      >
         <Placeholder name="main" rendering={layoutDataWithEmptyPlaceholder.sitecore.route} />
       </SitecoreProvider>,
       { container: document.body }
@@ -821,7 +855,11 @@ describe('PlaceholderMetadata', () => {
 
   it('should render missing component with code blocks if component is not registered', () => {
     const wrapper = render(
-      <SitecoreProvider componentMap={componentMap} layoutData={layoutDataWithUnknownComponent}>
+      <SitecoreProvider
+        componentMap={componentMap}
+        layoutData={layoutDataWithUnknownComponent}
+        mode={mode}
+      >
         <Placeholder name="main" rendering={layoutDataWithUnknownComponent.sitecore.route} />
       </SitecoreProvider>
     );
@@ -841,7 +879,7 @@ describe('PlaceholderMetadata', () => {
     const phKey = 'container-1';
     const layoutData = layoutDataForNestedDynamicPlaceholder('container-{*}');
     const wrapper = render(
-      <SitecoreProvider componentMap={componentMap} layoutData={layoutData}>
+      <SitecoreProvider componentMap={componentMap} layoutData={layoutData} mode={mode}>
         <Placeholder name={phKey} rendering={layoutData.sitecore.route} />
       </SitecoreProvider>
     );
@@ -868,7 +906,7 @@ describe('PlaceholderMetadata', () => {
     const phKey = 'container-1-2';
     const layoutData = layoutDataForNestedDynamicPlaceholder('container-1-{*}');
     const wrapper = render(
-      <SitecoreProvider componentMap={componentMap} layoutData={layoutData}>
+      <SitecoreProvider componentMap={componentMap} layoutData={layoutData} mode={mode}>
         <Placeholder name={phKey} rendering={layoutData.sitecore.route} />
       </SitecoreProvider>
     );

--- a/packages/react/src/components/Placeholder.test.tsx
+++ b/packages/react/src/components/Placeholder.test.tsx
@@ -34,15 +34,30 @@ import { MissingComponent, MissingComponentProps } from './MissingComponent';
 import { Placeholder } from './Placeholder';
 import { ComponentProps } from './PlaceholderCommon';
 import { SitecoreProvider } from './SitecoreProvider';
-import { PageMode } from '@sitecore-content-sdk/core/client';
+import { Page, PageMode } from '@sitecore-content-sdk/core/client';
 
 const componentMap = new Map<string, React.FC>();
 const dynamicComponent = React.lazy(() => import('../test-data/test-dynamic-component'));
 
-const mode: PageMode = {
-  name: LayoutServicePageState.Normal,
-  isNormal: true,
-};
+const getPage = (): Page => ({
+  locale: 'en',
+  layout: {
+    sitecore: {
+      context: {},
+      route: null,
+    },
+  },
+  mode: {
+    name: LayoutServicePageState.Normal,
+    isNormal: true,
+    isPreview: false,
+    isEditing: false,
+    isDesignLibrary: false,
+    designLibrary: {
+      isVariantGeneration: false,
+    },
+  },
+});
 
 // pass otherProps to page-content to test property cascading through the Placeholder
 
@@ -85,6 +100,8 @@ describe('<Placeholder />', () => {
   testData.forEach((dataSet) => {
     describe(`with ${dataSet.label}`, () => {
       it('should render a placeholder with given key', () => {
+        const page = getPage();
+        page.layout = dataSet.data;
         const component = (dataSet.data.sitecore.route.placeholders.main as (
           | ComponentRendering
           | RouteData
@@ -92,7 +109,7 @@ describe('<Placeholder />', () => {
         const phKey = 'page-content';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap} mode={mode}>
+          <SitecoreProvider componentMap={componentMap} page={page}>
             <Placeholder name={phKey} rendering={component} />
           </SitecoreProvider>
         );
@@ -103,11 +120,13 @@ describe('<Placeholder />', () => {
       });
 
       it('should render nested placeholders', () => {
+        const page = getPage();
+        page.layout = dataSet.data;
         const component = dataSet.data.sitecore.route as RouteData;
         const phKey = 'main';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap} mode={mode}>
+          <SitecoreProvider componentMap={componentMap} page={page}>
             <Placeholder name={phKey} rendering={component} />
           </SitecoreProvider>
         );
@@ -118,11 +137,13 @@ describe('<Placeholder />', () => {
       });
 
       it('should render components based on the rendereach function', () => {
+        const page = getPage();
+        page.layout = dataSet.data;
         const component = dataSet.data.sitecore.route as RouteData;
         const phKey = 'main';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap} mode={mode}>
+          <SitecoreProvider componentMap={componentMap} page={page}>
             <Placeholder
               name={phKey}
               rendering={component}
@@ -135,11 +156,13 @@ describe('<Placeholder />', () => {
       });
 
       it('should render components based on the render function', () => {
+        const page = getPage();
+        page.layout = dataSet.data;
         const component = dataSet.data.sitecore.route as RouteData;
         const phKey = 'main';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap} mode={mode}>
+          <SitecoreProvider componentMap={componentMap} page={page}>
             <Placeholder
               name={phKey}
               rendering={component}
@@ -152,11 +175,13 @@ describe('<Placeholder />', () => {
       });
 
       it('should render empty placeholder', () => {
+        const page = getPage();
+        page.layout = dataSet.data;
         const component = dataSet.data.sitecore.route as RouteData;
         const phKey = 'mainEmpty';
 
         const renderedComponent = render(
-          <SitecoreProvider componentMap={componentMap} mode={mode}>
+          <SitecoreProvider componentMap={componentMap} page={page}>
             <Placeholder name={phKey} rendering={component} render={() => null} />
           </SitecoreProvider>
         );
@@ -166,6 +191,8 @@ describe('<Placeholder />', () => {
     });
 
     it('should render output based on the renderEmpty function in case of no renderings', () => {
+      const page = getPage();
+      page.layout = dataSet.data;
       const component = dataSet.data.sitecore.route as RouteData;
       const renderings = component.placeholders.main.filter(
         (c) => !(c as ComponentRendering).componentName
@@ -181,7 +208,7 @@ describe('<Placeholder />', () => {
       const phKey = 'main';
 
       const renderedComponent = render(
-        <SitecoreProvider componentMap={componentMap} mode={mode}>
+        <SitecoreProvider componentMap={componentMap} page={page}>
           <Placeholder
             name={phKey}
             rendering={myComponent}
@@ -199,13 +226,15 @@ describe('<Placeholder />', () => {
     });
 
     it('should pass properties to nested components', () => {
+      const page = getPage();
+      page.layout = dataSet.data;
       const component = dataSet.data.sitecore.route as any;
       const phKey = 'main';
       const expectedMessage = (component.placeholders.main as any[]).find((c) => c.componentName)
         .fields.message;
 
       const renderedComponent = render(
-        <SitecoreProvider componentMap={componentMap} mode={mode}>
+        <SitecoreProvider componentMap={componentMap} page={page}>
           <Placeholder name={phKey} rendering={component} />
         </SitecoreProvider>
       );
@@ -218,6 +247,8 @@ describe('<Placeholder />', () => {
     });
 
     it('should apply modifyComponentProps to the final props', () => {
+      const page = getPage();
+      page.layout = dataSet.data;
       const component = dataSet.data.sitecore.route as any;
       const phKey = 'main';
       const expectedMessage = (component.placeholders.main as any[]).find((c) => c.componentName)
@@ -235,7 +266,7 @@ describe('<Placeholder />', () => {
       };
 
       const renderedComponent = render(
-        <SitecoreProvider componentMap={componentMap} mode={mode}>
+        <SitecoreProvider componentMap={componentMap} page={page}>
           <Placeholder
             name={phKey}
             rendering={component}
@@ -257,19 +288,16 @@ describe('<Placeholder />', () => {
 describe('SXA rendering variants', () => {
   const componentMap = new Map();
 
-  const mode: PageMode = {
-    name: LayoutServicePageState.Normal,
-    isNormal: true,
-  };
-
   componentMap.set('RichText', SxaRichText);
 
   it('should render', () => {
+    const page = getPage();
+    page.layout = sxaRenderingVariantData;
     const component = sxaRenderingVariantData.sitecore.route as RouteData;
     const phKey = 'main';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -291,11 +319,13 @@ describe('SXA rendering variants', () => {
   });
 
   it('should render with container-{*} type dynamic placeholder', () => {
+    const page = getPage();
+    page.layout = sxaRenderingCommonContainerName;
     const component = sxaRenderingCommonContainerName.sitecore.route as RouteData;
     const phKey = 'container-1';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -313,11 +343,13 @@ describe('SXA rendering variants', () => {
   });
 
   it('should not render without container-{*} type dynamic placeholder', () => {
+    const page = getPage();
+    page.layout = sxaRenderingWithoutContainerName;
     const component = sxaRenderingWithoutContainerName.sitecore.route as RouteData;
     const phKey = 'richText';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -327,11 +359,13 @@ describe('SXA rendering variants', () => {
   });
 
   it('should render with dynamic-1-{*} type dynamic placeholder', () => {
+    const page = getPage();
+    page.layout = sxaRenderingDoubleDigitContainerName;
     const component = sxaRenderingDoubleDigitContainerName.sitecore.route as RouteData;
     const phKey = 'dynamic-1-{*}';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -349,11 +383,13 @@ describe('SXA rendering variants', () => {
   });
 
   it('should render another rendering variant', () => {
+    const page = getPage();
+    page.layout = sxaRenderingVariantData;
     const component = sxaRenderingVariantData.sitecore.route as RouteData;
     const phKey = 'main-second';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -368,11 +404,13 @@ describe('SXA rendering variants', () => {
   });
 
   it('should render column splitter rendering variant', () => {
+    const page = getPage();
+    page.layout = sxaRenderingColumnSplitterVariant;
     const component = sxaRenderingColumnSplitterVariant.sitecore.route as RouteData;
     const phKey = 'column-1-{*}';
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -388,17 +426,14 @@ describe('SXA rendering variants', () => {
 });
 
 describe('BYOC fallback', () => {
-  const mode: PageMode = {
-    name: LayoutServicePageState.Normal,
-    isNormal: true,
-  };
-
   let byocComponentStub;
   let byocWrapperStub;
 
   const componentMap = new Map();
 
   it('should render', () => {
+    const page = getPage();
+    page.layout = byocWrapperData;
     const component = byocWrapperData.sitecore.route as RouteData;
     const phKey = 'main';
 
@@ -413,7 +448,7 @@ describe('BYOC fallback', () => {
     ));
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -426,6 +461,8 @@ describe('BYOC fallback', () => {
   });
 
   it('should render ErrorBoundary without Suspense for byoc wrapper', () => {
+    const page = getPage();
+    page.layout = byocWrapperData;
     const component = byocWrapperData.sitecore.route as RouteData;
     const phKey = 'main';
 
@@ -442,7 +479,7 @@ describe('BYOC fallback', () => {
     const errorBoundarySpy = spy(ErrorBoundary, 'default');
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -465,17 +502,14 @@ describe('BYOC fallback', () => {
 });
 
 describe('FEaaS fallback', () => {
-  const mode: PageMode = {
-    name: LayoutServicePageState.Normal,
-    isNormal: true,
-  };
-
   let feaasComponentStub;
   let feaasWrapperStub;
 
   const componentMap = new Map();
 
   it('should render', () => {
+    const page = getPage();
+    page.layout = feaasWrapperData;
     const component = feaasWrapperData.sitecore.route as RouteData;
     const phKey = 'main';
 
@@ -490,7 +524,7 @@ describe('FEaaS fallback', () => {
     ));
 
     const renderedComponent = render(
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={component} />
       </SitecoreProvider>
     );
@@ -504,11 +538,13 @@ describe('FEaaS fallback', () => {
 });
 
 it('should render Suspense when disableSuspense is false', async () => {
+  const page = getPage();
+  page.layout = normalModeDevData;
   const component = normalModeDevData.sitecore.route as RouteData;
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap} mode={mode}>
+    <SitecoreProvider componentMap={componentMap} page={page}>
       <Placeholder name={phKey} disableSuspense={false} rendering={component} />
     </SitecoreProvider>
   );
@@ -519,11 +555,13 @@ it('should render Suspense when disableSuspense is false', async () => {
 });
 
 it('should not render Suspense when disableSuspense is true', async () => {
+  const page = getPage();
+  page.layout = normalModeDevData;
   const component = normalModeDevData.sitecore.route as RouteData;
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap} mode={mode}>
+    <SitecoreProvider componentMap={componentMap} page={page}>
       <Placeholder name={phKey} disableSuspense={true} rendering={component} />
     </SitecoreProvider>
   );
@@ -534,6 +572,7 @@ it('should not render Suspense when disableSuspense is true', async () => {
 });
 
 it('should render null for unknown placeholder', () => {
+  const page = getPage();
   const route = ({
     placeholders: {
       main: [
@@ -543,10 +582,16 @@ it('should render null for unknown placeholder', () => {
       ],
     },
   } as unknown) as RouteData;
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
+    },
+  };
   const phKey = 'unknown';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap} mode={mode}>
+    <SitecoreProvider componentMap={componentMap} page={page}>
       <Placeholder name={phKey} rendering={route} />
     </SitecoreProvider>
   );
@@ -576,10 +621,17 @@ it('should render error message on error', () => {
       ],
     },
   } as unknown) as RouteData;
+  const page = getPage();
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
+    },
+  };
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={components} mode={mode}>
+    <SitecoreProvider componentMap={components} page={page}>
       <Placeholder name={phKey} rendering={route} />
     </SitecoreProvider>
   );
@@ -615,10 +667,19 @@ it('should render error message on error, only for the errored component', () =>
       ],
     },
   } as unknown) as RouteData;
+  const page = getPage();
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
+    },
+  };
   const phKey = 'main';
 
   const renderedComponent = render(
-    <Placeholder name={phKey} rendering={route} componentMap={components} mode={mode} />
+    <SitecoreProvider componentMap={components} page={page}>
+      <Placeholder name={phKey} rendering={route} />
+    </SitecoreProvider>
   );
   expect(
     renderedComponent.container.querySelectorAll('.sc-content-sdk-placeholder-error').length
@@ -627,11 +688,12 @@ it('should render error message on error, only for the errored component', () =>
 });
 
 it('should render custom errorComponent on error, if provided', () => {
+  const page = getPage();
   const components = new Map<string, React.FC<{ [key: string]: unknown }>>();
 
   const Home: React.FC<{ rendering?: RouteData }> = ({ rendering }) => (
     <div className="home-mock">
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name="main" rendering={rendering} />
       </SitecoreProvider>
     </div>
@@ -653,10 +715,16 @@ it('should render custom errorComponent on error, if provided', () => {
       ],
     },
   } as unknown) as RouteData;
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
+    },
+  };
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={components} mode={mode}>
+    <SitecoreProvider componentMap={components} page={page}>
       <Placeholder name={phKey} rendering={route} errorComponent={CustomError} />
     </SitecoreProvider>
   );
@@ -664,6 +732,7 @@ it('should render custom errorComponent on error, if provided', () => {
 });
 
 it('should render MissingComponent for unknown rendering', () => {
+  const page = getPage();
   const route: any = {
     placeholders: {
       main: [
@@ -671,6 +740,12 @@ it('should render MissingComponent for unknown rendering', () => {
           componentName: 'Unknown',
         },
       ],
+    },
+  };
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
     },
   };
   const phKey = 'main';
@@ -682,7 +757,7 @@ it('should render MissingComponent for unknown rendering', () => {
   );
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap} mode={mode}>
+    <SitecoreProvider componentMap={componentMap} page={page}>
       <Placeholder
         name={phKey}
         rendering={route}
@@ -694,6 +769,7 @@ it('should render MissingComponent for unknown rendering', () => {
 });
 
 it('should render nothing for rendering without a name', () => {
+  const page = getPage();
   const componentMap = new Map<string, React.FC<{ [key: string]: unknown }>>();
 
   const Home: React.FC<{ rendering?: RouteData }> = () => <div className="home-mock"></div>;
@@ -712,11 +788,17 @@ it('should render nothing for rendering without a name', () => {
       ],
     },
   };
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
+    },
+  };
   const phKey = 'main';
 
   const renderedComponent = render(
     <div className="empty-test">
-      <SitecoreProvider componentMap={componentMap} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={route} />
       </SitecoreProvider>
     </div>
@@ -725,6 +807,7 @@ it('should render nothing for rendering without a name', () => {
 });
 
 it('should render HiddenRendering when rendering is hidden', () => {
+  const page = getPage();
   const route: any = {
     placeholders: {
       main: [
@@ -734,10 +817,16 @@ it('should render HiddenRendering when rendering is hidden', () => {
       ],
     },
   };
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
+    },
+  };
   const phKey = 'main';
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap} mode={mode}>
+    <SitecoreProvider componentMap={componentMap} page={page}>
       <Placeholder name={phKey} rendering={route} />
     </SitecoreProvider>
   );
@@ -745,7 +834,8 @@ it('should render HiddenRendering when rendering is hidden', () => {
 });
 
 it('should render custom HiddenRendering when rendering is hidden', () => {
-  const hiddenRenderingSpy = spy(HiddenRendering, 'HiddenRendering');
+  const page = getPage();
+  spy(HiddenRendering, 'HiddenRendering');
 
   const route: any = {
     placeholders: {
@@ -754,6 +844,12 @@ it('should render custom HiddenRendering when rendering is hidden', () => {
           componentName: 'Hidden Rendering',
         },
       ],
+    },
+  };
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
     },
   };
   const phKey = 'main';
@@ -766,7 +862,7 @@ it('should render custom HiddenRendering when rendering is hidden', () => {
   );
 
   const renderedComponent = render(
-    <SitecoreProvider componentMap={componentMap} mode={mode}>
+    <SitecoreProvider componentMap={componentMap} page={page}>
       <Placeholder
         name={phKey}
         rendering={route}
@@ -793,7 +889,21 @@ describe('PlaceholderMetadata', () => {
   const mode: PageMode = {
     name: LayoutServicePageState.Edit,
     isEditing: true,
+    isNormal: false,
+    isPreview: false,
+    isDesignLibrary: false,
+    designLibrary: {
+      isVariantGeneration: false,
+    },
   };
+
+  let page: Page;
+
+  beforeEach(() => {
+    page = getPage();
+    page.layout = layoutData;
+    page.mode = mode;
+  });
 
   const componentMap = new Map<string, React.FC>();
 
@@ -806,7 +916,7 @@ describe('PlaceholderMetadata', () => {
 
   it('should render <PlaceholderMetadata> with nested placeholder components', () => {
     const wrapper = render(
-      <SitecoreProvider componentMap={componentMap} layoutData={layoutData} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name="main" rendering={layoutData.sitecore.route} />
       </SitecoreProvider>,
       { container: document.body }
@@ -832,12 +942,9 @@ describe('PlaceholderMetadata', () => {
   });
 
   it('should render code blocks even if placeholder is empty', () => {
+    page.layout = layoutDataWithEmptyPlaceholder;
     const wrapper = render(
-      <SitecoreProvider
-        componentMap={componentMap}
-        layoutData={layoutDataWithEmptyPlaceholder}
-        mode={mode}
-      >
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name="main" rendering={layoutDataWithEmptyPlaceholder.sitecore.route} />
       </SitecoreProvider>,
       { container: document.body }
@@ -854,12 +961,10 @@ describe('PlaceholderMetadata', () => {
   });
 
   it('should render missing component with code blocks if component is not registered', () => {
+    page.layout = layoutDataWithUnknownComponent;
+
     const wrapper = render(
-      <SitecoreProvider
-        componentMap={componentMap}
-        layoutData={layoutDataWithUnknownComponent}
-        mode={mode}
-      >
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name="main" rendering={layoutDataWithUnknownComponent.sitecore.route} />
       </SitecoreProvider>
     );
@@ -878,8 +983,10 @@ describe('PlaceholderMetadata', () => {
   it('should render dynamic placeholder', () => {
     const phKey = 'container-1';
     const layoutData = layoutDataForNestedDynamicPlaceholder('container-{*}');
+    page.layout = layoutData;
+
     const wrapper = render(
-      <SitecoreProvider componentMap={componentMap} layoutData={layoutData} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={layoutData.sitecore.route} />
       </SitecoreProvider>
     );
@@ -905,8 +1012,9 @@ describe('PlaceholderMetadata', () => {
   it('should render double digit dynamic placeholder', () => {
     const phKey = 'container-1-2';
     const layoutData = layoutDataForNestedDynamicPlaceholder('container-1-{*}');
+    page.layout = layoutData;
     const wrapper = render(
-      <SitecoreProvider componentMap={componentMap} layoutData={layoutData} mode={mode}>
+      <SitecoreProvider componentMap={componentMap} page={page}>
         <Placeholder name={phKey} rendering={layoutData.sitecore.route} />
       </SitecoreProvider>
     );

--- a/packages/react/src/components/Placeholder.tsx
+++ b/packages/react/src/components/Placeholder.tsx
@@ -71,7 +71,7 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     const placeholderData = PlaceholderCommon.getPlaceholderDataFromRenderingData(
       renderingData,
       this.props.name,
-      this.props.pageContext?.mode.isEditing
+      this.props.page.mode.isEditing
     );
 
     this.isEmpty = !placeholderData.length;
@@ -81,9 +81,7 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     if (this.isEmpty) {
       const rendered = this.props.renderEmpty ? this.props.renderEmpty(components) : components;
 
-      return this.props.pageContext?.mode.isEditing
-        ? this.renderEmptyPlaceholder(rendered)
-        : rendered;
+      return this.props.page.mode.isEditing ? this.renderEmptyPlaceholder(rendered) : rendered;
     } else if (this.props.render) {
       return this.props.render(components, placeholderData, childProps);
     } else if (this.props.renderEach) {

--- a/packages/react/src/components/Placeholder.tsx
+++ b/packages/react/src/components/Placeholder.tsx
@@ -71,7 +71,7 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     const placeholderData = PlaceholderCommon.getPlaceholderDataFromRenderingData(
       renderingData,
       this.props.name,
-      this.props.pageContext?.pageEditing
+      this.props.pageContext?.mode.isEditing
     );
 
     this.isEmpty = !placeholderData.length;
@@ -81,7 +81,9 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     if (this.isEmpty) {
       const rendered = this.props.renderEmpty ? this.props.renderEmpty(components) : components;
 
-      return this.props.pageContext?.pageEditing ? this.renderEmptyPlaceholder(rendered) : rendered;
+      return this.props.pageContext?.mode.isEditing
+        ? this.renderEmptyPlaceholder(rendered)
+        : rendered;
     } else if (this.props.render) {
       return this.props.render(components, placeholderData, childProps);
     } else if (this.props.renderEach) {

--- a/packages/react/src/components/PlaceholderCommon.tsx
+++ b/packages/react/src/components/PlaceholderCommon.tsx
@@ -10,12 +10,12 @@ import {
   getDynamicPlaceholderPattern,
 } from '@sitecore-content-sdk/core/layout';
 import { constants } from '@sitecore-content-sdk/core';
+import { Page } from '@sitecore-content-sdk/core/client';
 import { HiddenRendering } from './HiddenRendering';
 import { FEaaSComponent, FEAAS_COMPONENT_RENDERING_NAME } from './FEaaSComponent';
 import { FEaaSWrapper, FEAAS_WRAPPER_RENDERING_NAME } from './FEaaSWrapper';
 import { BYOCComponent, BYOC_COMPONENT_RENDERING_NAME } from './BYOCComponent';
 import { BYOCWrapper, BYOC_WRAPPER_RENDERING_NAME } from './BYOCWrapper';
-import { SitecoreProviderPageContext } from './SitecoreProvider';
 import { PlaceholderMetadata } from './PlaceholderMetadata';
 import ErrorBoundary from './ErrorBoundary';
 
@@ -78,10 +78,10 @@ export interface PlaceholderProps {
    */
   errorComponent?: React.ComponentClass<ErrorComponentProps> | React.FC<ErrorComponentProps>;
   /**
-   * Page context data.
+   * Page data.
    * This data is passed by the SitecoreProvider.
    */
-  pageContext: SitecoreProviderPageContext;
+  page: Page;
   /**
    * The message that gets displayed while component is loading
    */
@@ -271,7 +271,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         }
 
         // if in edit mode then emit shallow chromes for hydration in Pages
-        if (this.props.pageContext?.mode.isEditing) {
+        if (this.props.page.mode.isEditing) {
           return (
             <PlaceholderMetadata key={key} rendering={rendering as ComponentRendering}>
               {rendered}
@@ -283,7 +283,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       })
       .filter((element) => element); // remove nulls
 
-    if (this.props.pageContext?.mode.isEditing) {
+    if (this.props.page.mode.isEditing) {
       return [
         <PlaceholderMetadata
           key={(this.props.rendering as ComponentRendering).uid}

--- a/packages/react/src/components/PlaceholderCommon.tsx
+++ b/packages/react/src/components/PlaceholderCommon.tsx
@@ -271,7 +271,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         }
 
         // if in edit mode then emit shallow chromes for hydration in Pages
-        if (this.props.pageContext?.pageEditing) {
+        if (this.props.pageContext?.mode.isEditing) {
           return (
             <PlaceholderMetadata key={key} rendering={rendering as ComponentRendering}>
               {rendered}
@@ -283,7 +283,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       })
       .filter((element) => element); // remove nulls
 
-    if (this.props.pageContext?.pageEditing) {
+    if (this.props.pageContext?.mode.isEditing) {
       return [
         <PlaceholderMetadata
           key={(this.props.rendering as ComponentRendering).uid}

--- a/packages/react/src/components/SitecoreProvider.test.tsx
+++ b/packages/react/src/components/SitecoreProvider.test.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { expect } from 'chai';
-import { PageMode } from '@sitecore-content-sdk/core/client';
+import { Page } from '@sitecore-content-sdk/core/client';
 import { SitecoreProvider } from './SitecoreProvider';
 import { WithSitecoreProps, withSitecore, useSitecore } from '../enhancers/withSitecore';
 import { LayoutServiceData, LayoutServicePageState } from '../index';
@@ -9,18 +9,14 @@ import { render } from '@testing-library/react';
 describe('SitecoreProvider', () => {
   let nestedContext = {};
 
-  const mode: PageMode = {
-    name: LayoutServicePageState.Normal,
-  };
-
   interface NestedComponentProps extends WithSitecoreProps {
     anotherProperty?: string;
   }
 
   const NestedComponent: FC<NestedComponentProps> = () => {
-    const { pageContext } = useSitecore();
-    nestedContext = pageContext;
-    return null;
+    const { page } = useSitecore();
+    nestedContext = page;
+    return <span>Page mode is {page.mode.name}</span>;
   };
 
   const NestedComponentWithContext = withSitecore()(NestedComponent);
@@ -44,47 +40,55 @@ describe('SitecoreProvider', () => {
     },
   };
 
-  it('sets default context when no layoutData is supplied', () => {
-    render(
-      <SitecoreProvider api={apiStub} componentMap={components} mode={mode}>
+  const mockPage: Page = {
+    layout: mockLayoutData,
+    locale: 'en',
+    mode: {
+      name: LayoutServicePageState.Normal,
+      isNormal: true,
+      isPreview: false,
+      isEditing: false,
+      isDesignLibrary: false,
+      designLibrary: {
+        isVariantGeneration: false,
+      },
+    },
+  };
+
+  it('renders the component with the context', () => {
+    const rendered = render(
+      <SitecoreProvider api={apiStub} componentMap={components} page={mockPage}>
         <NestedComponentWithContext />
       </SitecoreProvider>
     );
 
-    expect(nestedContext).to.deep.equal({ mode: { name: 'normal' } });
+    expect(nestedContext).to.deep.equal(mockPage);
+    expect(rendered.getByText('Page mode is normal')).to.exist;
   });
 
-  it('updates state when new layoutData is received via props', () => {
+  it('updates state when new page is received via props', () => {
     const rendered = render(
-      <SitecoreProvider api={apiStub} componentMap={components} mode={mode}>
+      <SitecoreProvider api={apiStub} componentMap={components} page={mockPage}>
         <NestedComponentWithContext />
       </SitecoreProvider>
     );
 
-    expect(nestedContext).to.deep.equal({ mode: { name: 'normal' } });
+    expect(nestedContext).to.deep.equal(mockPage);
+
+    const newMockPage: Page = {
+      ...mockPage,
+      locale: 'gr',
+    };
 
     rendered.rerender(
-      <SitecoreProvider
-        api={apiStub}
-        componentMap={components}
-        layoutData={mockLayoutData}
-        mode={mode}
-      >
+      <SitecoreProvider api={apiStub} componentMap={components} page={newMockPage}>
         <NestedComponentWithContext />
       </SitecoreProvider>
     );
 
     expect(nestedContext).to.deep.equal({
-      mode: { name: 'normal' },
-      pageEditing: false,
-      itemId: 'testitemid',
-      language: 'en',
-      route: {
-        itemId: 'testitemid',
-        name: 'styleguide',
-        placeholders: { 'ContentSdkTestWeb-main': [] },
-      },
-      site: { name: 'ContentSdkTestWeb' },
+      ...mockPage,
+      locale: 'gr',
     });
   });
 });

--- a/packages/react/src/components/SitecoreProvider.test.tsx
+++ b/packages/react/src/components/SitecoreProvider.test.tsx
@@ -1,12 +1,17 @@
 import React, { FC } from 'react';
 import { expect } from 'chai';
+import { PageMode } from '@sitecore-content-sdk/core/client';
 import { SitecoreProvider } from './SitecoreProvider';
 import { WithSitecoreProps, withSitecore, useSitecore } from '../enhancers/withSitecore';
-import { LayoutServiceData } from '../index';
+import { LayoutServiceData, LayoutServicePageState } from '../index';
 import { render } from '@testing-library/react';
 
 describe('SitecoreProvider', () => {
   let nestedContext = {};
+
+  const mode: PageMode = {
+    name: LayoutServicePageState.Normal,
+  };
 
   interface NestedComponentProps extends WithSitecoreProps {
     anotherProperty?: string;
@@ -41,30 +46,36 @@ describe('SitecoreProvider', () => {
 
   it('sets default context when no layoutData is supplied', () => {
     render(
-      <SitecoreProvider api={apiStub} componentMap={components}>
+      <SitecoreProvider api={apiStub} componentMap={components} mode={mode}>
         <NestedComponentWithContext />
       </SitecoreProvider>
     );
 
-    expect(nestedContext).to.deep.equal({ pageEditing: false });
+    expect(nestedContext).to.deep.equal({ mode: { name: 'normal' } });
   });
 
   it('updates state when new layoutData is received via props', () => {
     const rendered = render(
-      <SitecoreProvider api={apiStub} componentMap={components}>
+      <SitecoreProvider api={apiStub} componentMap={components} mode={mode}>
         <NestedComponentWithContext />
       </SitecoreProvider>
     );
 
-    expect(nestedContext).to.deep.equal({ pageEditing: false });
+    expect(nestedContext).to.deep.equal({ mode: { name: 'normal' } });
 
     rendered.rerender(
-      <SitecoreProvider api={apiStub} componentMap={components} layoutData={mockLayoutData}>
+      <SitecoreProvider
+        api={apiStub}
+        componentMap={components}
+        layoutData={mockLayoutData}
+        mode={mode}
+      >
         <NestedComponentWithContext />
       </SitecoreProvider>
     );
 
     expect(nestedContext).to.deep.equal({
+      mode: { name: 'normal' },
       pageEditing: false,
       itemId: 'testitemid',
       language: 'en',

--- a/packages/react/src/components/SitecoreProvider.tsx
+++ b/packages/react/src/components/SitecoreProvider.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import fastDeepEqual from 'fast-deep-equal/es6/react';
+import { Page } from '@sitecore-content-sdk/core/client';
 import { SitecoreConfig } from '@sitecore-content-sdk/core/config';
-import { LayoutServiceContext, LayoutServiceData, RouteData } from '../index';
 import { constants } from '@sitecore-content-sdk/core';
 import { ComponentMap } from './sharedTypes';
-import { PageMode } from '@sitecore-content-sdk/core/client';
 
 export interface SitecoreProviderProps {
   /**
@@ -17,27 +15,23 @@ export interface SitecoreProviderProps {
    */
   componentMap: ComponentMap;
   /**
-   * The Sitecore Layout data.
+   * The page data.
    */
-  layoutData?: LayoutServiceData;
-  /**
-   * Page mode
-   */
-  mode: PageMode;
+  page: Page;
   children: React.ReactNode;
 }
 
 export interface SitecoreProviderState {
   /**
-   * Method to set the page context.
-   * @param {SitecoreProviderPageContext | LayoutServiceData} value New page context value.
+   * Method to set the page.
+   * @param {Page} value New page  value.
    * @returns {void}
    */
-  setContext: (value: SitecoreProviderPageContext | LayoutServiceData) => void;
+  setPage: (value: Page) => void;
   /**
-   * The current page context.
+   * The current page.
    */
-  pageContext: SitecoreProviderPageContext;
+  page: Page;
   /**
    * The API configuration defined in the `SitecoreConfig`.
    */
@@ -49,15 +43,6 @@ export const SitecoreProviderReactContext = React.createContext<SitecoreProvider
 );
 export const ComponentMapReactContext = React.createContext<ComponentMap>(new Map());
 
-/**
- * The page context provided by the SitecoreProvider.
- */
-export type SitecoreProviderPageContext = LayoutServiceContext & {
-  itemId?: string;
-  route?: RouteData;
-  mode: PageMode;
-};
-
 export class SitecoreProvider extends React.Component<
   SitecoreProviderProps,
   SitecoreProviderState
@@ -66,8 +51,6 @@ export class SitecoreProvider extends React.Component<
 
   constructor(props: SitecoreProviderProps) {
     super(props);
-
-    const pageContext: SitecoreProviderPageContext = this.constructContext(props.layoutData);
 
     // If any Edge ID is present but no edgeUrl, apply the default
     let api = props.api;
@@ -85,45 +68,29 @@ export class SitecoreProvider extends React.Component<
     }
 
     this.state = {
-      pageContext,
-      setContext: this.setContext,
+      page: props.page,
+      setPage: this.setPage,
       api,
     };
   }
 
-  constructContext(layoutData?: LayoutServiceData): SitecoreProviderPageContext {
-    if (!layoutData) {
-      return { mode: this.props.mode };
-    }
-
-    return {
-      route: layoutData.sitecore.route,
-      itemId: layoutData.sitecore.route?.itemId,
-      ...layoutData.sitecore.context,
-      mode: this.props.mode,
-    };
-  }
-
   componentDidUpdate(prevProps: SitecoreProviderProps) {
-    // In case if somebody will manage SitecoreProvider state by passing fresh `layoutData` prop
+    // In case if somebody will manage SitecoreProvider state by passing fresh `page` prop
     // instead of using `updateContext`
-    if (!fastDeepEqual(prevProps.layoutData, this.props.layoutData)) {
-      this.setContext(this.props.layoutData);
+    if (!fastDeepEqual(prevProps.page, this.props.page)) {
+      this.setPage(this.props.page);
 
       return;
     }
   }
 
   /**
-   * Update context state. Value can be @type {LayoutServiceData} which will be automatically transformed
-   * or you can provide exact @type {SitecoreProviderPageContext}
-   * @param {SitecoreProviderPageContext | LayoutServiceData} value New context value
+   * Update page state.
+   * @param {Page} value New page value
    */
-  setContext = (value: SitecoreProviderPageContext | LayoutServiceData) => {
+  setPage = (value: Page) => {
     this.setState({
-      pageContext: value.sitecore
-        ? this.constructContext(value as LayoutServiceData)
-        : { ...(value as SitecoreProviderPageContext), mode: this.props.mode },
+      page: value,
     });
   };
 

--- a/packages/react/src/components/SitecoreProvider.tsx
+++ b/packages/react/src/components/SitecoreProvider.tsx
@@ -5,6 +5,7 @@ import { SitecoreConfig } from '@sitecore-content-sdk/core/config';
 import { LayoutServiceContext, LayoutServiceData, RouteData } from '../index';
 import { constants } from '@sitecore-content-sdk/core';
 import { ComponentMap } from './sharedTypes';
+import { PageMode } from '@sitecore-content-sdk/core/client';
 
 export interface SitecoreProviderProps {
   /**
@@ -19,6 +20,10 @@ export interface SitecoreProviderProps {
    * The Sitecore Layout data.
    */
   layoutData?: LayoutServiceData;
+  /**
+   * Page mode
+   */
+  mode: PageMode;
   children: React.ReactNode;
 }
 
@@ -50,6 +55,7 @@ export const ComponentMapReactContext = React.createContext<ComponentMap>(new Ma
 export type SitecoreProviderPageContext = LayoutServiceContext & {
   itemId?: string;
   route?: RouteData;
+  mode: PageMode;
 };
 
 export class SitecoreProvider extends React.Component<
@@ -87,13 +93,14 @@ export class SitecoreProvider extends React.Component<
 
   constructContext(layoutData?: LayoutServiceData): SitecoreProviderPageContext {
     if (!layoutData) {
-      return { pageEditing: false };
+      return { mode: this.props.mode };
     }
 
     return {
       route: layoutData.sitecore.route,
       itemId: layoutData.sitecore.route?.itemId,
       ...layoutData.sitecore.context,
+      mode: this.props.mode,
     };
   }
 
@@ -116,7 +123,7 @@ export class SitecoreProvider extends React.Component<
     this.setState({
       pageContext: value.sitecore
         ? this.constructContext(value as LayoutServiceData)
-        : { ...(value as SitecoreProviderPageContext) },
+        : { ...(value as SitecoreProviderPageContext), mode: this.props.mode },
     });
   };
 

--- a/packages/react/src/enhancers/withDatasourceCheck.test.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.test.tsx
@@ -5,13 +5,34 @@ import { render } from '@testing-library/react';
 import { spy } from 'sinon';
 
 import { withDatasourceCheck, WithDatasourceCheckProps } from '../enhancers/withDatasourceCheck';
-import { SitecoreProviderReactContext } from '../components/SitecoreProvider';
-import { PageMode } from '@sitecore-content-sdk/core/client';
+import {
+  SitecoreProviderReactContext,
+  SitecoreProviderState,
+} from '../components/SitecoreProvider';
+import { LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
 
-const mockContext = (editing: boolean) => {
+const mockContext = (editing: boolean): SitecoreProviderState => {
   return {
-    pageContext: { mode: { isEditing: editing } as PageMode },
-    setContext: spy(),
+    page: {
+      locale: 'en',
+      layout: {
+        sitecore: {
+          context: {},
+          route: null,
+        },
+      },
+      mode: {
+        name: LayoutServicePageState.Normal,
+        isNormal: false,
+        isPreview: false,
+        isEditing: editing,
+        isDesignLibrary: false,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+      },
+    },
+    setPage: spy(),
   };
 };
 
@@ -106,7 +127,7 @@ describe('withDatasourceCheck', () => {
 
     const context = mockContext(false);
 
-    context.pageContext.mode.isDesignLibrary = true;
+    context.page.mode.isDesignLibrary = true;
 
     const wrapper = render(
       <SitecoreProviderReactContext.Provider value={context}>

--- a/packages/react/src/enhancers/withDatasourceCheck.test.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.test.tsx
@@ -6,11 +6,11 @@ import { spy } from 'sinon';
 
 import { withDatasourceCheck, WithDatasourceCheckProps } from '../enhancers/withDatasourceCheck';
 import { SitecoreProviderReactContext } from '../components/SitecoreProvider';
-import { RenderingType } from '@sitecore-content-sdk/core/layout';
+import { PageMode } from '@sitecore-content-sdk/core/client';
 
-const mockContext = (editing: boolean, renderingType?: RenderingType) => {
+const mockContext = (editing: boolean) => {
   return {
-    pageContext: { pageEditing: editing, renderingType },
+    pageContext: { mode: { isEditing: editing } as PageMode },
     setContext: spy(),
   };
 };
@@ -104,8 +104,12 @@ describe('withDatasourceCheck', () => {
       },
     };
 
+    const context = mockContext(false);
+
+    context.pageContext.mode.isDesignLibrary = true;
+
     const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={mockContext(false, RenderingType.Component)}>
+      <SitecoreProviderReactContext.Provider value={context}>
         <TestComponentWithDatasourceCheck {...props} />
       </SitecoreProviderReactContext.Provider>
     );
@@ -161,7 +165,11 @@ describe('withDatasourceCheck', () => {
       },
     };
 
-    const wrapper = render(<TestComponentWithDatasourceCheck {...props} />);
+    const wrapper = render(
+      <SitecoreProviderReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreProviderReactContext.Provider>
+    );
 
     expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
     expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);

--- a/packages/react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.tsx
@@ -1,5 +1,5 @@
 ﻿import React, { JSX } from 'react';
-import { ComponentRendering, RenderingType } from '@sitecore-content-sdk/core/layout';
+import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
 import { useSitecore } from './withSitecore';
 
 export const DefaultEditingError = (): JSX.Element => (
@@ -36,11 +36,11 @@ export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
       const EditingError = options?.editingErrorComponent ?? DefaultEditingError;
 
       // If the component is rendered in DesignLibrary, we don't need to check for datasource
-      const isDesignLibrary = pageContext?.renderingType === RenderingType.Component;
+      const isDesignLibrary = pageContext.mode.isDesignLibrary;
 
       return isDesignLibrary || props.rendering?.dataSource ? (
         <Component {...props} />
-      ) : pageContext.pageEditing ? (
+      ) : pageContext.mode.isEditing ? (
         <EditingError />
       ) : null;
     };

--- a/packages/react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.tsx
@@ -32,15 +32,15 @@ export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
     Component: React.ComponentType<ComponentProps>
   ) {
     return function WithDatasourceCheck(props: ComponentProps) {
-      const { pageContext } = useSitecore();
+      const { page } = useSitecore();
       const EditingError = options?.editingErrorComponent ?? DefaultEditingError;
 
       // If the component is rendered in DesignLibrary, we don't need to check for datasource
-      const isDesignLibrary = pageContext.mode.isDesignLibrary;
+      const isDesignLibrary = page.mode.isDesignLibrary;
 
       return isDesignLibrary || props.rendering?.dataSource ? (
         <Component {...props} />
-      ) : pageContext.mode.isEditing ? (
+      ) : page.mode.isEditing ? (
         <EditingError />
       ) : null;
     };

--- a/packages/react/src/enhancers/withPlaceholder.test.tsx
+++ b/packages/react/src/enhancers/withPlaceholder.test.tsx
@@ -4,6 +4,8 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { PageMode } from '@sitecore-content-sdk/core/client';
+import { LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
 import { convertedDevData as normalModeDevData } from '../test-data/normal-mode-data';
 import * as metadataData from '../test-data/metadata-data';
 import { withPlaceholder } from '../enhancers/withPlaceholder';
@@ -76,6 +78,8 @@ componentMap.set(
 const testData = [{ label: 'Dev data', data: normalModeDevData }];
 
 describe('withPlaceholder HOC', () => {
+  const mode: PageMode = { name: LayoutServicePageState.Normal, isEditing: false };
+
   describe('Error handling', () => {
     before(() => {
       // Set to development mode to show error details
@@ -93,6 +97,7 @@ describe('withPlaceholder HOC', () => {
         <SitecoreProvider
           layoutData={(normalModeDevData as unknown) as LayoutServiceData}
           componentMap={componentMap}
+          mode={mode}
         >
           <Element {...props} />
         </SitecoreProvider>
@@ -114,6 +119,7 @@ describe('withPlaceholder HOC', () => {
         <SitecoreProvider
           layoutData={(normalModeDevData as unknown) as LayoutServiceData}
           componentMap={componentMap}
+          mode={mode}
         >
           <Element {...props} />
         </SitecoreProvider>
@@ -133,7 +139,7 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={normalModeDevData} componentMap={componentMap}>
+        <SitecoreProvider layoutData={normalModeDevData} componentMap={componentMap} mode={mode}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -164,7 +170,7 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={normalModeDevData} componentMap={componentMap}>
+        <SitecoreProvider layoutData={normalModeDevData} componentMap={componentMap} mode={mode}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -197,6 +203,7 @@ describe('withPlaceholder HOC', () => {
           <SitecoreProvider
             layoutData={dataSet.data as LayoutServiceData}
             componentMap={componentMap}
+            mode={mode}
           >
             <Element {...props} />
           </SitecoreProvider>
@@ -224,6 +231,7 @@ describe('withPlaceholder HOC', () => {
           <SitecoreProvider
             layoutData={dataSet.data as LayoutServiceData}
             componentMap={componentMap}
+            mode={mode}
           >
             <Element {...props} />
           </SitecoreProvider>
@@ -257,6 +265,7 @@ describe('withPlaceholder HOC', () => {
           <SitecoreProvider
             layoutData={dataSet.data as LayoutServiceData}
             componentMap={componentMap}
+            mode={mode}
           >
             <Element {...props} />
           </SitecoreProvider>
@@ -270,6 +279,10 @@ describe('withPlaceholder HOC', () => {
   });
 
   describe('Metadata Mode', () => {
+    const mode: PageMode = {
+      name: LayoutServicePageState.Edit,
+      isEditing: true,
+    };
     const {
       layoutData,
       layoutDataWithEmptyPlaceholder,
@@ -298,7 +311,7 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutData} componentMap={componentMap}>
+        <SitecoreProvider layoutData={layoutData} componentMap={componentMap} mode={mode}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -334,7 +347,7 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKeyAndProp)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutData} componentMap={componentMap}>
+        <SitecoreProvider layoutData={layoutData} componentMap={componentMap} mode={mode}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -367,7 +380,11 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutDataWithEmptyPlaceholder} componentMap={componentMap}>
+        <SitecoreProvider
+          layoutData={layoutDataWithEmptyPlaceholder}
+          componentMap={componentMap}
+          mode={mode}
+        >
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -391,7 +408,11 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutDataWithUnknownComponent} componentMap={componentMap}>
+        <SitecoreProvider
+          layoutData={layoutDataWithUnknownComponent}
+          componentMap={componentMap}
+          mode={mode}
+        >
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -419,7 +440,7 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutData} componentMap={componentMap}>
+        <SitecoreProvider layoutData={layoutData} componentMap={componentMap} mode={mode}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -452,7 +473,7 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutData} componentMap={componentMap}>
+        <SitecoreProvider layoutData={layoutData} componentMap={componentMap} mode={mode}>
           <Element {...props} />
         </SitecoreProvider>
       );

--- a/packages/react/src/enhancers/withPlaceholder.test.tsx
+++ b/packages/react/src/enhancers/withPlaceholder.test.tsx
@@ -4,7 +4,7 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-import { PageMode } from '@sitecore-content-sdk/core/client';
+import { Page, PageMode } from '@sitecore-content-sdk/core/client';
 import { LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
 import { convertedDevData as normalModeDevData } from '../test-data/normal-mode-data';
 import * as metadataData from '../test-data/metadata-data';
@@ -78,7 +78,33 @@ componentMap.set(
 const testData = [{ label: 'Dev data', data: normalModeDevData }];
 
 describe('withPlaceholder HOC', () => {
-  const mode: PageMode = { name: LayoutServicePageState.Normal, isEditing: false };
+  const api = {
+    edge: {
+      contextId: 'id',
+      edgeUrl: 'url',
+      clientContextId: 'clientId',
+    },
+    local: {
+      apiKey: 'apiKey',
+      apiHost: 'apiHost',
+      path: 'path',
+    },
+  };
+
+  const getPage = (): Page => ({
+    layout: normalModeDevData,
+    locale: 'en',
+    mode: {
+      name: LayoutServicePageState.Normal,
+      isNormal: true,
+      isPreview: false,
+      isEditing: false,
+      isDesignLibrary: false,
+      designLibrary: {
+        isVariantGeneration: false,
+      },
+    },
+  });
 
   describe('Error handling', () => {
     before(() => {
@@ -88,17 +114,13 @@ describe('withPlaceholder HOC', () => {
 
     it('should render default error component on wrapped component error', () => {
       const phKey = 'page-content';
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: (null as unknown) as ComponentRendering,
       };
       const Element = withPlaceholder(phKey)(ErrorComponent);
       const renderedComponent = render(
-        <SitecoreProvider
-          layoutData={(normalModeDevData as unknown) as LayoutServiceData}
-          componentMap={componentMap}
-          mode={mode}
-        >
+        <SitecoreProvider api={api} componentMap={componentMap} page={getPage()}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -109,18 +131,14 @@ describe('withPlaceholder HOC', () => {
 
     it('should render custom component error on wrapped component error, when provided', () => {
       const phKey = 'page-content';
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: (null as unknown) as ComponentRendering,
         errorComponent: ErrorMessageComponent,
       };
       const Element = withPlaceholder(phKey)(ErrorComponent);
       const renderedComponent = render(
-        <SitecoreProvider
-          layoutData={(normalModeDevData as unknown) as LayoutServiceData}
-          componentMap={componentMap}
-          mode={mode}
-        >
+        <SitecoreProvider api={api} componentMap={componentMap} page={getPage()}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -133,13 +151,13 @@ describe('withPlaceholder HOC', () => {
         | RouteData
       )[]).find((c) => (c as ComponentRendering).componentName) as ComponentRendering;
       const phKey = 'page-content';
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: component,
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={normalModeDevData} componentMap={componentMap} mode={mode}>
+        <SitecoreProvider api={api} componentMap={componentMap} page={getPage()}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -162,7 +180,7 @@ describe('withPlaceholder HOC', () => {
         | RouteData
       )[]).find((c) => (c as ComponentRendering).componentName) as ComponentRendering;
       const phKey = 'page-content';
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: component,
         errorComponent: ErrorMessageComponent,
@@ -170,7 +188,7 @@ describe('withPlaceholder HOC', () => {
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={normalModeDevData} componentMap={componentMap} mode={mode}>
+        <SitecoreProvider api={api} componentMap={componentMap} page={getPage()}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -194,17 +212,13 @@ describe('withPlaceholder HOC', () => {
           | RouteData
         )[]).find((c) => (c as ComponentRendering).componentName) as ComponentRendering;
         const phKey = 'page-content';
-        const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+        const props: EnhancedOmit<PlaceholderProps, 'page'> = {
           name: phKey,
           rendering: component,
         };
         const Element = withPlaceholder(phKey)(Home);
         const renderedComponent = render(
-          <SitecoreProvider
-            layoutData={dataSet.data as LayoutServiceData}
-            componentMap={componentMap}
-            mode={mode}
-          >
+          <SitecoreProvider api={api} componentMap={componentMap} page={getPage()}>
             <Element {...props} />
           </SitecoreProvider>
         );
@@ -222,17 +236,13 @@ describe('withPlaceholder HOC', () => {
           placeholder: 'page-header',
           prop: 'subProp',
         };
-        const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+        const props: EnhancedOmit<PlaceholderProps, 'page'> = {
           name: 'page-header',
           rendering: component,
         };
         const Element = withPlaceholder(phKeyAndProp)(Home);
         const renderedComponent = render(
-          <SitecoreProvider
-            layoutData={dataSet.data as LayoutServiceData}
-            componentMap={componentMap}
-            mode={mode}
-          >
+          <SitecoreProvider api={api} componentMap={componentMap} page={getPage()}>
             <Element {...props} />
           </SitecoreProvider>
         );
@@ -256,17 +266,13 @@ describe('withPlaceholder HOC', () => {
             return { ...props, reset: true };
           },
         };
-        const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+        const props: EnhancedOmit<PlaceholderProps, 'page'> = {
           name: 'page-header',
           rendering: component,
         };
         const Element = withPlaceholder(phKeyAndProp, phOptions)(Home);
         const renderedComponent = render(
-          <SitecoreProvider
-            layoutData={dataSet.data as LayoutServiceData}
-            componentMap={componentMap}
-            mode={mode}
-          >
+          <SitecoreProvider api={api} componentMap={componentMap} page={getPage()}>
             <Element {...props} />
           </SitecoreProvider>
         );
@@ -279,10 +285,16 @@ describe('withPlaceholder HOC', () => {
   });
 
   describe('Metadata Mode', () => {
-    const mode: PageMode = {
-      name: LayoutServicePageState.Edit,
-      isEditing: true,
+    const defaultPage = getPage();
+    const editModePage: Page = {
+      ...defaultPage,
+      mode: {
+        ...defaultPage.mode,
+        name: LayoutServicePageState.Edit,
+        isEditing: true,
+      },
     };
+
     const {
       layoutData,
       layoutDataWithEmptyPlaceholder,
@@ -305,13 +317,13 @@ describe('withPlaceholder HOC', () => {
     it('should render a placeholder with given key', () => {
       const component = layoutData.sitecore.route;
       const phKey = 'main';
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: component,
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutData} componentMap={componentMap} mode={mode}>
+        <SitecoreProvider api={api} componentMap={componentMap} page={editModePage}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -341,13 +353,13 @@ describe('withPlaceholder HOC', () => {
         placeholder: phKey,
         prop: 'subProp',
       };
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: component,
       };
       const Element = withPlaceholder(phKeyAndProp)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutData} componentMap={componentMap} mode={mode}>
+        <SitecoreProvider api={api} componentMap={componentMap} page={editModePage}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -374,17 +386,13 @@ describe('withPlaceholder HOC', () => {
     it('should render code blocks even if placeholder is empty', () => {
       const component = layoutDataWithEmptyPlaceholder.sitecore.route;
       const phKey = 'main';
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: component,
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider
-          layoutData={layoutDataWithEmptyPlaceholder}
-          componentMap={componentMap}
-          mode={mode}
-        >
+        <SitecoreProvider api={api} componentMap={componentMap} page={editModePage}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -402,17 +410,13 @@ describe('withPlaceholder HOC', () => {
     it('should render missing component with code blocks if component is not registered', () => {
       const component = layoutDataWithUnknownComponent.sitecore.route;
       const phKey = 'main';
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: component,
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider
-          layoutData={layoutDataWithUnknownComponent}
-          componentMap={componentMap}
-          mode={mode}
-        >
+        <SitecoreProvider api={api} componentMap={componentMap} page={editModePage}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -434,13 +438,13 @@ describe('withPlaceholder HOC', () => {
       const phKey = 'container-1';
       const layoutData = layoutDataForNestedDynamicPlaceholder('container-{*}');
       const component = layoutData.sitecore.route;
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: component,
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutData} componentMap={componentMap} mode={mode}>
+        <SitecoreProvider api={api} componentMap={componentMap} page={editModePage}>
           <Element {...props} />
         </SitecoreProvider>
       );
@@ -467,13 +471,13 @@ describe('withPlaceholder HOC', () => {
       const phKey = 'container-1-2';
       const layoutData = layoutDataForNestedDynamicPlaceholder('container-1-{*}');
       const component = layoutData.sitecore.route;
-      const props: EnhancedOmit<PlaceholderProps, 'pageContext'> = {
+      const props: EnhancedOmit<PlaceholderProps, 'page'> = {
         name: phKey,
         rendering: component,
       };
       const Element = withPlaceholder(phKey)(Home);
       const renderedComponent = render(
-        <SitecoreProvider layoutData={layoutData} componentMap={componentMap} mode={mode}>
+        <SitecoreProvider api={api} componentMap={componentMap} page={editModePage}>
           <Element {...props} />
         </SitecoreProvider>
       );

--- a/packages/react/src/enhancers/withPlaceholder.tsx
+++ b/packages/react/src/enhancers/withPlaceholder.tsx
@@ -90,7 +90,7 @@ export function withPlaceholder(
             placeholderData = PlaceholderCommon.getPlaceholderDataFromRenderingData(
               renderingData,
               placeholder.placeholder,
-              childProps.pageContext.pageEditing
+              childProps.pageContext.mode.isEditing
             );
             if (placeholderData) {
               childProps[placeholder.prop] = this.getComponentsForRenderingData(placeholderData);
@@ -99,7 +99,7 @@ export function withPlaceholder(
             placeholderData = PlaceholderCommon.getPlaceholderDataFromRenderingData(
               renderingData,
               placeholder as string,
-              childProps.pageContext.pageEditing
+              childProps.pageContext.mode.isEditing
             );
             if (placeholderData) {
               childProps[placeholder as string] = this.getComponentsForRenderingData(

--- a/packages/react/src/enhancers/withPlaceholder.tsx
+++ b/packages/react/src/enhancers/withPlaceholder.tsx
@@ -90,7 +90,7 @@ export function withPlaceholder(
             placeholderData = PlaceholderCommon.getPlaceholderDataFromRenderingData(
               renderingData,
               placeholder.placeholder,
-              childProps.pageContext.mode.isEditing
+              childProps.page.mode.isEditing
             );
             if (placeholderData) {
               childProps[placeholder.prop] = this.getComponentsForRenderingData(placeholderData);
@@ -99,7 +99,7 @@ export function withPlaceholder(
             placeholderData = PlaceholderCommon.getPlaceholderDataFromRenderingData(
               renderingData,
               placeholder as string,
-              childProps.pageContext.mode.isEditing
+              childProps.page.mode.isEditing
             );
             if (placeholderData) {
               childProps[placeholder as string] = this.getComponentsForRenderingData(

--- a/packages/react/src/enhancers/withSitecore.test.tsx
+++ b/packages/react/src/enhancers/withSitecore.test.tsx
@@ -5,36 +5,66 @@ import { fireEvent, render } from '@testing-library/react';
 import { spy } from 'sinon';
 import sinonChai from 'sinon-chai';
 
-import { useSitecore, withSitecore } from '../enhancers/withSitecore';
-import { SitecoreProviderReactContext } from '../components/SitecoreProvider';
+import { useSitecore, withSitecore, WithSitecoreProps } from '../enhancers/withSitecore';
+import {
+  SitecoreProviderReactContext,
+  SitecoreProviderState,
+} from '../components/SitecoreProvider';
+import { LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
 
 use(sinonChai);
 
 describe('withSitecore', () => {
-  it('withSitecore()', () => {
-    const setContext = spy();
+  const setPage = spy();
 
-    const testComponentProps = {
-      pageContext: {
-        text: 'value',
-      },
-      api: {
-        edge: {
-          contextId: 'id',
-          edgeUrl: 'url',
+  const testComponentProps: SitecoreProviderState = {
+    page: {
+      layout: {
+        sitecore: {
+          context: {},
+          route: null,
         },
       },
-      setContext,
-    };
+      locale: 'en',
+      mode: {
+        name: LayoutServicePageState.Normal,
+        isNormal: true,
+        isPreview: false,
+        isEditing: false,
+        isDesignLibrary: false,
+        designLibrary: {
+          isVariantGeneration: false,
+        },
+      },
+    },
+    api: {
+      edge: {
+        contextId: 'id',
+        edgeUrl: 'url',
+        clientContextId: 'clientId',
+      },
+      local: {
+        apiKey: 'apiKey',
+        apiHost: 'apiHost',
+        path: 'path',
+      },
+    },
+    setPage,
+  };
 
-    const TestComponent: React.FC<any> = (props: any) => (
+  afterEach(() => {
+    setPage.resetHistory();
+  });
+
+  it('withSitecore()', () => {
+    const TestComponent: React.FC<any> = (props: WithSitecoreProps & { customProp: string }) => (
       <>
-        <div onClick={props.updateContext}>
-          {props.pageContext.text}
+        <div onClick={props.updatePage}>
+          {props.page.locale}
           {props.customProp}
         </div>
         <span>
-          {props.api.edge.contextId} {props.api.edge.edgeUrl}
+          {props.api?.edge.contextId} {props.api?.edge.edgeUrl}
         </span>
       </>
     );
@@ -49,12 +79,12 @@ describe('withSitecore', () => {
 
     expect(wrapper.container.querySelector('span')?.textContent).equal('id url');
     expect(wrapper.container.querySelector('div')?.textContent).equal(
-      testComponentProps.pageContext.text + 'xxx'
+      testComponentProps.page.locale + 'xxx'
     );
     fireEvent.click(wrapper.container.querySelector('div') as Element);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(testComponentProps.setContext).not.to.be.called;
+    expect(testComponentProps.setPage).not.to.be.called;
 
     TestComponentWithContext = withSitecore({ updatable: true })(TestComponent);
 
@@ -67,34 +97,19 @@ describe('withSitecore', () => {
     fireEvent.click(wrapper.container.querySelector('div') as Element);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(testComponentProps.setContext).to.have.been.called;
+    expect(testComponentProps.setPage).to.have.been.called;
   });
 
   describe('useSitecore()', () => {
     it('context access', () => {
-      const setContext = spy();
-
-      const testComponentProps = {
-        pageContext: {
-          text: 'value',
-        },
-        api: {
-          edge: {
-            contextId: 'id',
-            edgeUrl: 'url',
-          },
-        },
-        setContext,
-      };
-
       const TestComponent: React.FC<any> = (props: any) => {
         const reactContext = useSitecore();
-        const context = reactContext.pageContext as { text: string };
+        const page = reactContext.page;
 
         return (
           <>
-            <div onClick={reactContext.updateContext}>
-              {context.text}
+            <div onClick={reactContext.updatePage}>
+              {page.locale}
               {props.customProp}
             </div>
             <span>
@@ -111,32 +126,23 @@ describe('withSitecore', () => {
       );
 
       expect(wrapper.container.querySelector('div')?.textContent).equal(
-        testComponentProps.pageContext.text + 'xxx'
+        testComponentProps.page.locale + 'xxx'
       );
       expect(wrapper.container.querySelector('span')?.textContent).equal('id url');
       fireEvent.click(wrapper.container.querySelector('div') as Element);
 
       // eslint-disable-next-line no-unused-expressions
-      expect(testComponentProps.setContext).to.not.have.been.called;
+      expect(testComponentProps.setPage).to.not.have.been.called;
     });
 
     it('updatable', () => {
-      const setContext = spy();
-
-      const testComponentProps = {
-        pageContext: {
-          text: 'value',
-        },
-        setContext,
-      };
-
       const TestComponent: React.FC<any> = (props: any) => {
         const reactContext = useSitecore({ updatable: true });
-        const context = reactContext.pageContext as { text: string };
+        const context = reactContext.page;
 
         return (
-          <div onClick={reactContext.updateContext}>
-            {context.text}
+          <div onClick={reactContext.updatePage}>
+            {context.locale}
             {props.customProp}
           </div>
         );
@@ -149,12 +155,12 @@ describe('withSitecore', () => {
       );
 
       expect(wrapper.container.querySelector('div')?.textContent).equal(
-        testComponentProps.pageContext.text + 'bbb'
+        testComponentProps.page.locale + 'bbb'
       );
       fireEvent.click(wrapper.container.querySelector('div') as Element);
 
       // eslint-disable-next-line no-unused-expressions
-      expect(testComponentProps.setContext).to.have.been.called;
+      expect(testComponentProps.setPage).to.have.been.called;
     });
   });
 });

--- a/packages/react/src/enhancers/withSitecore.tsx
+++ b/packages/react/src/enhancers/withSitecore.tsx
@@ -3,8 +3,8 @@ import { EnhancedOmit } from '@sitecore-content-sdk/core/utils';
 import {
   SitecoreProviderReactContext,
   SitecoreProviderState,
-  SitecoreProviderPageContext,
 } from '../components/SitecoreProvider';
+import { Page } from '@sitecore-content-sdk/core/client';
 
 export interface WithSitecoreOptions {
   /**
@@ -18,17 +18,17 @@ export interface WithSitecoreProps {
   /**
    * The current page context.
    */
-  pageContext: SitecoreProviderPageContext;
+  page: Page;
   /**
    * The API configuration defined in the `SitecoreConfig`.
    */
   api?: SitecoreProviderState['api'];
   /**
-   * Method to update the page context. This is only available if `updatable` is set to true.
-   * @param {SitecoreProviderPageContext} value New page context value.
+   * Method to update the page. This is only available if `updatable` is set to true.
+   * @param {Page} value New page value.
    * @returns {void}
    */
-  updateContext?: ((value: SitecoreProviderPageContext) => void) | false;
+  updatePage?: ((value: Page) => void) | false;
 }
 
 // The props that HOC will receive.
@@ -50,9 +50,9 @@ export function withSitecore(options?: WithSitecoreOptions) {
           {(value) => (
             <Component
               {...(props as ComponentProps)}
-              pageContext={value.pageContext}
+              page={value.page}
               api={value.api}
-              updateContext={options && options.updatable && value.setContext}
+              updatePage={options && options.updatable && value.setPage}
             />
           )}
         </SitecoreProviderReactContext.Consumer>
@@ -62,20 +62,20 @@ export function withSitecore(options?: WithSitecoreOptions) {
 }
 
 /**
- * This hook grants acсess to the current Sitecore page context and api.
+ * This hook grants acсess to the current Sitecore page and api.
  * @param {WithSitecoreOptions} [options] hook options
  * @example
  * const EditMode = () => {
- *    const { pageContext } = useSitecore();
- *    return <span>Edit Mode is {pageContext.mode.isEditing ? 'active' : 'inactive'}</span>
+ *    const { page } = useSitecore();
+ *    return <span>Edit Mode is {page.mode.isEditing ? 'active' : 'inactive'}</span>
  * }
  * @example
  * const EditMode = () => {
- *    const { pageContext, updateContext } = useSitecore({ updatable: true });
- *    const onClick = () => updateContext({ itemId: '123' });
- *    return <span onClick={onClick}>Item id is {pageContext.itemId}</span>
+ *    const { page, updatePage } = useSitecore({ updatable: true });
+ *    const onClick = () => updatePage({ itemId: '123' });
+ *    return <span onClick={onClick}>Item id is {page.itemId}</span>
  * }
- * @returns {object} { api, pageContext, updateContext }
+ * @returns {object} { api, page, updatePage }
  */
 export function useSitecore(options?: WithSitecoreOptions): WithSitecoreProps {
   const reactContext = React.useContext(SitecoreProviderReactContext);
@@ -83,7 +83,7 @@ export function useSitecore(options?: WithSitecoreOptions): WithSitecoreProps {
 
   return {
     api: reactContext.api,
-    pageContext: reactContext.pageContext,
-    updateContext: updatable ? reactContext.setContext : undefined,
+    page: reactContext.page,
+    updatePage: updatable ? reactContext.setPage : undefined,
   };
 }

--- a/packages/react/src/enhancers/withSitecore.tsx
+++ b/packages/react/src/enhancers/withSitecore.tsx
@@ -63,21 +63,17 @@ export function withSitecore(options?: WithSitecoreOptions) {
 
 /**
  * This hook grants acсess to the current Sitecore page context and api.
- * by default Content SDK includes the following properties in this context:
- * - pageEditing - Provided by Layout Service, a boolean indicating whether the route is being accessed via the Sitecore Editor.
- * - pageState - Like pageEditing, but a string: normal, preview or edit.
- * - site - Provided by Layout Service, an object containing the name of the current Sitecore site context.
  * @param {WithSitecoreOptions} [options] hook options
  * @example
  * const EditMode = () => {
  *    const { pageContext } = useSitecore();
- *    return <span>Edit Mode is {pageContext.pageEditing ? 'active' : 'inactive'}</span>
+ *    return <span>Edit Mode is {pageContext.mode.isEditing ? 'active' : 'inactive'}</span>
  * }
  * @example
  * const EditMode = () => {
  *    const { pageContext, updateContext } = useSitecore({ updatable: true });
- *    const onClick = () => updateContext({ pageEditing: true });
- *    return <span onClick={onClick}>Edit Mode is {pageContext.pageEditing ? 'active' : 'inactive'}</span>
+ *    const onClick = () => updateContext({ itemId: '123' });
+ *    return <span onClick={onClick}>Item id is {pageContext.itemId}</span>
  * }
  * @returns {object} { api, pageContext, updateContext }
  */

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -37,6 +37,8 @@ export {
   GraphQLRequestClientFactoryConfig,
   GraphQLRequestClient,
   PageMode,
+  ErrorPage,
+  Page,
 } from '@sitecore-content-sdk/core/client';
 export { mediaApi } from '@sitecore-content-sdk/core/media';
 export { Form } from './components/Form';
@@ -72,7 +74,6 @@ export { File, FileField } from './components/File';
 export {
   SitecoreProvider,
   SitecoreProviderState,
-  SitecoreProviderPageContext,
   SitecoreProviderReactContext,
 } from './components/SitecoreProvider';
 export {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,6 +36,7 @@ export {
   DefaultRetryStrategy,
   GraphQLRequestClientFactoryConfig,
   GraphQLRequestClient,
+  PageMode,
 } from '@sitecore-content-sdk/core/client';
 export { mediaApi } from '@sitecore-content-sdk/core/media';
 export { Form } from './components/Form';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
As part of our work on the AI generation mode, we realized the need to revisit how page state is stored and shared across components. This PR introduces foundational changes that go beyond the AI-related functionality.

## Introduced `VariantGeneration` Mode

- Added support for a new **`VariantGeneration`** mode.
- The `DesignLibrary` component now supports `VariantGeneration` mode. It can:
  - Send a **mock import map** to simulate available components.
  - Send **mock component props** (including `fields` and `params`).
  - Subscribe to the `preview` event and set **mock component** for live previewing.
  - The Next.js middleware now can recognize `VariantGeneration` mode.

## Reworked `SitecoreProvider` and Context

- Refactored components that use `SitecoreProvider` and related utilities.
- `SitecoreProvider` now accepts a `page` prop (`Page` type from `SitecoreClient`) instead of `layoutData`.
- Context state updates:
  - `pageContext` → renamed to `page`. `page` represents `Page` interface.
  - `setContext` → renamed to `setPage`
- Removed `SitecoreProviderPageContext` interface.
  - Consumers should now access `page` via the `Page` interface.

## Updated `withSitecore` and `useSitecore` APIs

- Updated naming for clarity and consistency:
  - `pageContext` → `page`
  - `updateContext` → `updatePage`

## Improvements to `SitecoreClient`

- **Type cleanup and consistency**:
  - Removed `NextjsPage` interface.
  - All methods that generate page data now return a consistent `Page` object.
  - Properties `componentProps` and `notFound` are now part of the `SitecorePageProps` interface and are treated as optional.
  - `SitecorePageProps` now requires a standalone `page` field instead of merging all data into one props object.

- **New `getErrorPage()` method**:
  - Replaces `getErrorPages()`, exposing only necessary data.
  - Introduces a new `ErrorPage` enum to select specific error types (e.g., `ErrorPage.NotFound`)
  
- **New `PageMode` Type**
     - The `Page` type now includes a `mode` field of type `PageMode`, providing runtime context (e.g. editing, design library, preview).
     - Replaces older properties like `pageState`, `pageEditing`, `componentType`.

## DesignLibrary Component

- The `DesignLibrary` component no longer accepts a `layoutData` prop.
- It now accesses `page` directly from `SitecoreProvider`.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
