### PR TITLE
[core] Duplicate dictionary requests in editing, preview, and design library modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+
+* `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))
+  - `SitecoreClient.getPreview` and `SitecoreClient.getDesignLibraryData` no longer request dictionary data. `Page` type is not affected.
+  - Updated `EditingService.fetchEditingData`:
+    - Removed `siteName` parameter.
+    - No longer requests and returns dictionary data.
+
 ## 1.0.0
 
 ### 🎉 New Features & Improvements

--- a/packages/core/src/client/sitecore-client.test.ts
+++ b/packages/core/src/client/sitecore-client.test.ts
@@ -155,7 +155,6 @@ describe('SitecoreClient', () => {
               context: { site: { name: 'custom-site' } },
             },
           },
-          dictionary: { key: 'custom-dictionary' },
         }),
       };
 
@@ -724,7 +723,6 @@ describe('SitecoreClient', () => {
             context: { site: { name: 'default-site' } },
           },
         },
-        dictionary: { key1: 'value1', key2: 'value2' },
       };
 
       editingServiceStub.fetchEditingData.resolves(editingData);
@@ -734,7 +732,6 @@ describe('SitecoreClient', () => {
       expect(result).to.deep.include({
         locale: previewData.language,
         layout: editingData.layoutData,
-        dictionary: editingData.dictionary,
         mode: {
           name: LayoutServicePageState.Edit,
           isEditing: true,
@@ -750,7 +747,6 @@ describe('SitecoreClient', () => {
       expect(editingServiceStub.fetchEditingData.calledOnce).to.be.true;
       expect(
         editingServiceStub.fetchEditingData.calledWith({
-          siteName: previewData.site,
           itemId: previewData.itemId,
           language: previewData.language,
           version: previewData.version,
@@ -778,7 +774,6 @@ describe('SitecoreClient', () => {
             context: { site: { name: 'default-site' } },
           },
         },
-        dictionary: { key1: 'value1', key2: 'value2' },
       };
 
       editingServiceStub.fetchEditingData.resolves(editingData);
@@ -788,7 +783,6 @@ describe('SitecoreClient', () => {
       expect(result).to.deep.include({
         locale: previewData.language,
         layout: editingData.layoutData,
-        dictionary: editingData.dictionary,
         mode: {
           name: LayoutServicePageState.Preview,
           isNormal: false,
@@ -804,7 +798,6 @@ describe('SitecoreClient', () => {
       expect(editingServiceStub.fetchEditingData.calledOnce).to.be.true;
       expect(
         editingServiceStub.fetchEditingData.calledWith({
-          siteName: previewData.site,
           itemId: previewData.itemId,
           language: previewData.language,
           version: previewData.version,
@@ -830,7 +823,6 @@ describe('SitecoreClient', () => {
 
       const editingData = {
         layoutData: testLayoutData,
-        dictionary: { key1: 'value1', key2: 'value2' },
       };
 
       editingServiceStub.fetchEditingData.resolves(editingData);
@@ -901,12 +893,10 @@ describe('SitecoreClient', () => {
             },
           },
         },
-        dictionary: { key1: 'value1', key2: 'value2' },
       };
 
       editingServiceStub.fetchEditingData
         .withArgs({
-          siteName: previewData.site,
           itemId: previewData.itemId,
           language: previewData.language,
           version: previewData.version,
@@ -920,7 +910,6 @@ describe('SitecoreClient', () => {
       expect(
         editingServiceStub.fetchEditingData.calledWith(
           {
-            siteName: previewData.site,
             itemId: previewData.itemId,
             language: previewData.language,
             version: previewData.version,
@@ -959,20 +948,14 @@ describe('SitecoreClient', () => {
           },
         },
       };
-      const dictionaryData = { key: 'value' };
 
       restComponentServiceStub.fetchComponentData.resolves(componentData);
-
-      editingServiceStub.fetchDictionaryData
-        .withArgs({ siteName: componentLibData.site, language: componentLibData.language })
-        .resolves(dictionaryData);
 
       const result = await sitecoreClient.getDesignLibraryData(componentLibData);
 
       expect(result).to.deep.include({
         locale: componentLibData.language,
         layout: componentData,
-        dictionary: dictionaryData,
         siteName: componentData.sitecore.context.site?.name,
         mode: {
           name: DesignLibraryMode.Normal,
@@ -985,13 +968,6 @@ describe('SitecoreClient', () => {
           },
         },
       });
-
-      expect(
-        editingServiceStub.fetchDictionaryData.calledWithMatch({
-          siteName: componentLibData.site,
-          language: componentLibData.language,
-        })
-      ).to.be.true;
 
       expect(
         restComponentServiceStub.fetchComponentData.calledWith({
@@ -1032,20 +1008,14 @@ describe('SitecoreClient', () => {
           },
         },
       };
-      const dictionaryData = { key: 'value' };
 
       restComponentServiceStub.fetchComponentData.resolves(componentData);
-
-      editingServiceStub.fetchDictionaryData
-        .withArgs({ siteName: componentLibData.site, language: componentLibData.language })
-        .resolves(dictionaryData);
 
       const result = await sitecoreClient.getDesignLibraryData(componentLibData);
 
       expect(result).to.deep.include({
         locale: componentLibData.language,
         layout: componentData,
-        dictionary: dictionaryData,
         siteName: componentData.sitecore.context.site?.name,
         mode: {
           name: DesignLibraryMode.VariantGeneration,
@@ -1058,13 +1028,6 @@ describe('SitecoreClient', () => {
           },
         },
       });
-
-      expect(
-        editingServiceStub.fetchDictionaryData.calledWithMatch({
-          siteName: componentLibData.site,
-          language: componentLibData.language,
-        })
-      ).to.be.true;
 
       expect(
         restComponentServiceStub.fetchComponentData.calledWith({
@@ -1114,7 +1077,7 @@ describe('SitecoreClient', () => {
       }
     });
 
-    it('should pass fetchOptions to both editingService and componentService when calling getDesignLibraryData', async () => {
+    it('should pass fetchOptions to componentService when calling getDesignLibraryData', async () => {
       const componentLibData = {
         itemId: 'item-id',
         componentUid: 'comp-uid',
@@ -1123,6 +1086,7 @@ describe('SitecoreClient', () => {
         renderingId: 'rendering-id',
         dataSourceId: 'datasource-id',
         version: '1',
+        mode: DesignLibraryMode.Normal,
       };
 
       const fetchOptions = {
@@ -1150,18 +1114,22 @@ describe('SitecoreClient', () => {
           },
         },
       };
-      const dictionaryData = { key: 'value' };
 
       restComponentServiceStub.fetchComponentData.resolves(componentData);
-      editingServiceStub.fetchDictionaryData.resolves(dictionaryData);
 
       await sitecoreClient.getDesignLibraryData(componentLibData, fetchOptions);
 
       expect(
-        editingServiceStub.fetchDictionaryData.calledWith(
+        restComponentServiceStub.fetchComponentData.calledWith(
           {
             siteName: componentLibData.site,
+            itemId: componentLibData.itemId,
             language: componentLibData.language,
+            componentUid: componentLibData.componentUid,
+            renderingId: componentLibData.renderingId,
+            dataSourceId: componentLibData.dataSourceId,
+            version: componentLibData.version,
+            mode: componentLibData.mode,
           },
           fetchOptions
         )

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -414,7 +414,6 @@ export class SitecoreClient implements BaseSitecoreClient {
 
     const data = await this.editingService.fetchEditingData(
       {
-        siteName: site,
         itemId,
         language,
         version,
@@ -427,13 +426,12 @@ export class SitecoreClient implements BaseSitecoreClient {
     if (!data) {
       throw new Error(`Unable to fetch editing data for preview ${JSON.stringify(previewData)}`);
     }
-    const page = {
+    const page: Page = {
       locale: language,
       layout: data.layoutData,
-      dictionary: data.dictionary,
       siteName: data.layoutData.sitecore.context.site?.name || site,
       mode: this.getPageMode(mode),
-    } as Page;
+    };
     const personalizeData = getGroomedVariantIds(variantIds);
     personalizeLayout(page.layout, personalizeData.variantId, personalizeData.componentVariantIds);
 
@@ -465,21 +463,16 @@ export class SitecoreClient implements BaseSitecoreClient {
       mode,
     } = designLibData;
 
-    const componentData = await this.componentService.fetchComponentData({
-      siteName: site,
-      itemId,
-      language,
-      componentUid,
-      renderingId,
-      dataSourceId,
-      version,
-      mode,
-    });
-
-    const dictionaryData = await this.editingService.fetchDictionaryData(
+    const componentData = await this.componentService.fetchComponentData(
       {
         siteName: site,
+        itemId,
         language,
+        componentUid,
+        renderingId,
+        dataSourceId,
+        version,
+        mode,
       },
       fetchOptions
     );
@@ -487,13 +480,12 @@ export class SitecoreClient implements BaseSitecoreClient {
     if (!componentData) {
       throw new Error(`Unable to fetch editing data for preview ${JSON.stringify(designLibData)}`);
     }
-    const page = {
+    const page: Page = {
       locale: designLibData.language,
       layout: componentData,
-      dictionary: dictionaryData,
       siteName: componentData.sitecore.context.site?.name || site,
       mode: this.getPageMode(mode),
-    } as Page;
+    };
     return page;
   }
 

--- a/packages/core/src/editing/component-layout-service.test.ts
+++ b/packages/core/src/editing/component-layout-service.test.ts
@@ -126,6 +126,33 @@ describe('ComponentLayoutService', () => {
       });
   });
 
+  it('should fetch component data with custom fetch options', () => {
+    nock(SITECORE_EDGE_URL_DEFAULT, {
+      reqheaders: {
+        my_header: 'my_value',
+        sc_editMode: 'false',
+      },
+    })
+      .get(
+        '/layout/component?sitecoreContextId=test-context-id&item=123&uid=456&sc_site=supersite&sc_lang=en'
+      )
+      .reply(200, () => defaultTestData);
+
+    const service = new ComponentLayoutService({
+      contextId,
+    });
+
+    return service
+      .fetchComponentData(defaultTestInput, {
+        headers: {
+          my_header: 'my_value',
+        },
+      })
+      .then((layoutServiceData: LayoutServiceData & NativeDataFetcherConfig) => {
+        expect(layoutServiceData).to.deep.equal(defaultTestData);
+      });
+  });
+
   it('should fetch component data from a custom edge endpoint', () => {
     const customEdgeUrl = 'https://custom-edge-url.com';
 

--- a/packages/core/src/editing/component-layout-service.ts
+++ b/packages/core/src/editing/component-layout-service.ts
@@ -4,6 +4,7 @@ import debug from '../debug';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 import { resolveUrl } from '../utils';
 import { DesignLibraryMode } from './models';
+import { FetchOptions } from '../models';
 
 /**
  * Params for requesting component data in Design Library mode
@@ -71,7 +72,10 @@ export interface ComponentLayoutServiceConfig {
 export class ComponentLayoutService {
   constructor(private config: ComponentLayoutServiceConfig) {}
 
-  fetchComponentData(params: ComponentLayoutRequestParams): Promise<LayoutServiceData> {
+  fetchComponentData(
+    params: ComponentLayoutRequestParams,
+    fetchOptions?: FetchOptions
+  ): Promise<LayoutServiceData> {
     const fetcher = new NativeDataFetcher({ debugger: debug.layout });
 
     debug.layout(
@@ -85,7 +89,11 @@ export class ComponentLayoutService {
 
     return fetcher
       .get<LayoutServiceData>(this.getFetchUrl(params), {
-        headers: { sc_editMode: `${params.mode === DesignLibraryMode.Metadata}` },
+        ...fetchOptions,
+        headers: {
+          ...fetchOptions?.headers,
+          sc_editMode: `${params.mode === DesignLibraryMode.Metadata}`,
+        },
       })
       .then((response) => response.data)
       .catch((error) => {

--- a/packages/core/src/editing/editing-service.test.ts
+++ b/packages/core/src/editing/editing-service.test.ts
@@ -4,11 +4,8 @@ import sinon from 'sinon';
 import nock from 'nock';
 import spies from 'chai-spies';
 import { GraphQLRequestClient } from '../graphql-request-client';
-import { EditingService, EditingServiceConfig, query, dictionaryQuery } from './editing-service';
-import {
-  mockEditingServiceDictionaryResponse,
-  mockEditingServiceResponse,
-} from '../test-data/mockEditingServiceResponse';
+import { EditingService, EditingServiceConfig, query } from './editing-service';
+import { mockEditingServiceResponse } from '../test-data/mockEditingServiceResponse';
 import { LayoutKind } from './models';
 import debug from '../debug';
 import { LayoutServicePageState } from '../layout';
@@ -18,7 +15,6 @@ use(spies);
 describe('EditingService', () => {
   const hostname = 'http://site';
   const endpointPath = '/?sitecoreContextId=context-id';
-  const siteName = 'site-name';
   const clientFactory = GraphQLRequestClient.createClientFactory({
     endpoint: hostname + endpointPath,
   });
@@ -74,7 +70,6 @@ describe('EditingService', () => {
       language,
       version,
       itemId,
-      siteName,
       mode: LayoutServicePageState.Edit,
     });
 
@@ -91,7 +86,6 @@ describe('EditingService', () => {
         language,
         version,
         itemId,
-        siteName,
       },
       {
         headers: {
@@ -103,10 +97,6 @@ describe('EditingService', () => {
 
     expect(result).to.deep.equal({
       layoutData: layoutDataResponse,
-      dictionary: {
-        foo: 'foo-phrase',
-        bar: 'bar-phrase',
-      },
     });
 
     spy.restore(clientFactorySpy);
@@ -129,7 +119,6 @@ describe('EditingService', () => {
       language,
       version,
       itemId,
-      siteName,
       mode: LayoutServicePageState.Preview,
     });
 
@@ -146,7 +135,6 @@ describe('EditingService', () => {
         language,
         version,
         itemId,
-        siteName,
       },
       {
         headers: {
@@ -158,26 +146,17 @@ describe('EditingService', () => {
 
     expect(result).to.deep.equal({
       layoutData: layoutDataResponse,
-      dictionary: {
-        foo: 'foo-phrase',
-        bar: 'bar-phrase',
-      },
     });
 
     spy.restore(clientFactorySpy);
   });
 
-  it('should return empty dictionary and layout', async () => {
+  it('should return empty layout', async () => {
     nock(hostname, { reqheaders: { sc_editMode: 'true' } })
       .post(endpointPath, /EditingQuery/gi)
       .reply(200, {
         data: {
           item: null,
-          site: {
-            siteInfo: {
-              dictionary: null,
-            },
-          },
         },
       });
 
@@ -193,7 +172,6 @@ describe('EditingService', () => {
       language,
       version,
       itemId,
-      siteName,
       mode: LayoutServicePageState.Edit,
     });
 
@@ -210,7 +188,6 @@ describe('EditingService', () => {
         language,
         version,
         itemId,
-        siteName,
       },
       {
         headers: {
@@ -227,7 +204,6 @@ describe('EditingService', () => {
           route: null,
         },
       },
-      dictionary: {},
     });
 
     spy.restore(clientFactorySpy);
@@ -249,7 +225,6 @@ describe('EditingService', () => {
     const result = await service.fetchEditingData({
       language,
       itemId,
-      siteName,
       mode: LayoutServicePageState.Edit,
     });
 
@@ -265,7 +240,6 @@ describe('EditingService', () => {
       {
         language,
         itemId,
-        siteName,
         version: undefined,
       },
       {
@@ -278,10 +252,6 @@ describe('EditingService', () => {
 
     expect(result).to.deep.equal({
       layoutData: layoutDataResponse,
-      dictionary: {
-        foo: 'foo-phrase',
-        bar: 'bar-phrase',
-      },
     });
 
     spy.restore(clientFactorySpy);
@@ -304,7 +274,6 @@ describe('EditingService', () => {
       language,
       version,
       itemId,
-      siteName,
       layoutKind: LayoutKind.Shared,
       mode: LayoutServicePageState.Edit,
     });
@@ -317,7 +286,6 @@ describe('EditingService', () => {
         language,
         version,
         itemId,
-        siteName,
       },
       {
         headers: {
@@ -329,212 +297,6 @@ describe('EditingService', () => {
 
     expect(result).to.deep.equal({
       layoutData: layoutDataResponse,
-      dictionary: {
-        foo: 'foo-phrase',
-        bar: 'bar-phrase',
-      },
-    });
-
-    spy.restore(clientFactorySpy);
-  });
-
-  it('should fetch editing data when dicionary has multiple pages', async () => {
-    nock(hostname, { reqheaders: { sc_editMode: 'true' } })
-      .post(endpointPath, /EditingQuery/gi)
-      .reply(200, mockEditingServiceResponse(true));
-
-    nock(hostname)
-      .post(endpointPath, /DictionaryQuery/gi)
-      .reply(200, mockEditingServiceDictionaryResponse.pageOne);
-
-    nock(hostname)
-      .post(endpointPath, /DictionaryQuery/gi)
-      .reply(200, mockEditingServiceDictionaryResponse.pageTwo);
-
-    const clientFactorySpy = sinon.spy(clientFactory);
-
-    const service = new EditingService({
-      clientFactory: clientFactorySpy,
-    });
-
-    spy.on(clientFactorySpy.returnValues[0], 'request');
-
-    const result = await service.fetchEditingData({
-      language,
-      version,
-      itemId,
-      siteName,
-      mode: LayoutServicePageState.Edit,
-    });
-
-    expect(clientFactorySpy.called).to.be.true;
-    expect(
-      clientFactorySpy.calledWith({
-        debugger: debug.editing,
-      })
-    ).to.be.true;
-
-    expect(clientFactorySpy.returnValues[0].request).to.be.called.exactly(3);
-    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(query, {
-      language,
-      version,
-      itemId,
-      siteName,
-    });
-
-    expect(clientFactorySpy.returnValues[0].request)
-      .on.nth(2)
-      .to.be.called.with(dictionaryQuery, {
-        language,
-        siteName,
-        after: 'cursor',
-      });
-
-    expect(clientFactorySpy.returnValues[0].request)
-      .on.nth(3)
-      .to.be.called.with(dictionaryQuery, {
-        language,
-        siteName,
-        after: 'cursor-one',
-      });
-
-    expect(result).to.deep.equal({
-      layoutData: layoutDataResponse,
-      dictionary: {
-        foo: 'foo-phrase',
-        bar: 'bar-phrase',
-        'foo-one': 'foo-one-phrase',
-        'bar-one': 'bar-one-phrase',
-        'foo-two': 'foo-two-phrase',
-        'bar-two': 'bar-two-phrase',
-      },
-    });
-
-    spy.restore(clientFactorySpy);
-  });
-
-  describe('fetchDictionaryData', () => {
-    it('should request dictionary from scratch when fetchDictionaryData called on its own', async () => {
-      nock(hostname)
-        .post(endpointPath, /DictionaryQuery/gi)
-        .reply(200, mockEditingServiceDictionaryResponse.pageOne);
-
-      nock(hostname)
-        .post(endpointPath, /DictionaryQuery/gi)
-        .reply(200, mockEditingServiceDictionaryResponse.pageTwo);
-
-      const service = new EditingService({
-        clientFactory: clientFactory,
-      });
-
-      const result = await service.fetchDictionaryData({
-        language,
-        siteName,
-      });
-
-      expect(result).to.deep.equal({
-        'foo-one': 'foo-one-phrase',
-        'bar-one': 'bar-one-phrase',
-        'foo-two': 'foo-two-phrase',
-        'bar-two': 'bar-two-phrase',
-      });
-    });
-
-    it('should pass fetchOptions to the GraphQL client', async () => {
-      const fetchOptions = {
-        retries: 3,
-        retryStrategy: {
-          shouldRetry: () => true,
-          getDelay: () => 1000,
-        },
-        fetch: globalThis.fetch,
-        headers: {
-          Authorization: 'Bearer test-token',
-          'Content-Type': 'application/json',
-        },
-      };
-      const requestMock = sinon.stub().resolves({
-        layout: {
-          item: {
-            rendered: {
-              sitecore: {
-                context: { pageEditing: false, language: 'en' },
-                route: null,
-              },
-            },
-          },
-        },
-      });
-
-      sinon.stub(GraphQLRequestClient.prototype, 'request').callsFake(requestMock);
-
-      const service = new EditingService({
-        clientFactory: clientFactory,
-      });
-
-      await service.fetchDictionaryData(
-        {
-          language,
-          siteName,
-        },
-        fetchOptions
-      );
-      expect(requestMock.calledOnce).to.be.true;
-      expect(requestMock.firstCall.args[2]).to.deep.equal(fetchOptions);
-    });
-  });
-
-  it('should return empty dictionary when dictionary is not provided', async () => {
-    const editingData = mockEditingServiceResponse();
-
-    (editingData.data.site.siteInfo as any) = null;
-
-    nock(hostname, { reqheaders: { sc_editMode: 'true' } })
-      .post(endpointPath, /EditingQuery/gi)
-      .reply(200, editingData);
-
-    const clientFactorySpy = sinon.spy(clientFactory);
-
-    const service = new EditingService({
-      clientFactory: clientFactorySpy,
-    });
-
-    spy.on(clientFactorySpy.returnValues[0], 'request');
-
-    const result = await service.fetchEditingData({
-      language,
-      version,
-      itemId,
-      siteName,
-      mode: LayoutServicePageState.Edit,
-    });
-
-    expect(clientFactorySpy.calledOnce).to.be.true;
-    expect(
-      clientFactorySpy.calledWith({
-        debugger: debug.editing,
-      })
-    ).to.be.true;
-    expect(clientFactorySpy.returnValues[0].request).to.be.called.exactly(1);
-    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(
-      query,
-      {
-        language,
-        version,
-        itemId,
-        siteName,
-      },
-      {
-        headers: {
-          sc_layoutKind: 'final',
-          sc_editMode: 'true',
-        },
-      }
-    );
-
-    expect(result).to.deep.equal({
-      layoutData: layoutDataResponse,
-      dictionary: {},
     });
 
     spy.restore(clientFactorySpy);
@@ -548,7 +310,6 @@ describe('EditingService', () => {
         language,
         version,
         itemId,
-        siteName,
         mode: LayoutServicePageState.Edit,
       });
     } catch (error) {
@@ -572,29 +333,10 @@ describe('EditingService', () => {
         language,
         version,
         itemId,
-        siteName,
         mode: LayoutServicePageState.Edit,
       });
     } catch (error) {
       expect(error.response.error).to.equal('Internal server error');
-    }
-  });
-
-  it('should throw an error when siteName is not provided', async () => {
-    const service = new EditingService({
-      clientFactory,
-    });
-
-    try {
-      await service.fetchEditingData({
-        language,
-        version,
-        itemId,
-        siteName: '',
-        mode: LayoutServicePageState.Edit,
-      });
-    } catch (error) {
-      expect(error.message).to.equal('The site name must be a non-empty string');
     }
   });
 
@@ -608,7 +350,6 @@ describe('EditingService', () => {
         language: '',
         version,
         itemId,
-        siteName,
         mode: LayoutServicePageState.Edit,
       });
     } catch (error) {
@@ -630,7 +371,6 @@ describe('EditingService', () => {
       },
     };
     const editingOptions = {
-      siteName: 'example-site',
       itemId: 'item-123',
       language: 'en',
       version: '1',
@@ -644,14 +384,6 @@ describe('EditingService', () => {
           sitecore: {
             context: { pageEditing: true, language: 'en' },
             route: null,
-          },
-        },
-      },
-      site: {
-        siteInfo: {
-          dictionary: {
-            results: [],
-            pageInfo: { hasNext: false, endCursor: '' },
           },
         },
       },

--- a/packages/core/src/editing/editing-service.ts
+++ b/packages/core/src/editing/editing-service.ts
@@ -1,89 +1,24 @@
 import debug from '../debug';
-import { PageInfo } from '../client';
 import { GraphQLClient, GraphQLRequestClientFactory } from '../graphql-request-client';
-import { DictionaryPhrases } from '../i18n';
 import { LayoutServiceData, LayoutServicePageState } from '../layout';
 import { LayoutKind } from './models';
 import { FetchOptions } from '../models';
 
 /**
- * The dictionary query default page size.
- */
-const PAGE_SIZE = 1000;
-
-/**
  * GraphQL query for fetching editing data.
  */
 export const query = /* GraphQL */ `
- query EditingQuery(
-    $siteName: String!
-    $itemId: String!
-    $language: String!
-    $version: String
-    $after: String
-    $pageSize: Int = ${PAGE_SIZE}
-) {
+  query EditingQuery($itemId: String!, $language: String!, $version: String) {
     item(path: $itemId, language: $language, version: $version) {
       rendered
     }
-    site {
-      siteInfo(site: $siteName) {
-        dictionary(language: $language, first: $pageSize, after: $after) {
-          results {
-            key
-            value
-          }
-          pageInfo {
-            endCursor
-            hasNext
-          }
-        }
-      }
-    }
   }
 `;
-
-/**
- * GraphQL query for fetching dictionary data.
- * This query is used when the dictionary data is paginated.
- */
-export const dictionaryQuery = /* GraphQL */ `
-  query EditingDictionaryQuery(
-    $siteName: String!
-    $language: String!
-    $after: String
-    $pageSize: Int = ${PAGE_SIZE}
-  ) {
-    site {
-      siteInfo(site: $siteName) {
-        dictionary(language: $language, first: $pageSize, after: $after) {
-          results {
-            key
-            value
-          }
-          pageInfo {
-            endCursor
-            hasNext
-          }
-        }
-      }
-    }
-  }
-`;
-
-/**
- * Response from the GraphQL Dictionary query.
- */
-export type GraphQLDictionaryQueryResponse = {
-  site: {
-    siteInfo: { dictionary: { results: { key: string; value: string }[]; pageInfo: PageInfo } };
-  };
-};
 
 /**
  * Response from the GraphQL Editing query.
  */
-export type GraphQLEditingQueryResponse = GraphQLDictionaryQueryResponse & {
+export type GraphQLEditingQueryResponse = {
   item: { rendered: LayoutServiceData };
 };
 
@@ -96,7 +31,6 @@ export interface EditingServiceConfig {
 }
 
 export type EditingOptions = {
-  siteName: string;
   itemId: string;
   language: string;
   version?: string;
@@ -122,7 +56,6 @@ export class EditingService {
   /**
    * Fetches editing data. Provides the layout data and dictionary phrases
    * @param {object} variables - The parameters for fetching editing data.
-   * @param {string} variables.siteName - The site name.
    * @param {string} variables.itemId - The item id (path) to fetch layout data for.
    * @param {string} variables.language - The language to fetch layout data for.
    * @param {string} variables.mode - The editing mode to fetch layout data for.
@@ -132,36 +65,20 @@ export class EditingService {
    * @returns {Promise} The layout data and dictionary phrases.
    */
   async fetchEditingData(
-    { siteName, itemId, language, version, layoutKind = LayoutKind.Final, mode }: EditingOptions,
+    { itemId, language, version, layoutKind = LayoutKind.Final, mode }: EditingOptions,
     fetchOptions?: FetchOptions
   ) {
-    debug.editing(
-      'fetching editing data for %s %s %s %s',
-      siteName,
-      itemId,
-      language,
-      version,
-      layoutKind
-    );
-
-    if (!siteName) {
-      throw new RangeError('The site name must be a non-empty string');
-    }
+    debug.editing('fetching editing data for %s %s %s %s', itemId, language, version, layoutKind);
 
     if (!language) {
       throw new RangeError('The language must be a non-empty string');
     }
-
-    let initDictionary: { key: string; value: string }[] = [];
-    let hasNext = true;
-    let after = '';
 
     const editModeHeader = mode === 'edit' ? 'true' : 'false';
 
     const editingData = await this.graphQLClient.request<GraphQLEditingQueryResponse>(
       query,
       {
-        siteName,
         itemId,
         version,
         language,
@@ -175,25 +92,6 @@ export class EditingService {
       }
     );
 
-    if (editingData?.site?.siteInfo?.dictionary) {
-      initDictionary = editingData.site.siteInfo.dictionary.results;
-      hasNext = editingData.site.siteInfo.dictionary.pageInfo.hasNext;
-      after = editingData.site.siteInfo.dictionary.pageInfo.endCursor;
-    } else {
-      hasNext = false;
-    }
-
-    const dictionary = await this.fetchDictionaryData(
-      {
-        siteName,
-        language,
-        initDictionary,
-        hasNext,
-        after,
-      },
-      fetchOptions
-    );
-
     return {
       layoutData: editingData?.item?.rendered || {
         sitecore: {
@@ -201,53 +99,7 @@ export class EditingService {
           route: null,
         },
       },
-      dictionary,
     };
-  }
-
-  async fetchDictionaryData(
-    {
-      siteName,
-      language,
-      initDictionary,
-      hasNext,
-      after,
-    }: {
-      siteName: string;
-      language: string;
-      hasNext?: boolean;
-      initDictionary?: {
-        key: string;
-        value: string;
-      }[];
-      after?: string;
-    },
-    fetchOptions?: FetchOptions
-  ) {
-    hasNext = hasNext !== undefined ? hasNext : true;
-    let dictionaryResults = initDictionary || [];
-    const dictionary: DictionaryPhrases = {};
-    while (hasNext) {
-      const data = await this.graphQLClient.request<GraphQLDictionaryQueryResponse>(
-        dictionaryQuery,
-        {
-          siteName,
-          language,
-          after,
-        },
-        fetchOptions
-      );
-
-      if (data?.site?.siteInfo?.dictionary) {
-        dictionaryResults = dictionaryResults.concat(data.site.siteInfo.dictionary.results);
-        hasNext = data.site.siteInfo.dictionary.pageInfo.hasNext;
-        after = data.site.siteInfo.dictionary.pageInfo.endCursor;
-      } else {
-        hasNext = false;
-      }
-    }
-    dictionaryResults.forEach((item) => (dictionary[item.key] = item.value));
-    return dictionary;
   }
 
   /**

--- a/packages/core/src/test-data/mockEditingServiceResponse.ts
+++ b/packages/core/src/test-data/mockEditingServiceResponse.ts
@@ -1,11 +1,6 @@
-import {
-  GraphQLDictionaryQueryResponse,
-  GraphQLEditingQueryResponse,
-} from '../editing/editing-service';
+import { GraphQLEditingQueryResponse } from '../editing/editing-service';
 
-export const mockEditingServiceResponse = (
-  hasNext = false
-): { data: GraphQLEditingQueryResponse } => ({
+export const mockEditingServiceResponse = (): { data: GraphQLEditingQueryResponse } => ({
   data: {
     item: {
       rendered: {
@@ -32,78 +27,5 @@ export const mockEditingServiceResponse = (
         },
       },
     },
-    site: {
-      siteInfo: {
-        dictionary: {
-          results: [
-            {
-              key: 'foo',
-              value: 'foo-phrase',
-            },
-            {
-              key: 'bar',
-              value: 'bar-phrase',
-            },
-          ],
-          pageInfo: {
-            hasNext,
-            endCursor: hasNext ? 'cursor' : '',
-          },
-        },
-      },
-    },
   },
 });
-
-export const mockEditingServiceDictionaryResponse: {
-  [key: string]: { data: GraphQLDictionaryQueryResponse };
-} = {
-  pageOne: {
-    data: {
-      site: {
-        siteInfo: {
-          dictionary: {
-            results: [
-              {
-                key: 'foo-one',
-                value: 'foo-one-phrase',
-              },
-              {
-                key: 'bar-one',
-                value: 'bar-one-phrase',
-              },
-            ],
-            pageInfo: {
-              hasNext: true,
-              endCursor: 'cursor-one',
-            },
-          },
-        },
-      },
-    },
-  },
-  pageTwo: {
-    data: {
-      site: {
-        siteInfo: {
-          dictionary: {
-            results: [
-              {
-                key: 'foo-two',
-                value: 'foo-two-phrase',
-              },
-              {
-                key: 'bar-two',
-                value: 'bar-two-phrase',
-              },
-            ],
-            pageInfo: {
-              hasNext: false,
-              endCursor: '',
-            },
-          },
-        },
-      },
-    },
-  },
-};


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Removed redundant dictionary fetches previously executed within `client.getPreview` and `client.getDesignLibraryData`.
The dictionary request is considered optional and should be initiated explicitly by consumers when needed.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - This update introduces breaking changes in `EditingService`. However, we could consider it acceptable for the 1.1.0 release, as customers typically do not customize editing-related services, and the current implementation has a performance-impacting bug that this change resolves. Also dictionary is fetched by default via separate request so there are no changes for customers
