### PR TITLE
[nextjs][core] Refactor Codegen debug log to only include paths and exclude scConfig

### DIFF
--- a/packages/nextjs/src/tools/codegen/import-map.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.ts
@@ -268,9 +268,10 @@ export const writeImportMap = (args: WriteImportMapArgs) => {
     const paths = _getComponentList(args.paths, args.exclude).map((entry) => entry.filePath);
     const importMapFile = path.join(process.cwd(), '.sitecore', 'import-map.ts');
     console.log(
-      `[Codegen] Generating import map for paths: ${JSON.stringify(
-        args
-      )}.\n Writing into ${importMapFile} ...`
+      `[Codegen] Generating import map for paths: ${JSON.stringify({
+        paths: args.paths,
+        exclude: args.exclude,
+      })}.\n Writing into ${importMapFile} ...`
     );
     // get generated map and combine with default one
     const importMap = getImportMap(paths);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

Refactor codegen debug logs to:
- Include only paths
- Exclude scConfig

<img width="757" height="76" alt="image" src="https://github.com/user-attachments/assets/433bd2b9-184c-44f2-b6a5-b82b3f6ba953" />



## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
