### PR TITLE
[nextjs][core] Refactor Codegen debug log to only include paths and exclude scConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs]``[Code Extraction]` Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))
+* `[nextjs]` `[Code Extraction]` Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))
 
 ### 🐛 Bug Fixes
 
@@ -23,7 +23,7 @@ Our versioning strategy is as follows:
   - Updated `EditingService.fetchEditingData`:
     - Removed `siteName` parameter.
     - No longer requests and returns dictionary data.
-* `[core]``[nextjs]` Refactor Codegen debug log to only include paths and exclude scConfig 
+* `[core]` `[nextjs]` Refactor Codegen debug log to only include paths and exclude scConfig ([#165](https://github.com/Sitecore/content-sdk/pull/165))
 
 ### 🎉 New Features & Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Our versioning strategy is as follows:
   - Updated `EditingService.fetchEditingData`:
     - Removed `siteName` parameter.
     - No longer requests and returns dictionary data.
+* `[core]``[nextjs]` Refactor Codegen debug log to only include paths and exclude scConfig 
 
 ### 🎉 New Features & Improvements
 

--- a/packages/nextjs/src/tools/codegen/import-map.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.ts
@@ -268,7 +268,7 @@ export const writeImportMap = (args: WriteImportMapArgs) => {
     const paths = _getComponentList(args.paths, args.exclude).map((entry) => entry.filePath);
     const importMapFile = path.join(process.cwd(), '.sitecore', 'import-map.ts');
     console.log(
-      `[Codegen] Generating import map for paths: ${JSON.stringify({
+      `[Codegen] Generating import map: ${JSON.stringify({
         paths: args.paths,
         exclude: args.exclude,
       })}.\n Writing into ${importMapFile} ...`

--- a/packages/nextjs/src/tools/codegen/import-map.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.ts
@@ -268,9 +268,10 @@ export const writeImportMap = (args: WriteImportMapArgs) => {
     const paths = _getComponentList(args.paths, args.exclude).map((entry) => entry.filePath);
     const importMapFile = path.join(process.cwd(), '.sitecore', 'import-map.ts');
     console.log(
-      `[Codegen] Generating import map for paths: ${JSON.stringify(
-        args
-      )}.\n Writing into ${importMapFile} ...`
+      `[Codegen] Generating import map for paths: ${JSON.stringify({
+        paths: args.paths,
+        exclude: args.exclude,
+      })}.\n Writing into ${importMapFile} ...`
     );
     // get generated map and combine with default one
     const importMap = getImportMap(paths);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

Refactor codegen debug logs to:
- Include only paths
- Exclude scConfig

<img width="515" height="98" alt="image" src="https://github.com/user-attachments/assets/5d479593-a375-4bdd-9878-9df7f683264b" />




## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
