### PR TITLE
[core][nextjs] Update CHANGELOG to include new import-map generation methods and exports for codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Our versioning strategy is as follows:
     - Removed `siteName` parameter.
     - No longer requests and returns dictionary data.
 * `[core]` `[nextjs]` Refactor Codegen debug log to only include paths and exclude scConfig ([#165](https://github.com/Sitecore/content-sdk/pull/165))
-* * `[core]` `[nextjs]` Update changelog to include new methods and export ([#165](https://github.com/Sitecore/content-sdk/pull/165))
+* `[core]` `[nextjs]` Update changelog to include new methods and export ([#166](https://github.com/Sitecore/content-sdk/pull/166))
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ Our versioning strategy is as follows:
   - Updated `EditingService.fetchEditingData`:
     - Removed `siteName` parameter.
     - No longer requests and returns dictionary data.
-* `[core]` `[nextjs]` Refactor Codegen debug log to only include paths and exclude scConfig ([#165](https://github.com/Sitecore/content-sdk/pull/165))
-* `[core]` `[nextjs]` Update changelog to include new methods and export ([#166](https://github.com/Sitecore/content-sdk/pull/166))
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
+- `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157))
+  - New `writeImportMap()`, `combineImportEntries()` methods and `defaultImportEntries` export available from `@sitecore-content-sdk/nextjs/tools`
 * `[nextjs]` `[Code Extraction]` Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))
 
 ### 🐛 Bug Fixes
@@ -24,11 +26,7 @@ Our versioning strategy is as follows:
     - Removed `siteName` parameter.
     - No longer requests and returns dictionary data.
 * `[core]` `[nextjs]` Refactor Codegen debug log to only include paths and exclude scConfig ([#165](https://github.com/Sitecore/content-sdk/pull/165))
-
-### 🎉 New Features & Improvements
-
-* Code generation for Design Library enablers:
-    * `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157))
+* * `[core]` `[nextjs]` Update changelog to include new methods and export ([#165](https://github.com/Sitecore/content-sdk/pull/165))
 
 ## 1.0.0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Revised the changelog to clearly document the newly added methods and export from ([#157](https://github.com/Sitecore/content-sdk/pull/157))

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
