### PR TITLE
[cli] Code extraction extends XM Cloud Rendering Host build by several minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Our versioning strategy is as follows:
   - Updated `EditingService.fetchEditingData`:
     - Removed `siteName` parameter.
     - No longer requests and returns dictionary data.
+* `[cli]` Code extraction extends XM Cloud Rendering Host build by several minutes ([#173](https://github.com/Sitecore/content-sdk/pull/173))
 
 ## 1.0.0
 

--- a/packages/cli/src/scripts/project/build.test.ts
+++ b/packages/cli/src/scripts/project/build.test.ts
@@ -14,6 +14,7 @@ describe('build command', () => {
       },
     };
     loadCliConfigStub = sinon.stub(loadConfigModule, 'default').returns(mockConfig);
+    sinon.stub(process, 'exit');
   });
 
   afterEach(() => {

--- a/packages/cli/src/scripts/project/build.ts
+++ b/packages/cli/src/scripts/project/build.ts
@@ -36,4 +36,7 @@ export async function handler(argv: BuildArgs) {
       await command();
     }
   }
+
+  // Exit the process to avoid hanging the process by custom build commands
+  process.exit(0);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

### Summary
This PR improves the behavior of the `sitecore-tools build` command by explicitly terminating the Node.js process after all build commands are executed. This prevents the process from hanging due to lingering background tasks.

### Motivation
The current implementation of `sitecore-tools build` allows any command to be executed during the build phase. However, we cannot guarantee that these commands will terminate cleanly - some may leave hanging processes, especially when tools like the TypeScript compiler (tscompiler) are initialized (e.g., during code extraction: [source](https://github.com/Sitecore/content-sdk/blob/dev/packages/nextjs/src/tools/codegen/utils.ts#L74)).

Unfortunately, the compiler provides no public API to dispose or clean up such internal processes.

### Solution
To address this, we now explicitly call process.exit(0) after all build commands complete. This ensures a clean and predictable termination of the build process, avoiding CI/CD deadlocks and local development issues caused by lingering processes.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
