### PR TITLE
[react][Codegen] Lazy load import map instead of direct import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Our versioning strategy is as follows:
 ### 🎉 New Features & Improvements
 
 * Code generation for Design Library enablers:
-  - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157) [#167](https://github.com/Sitecore/content-sdk/pull/167) [#170](https://github.com/Sitecore/content-sdk/pull/170) [#171](https://github.com/Sitecore/content-sdk/pull/171))
+  - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157) [#167](https://github.com/Sitecore/content-sdk/pull/167) [#170](https://github.com/Sitecore/content-sdk/pull/170) [#171](https://github.com/Sitecore/content-sdk/pull/171) [#175](https://github.com/Sitecore/content-sdk/pull/175))
     - New `writeImportMap()`, `combineImportEntries()` methods and `defaultImportEntries` export available from `@sitecore-content-sdk/nextjs/codegen`
   - Dynamic component rendering ([#163](https://github.com/Sitecore/content-sdk/pull/163))
   - Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/Layout.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/Layout.tsx
@@ -6,7 +6,6 @@ import Head from 'next/head';
 import { Placeholder, Field, DesignLibrary, Page } from '@sitecore-content-sdk/nextjs';
 import Scripts from 'src/Scripts';
 import SitecoreStyles from 'src/components/content-sdk/SitecoreStyles';
-import importMap from '.sitecore/import-map';
 
 interface LayoutProps {
   page: Page;
@@ -22,6 +21,7 @@ const Layout = ({ page }: LayoutProps): JSX.Element => {
   const { route } = layout.sitecore;
   const fields = route?.fields as RouteFields;
   const mainClassPageEditing = mode.isEditing ? 'editing-mode' : 'prod-mode';
+  const importMapDynamic = () => import('.sitecore/import-map');
 
   return (
     <>
@@ -35,7 +35,7 @@ const Layout = ({ page }: LayoutProps): JSX.Element => {
       {/* root placeholder for the app, which we add components to using route data */}
       <div className={mainClassPageEditing}>
         {mode.isDesignLibrary ? (
-          <DesignLibrary importMap={importMap} />
+          <DesignLibrary importMapImport={importMapDynamic} />
         ) : (
           <>
             <header>

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/Layout.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/Layout.tsx
@@ -35,7 +35,7 @@ const Layout = ({ page }: LayoutProps): JSX.Element => {
       {/* root placeholder for the app, which we add components to using route data */}
       <div className={mainClassPageEditing}>
         {mode.isDesignLibrary ? (
-          <DesignLibrary importMapImport={importMapDynamic} />
+          <DesignLibrary loadImportMap={importMapDynamic} />
         ) : (
           <>
             <header>

--- a/packages/nextjs/src/editing/codegen/index.ts
+++ b/packages/nextjs/src/editing/codegen/index.ts
@@ -1,1 +1,2 @@
 export { defaultImportEntries, combineImportEntries } from './import-map';
+export { ImportEntry } from '@sitecore-content-sdk/core/codegen';

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import { Page, PageMode } from '@sitecore-content-sdk/core/client';
 import { LayoutServiceData } from '@sitecore-content-sdk/core/layout';
 import { fireEvent, render, waitFor } from '@testing-library/react';
-import { DesignLibrary } from './DesignLibrary';
+import { DesignLibrary, ImportMapImport } from './DesignLibrary';
 import { getTestLayoutData } from '../test-data/component-editing-data';
 import { SitecoreProvider } from './SitecoreProvider';
 import { RichText } from './RichText';
@@ -21,7 +21,6 @@ import {
   DesignLibraryMode,
 } from '@sitecore-content-sdk/core/editing';
 import { __mockDependencies } from './DesignLibrary';
-import { ImportEntry } from '@sitecore-content-sdk/core/codegen';
 
 describe('<DesignLibrary />', () => {
   const postMessageSpy = sinon.spy(global.window, 'postMessage');
@@ -320,20 +319,25 @@ describe('<DesignLibrary />', () => {
     let addComponentPreviewHandlerSpy: sinon.SinonStub;
     let page: Page;
 
-    const defaultImportMap: ImportEntry[] = [
-      {
-        module: 'react',
-        exports: [{ name: 'default', value: React }],
-      },
-    ];
+    const defaultImportMap = () =>
+      new Promise((resolve) => {
+        resolve({
+          default: [
+            {
+              module: 'react',
+              exports: [{ name: 'default', value: React }],
+            },
+          ],
+        });
+      });
 
-    let fireEvent: any = null;
+    let callbackEvent: any = null;
 
     beforeEach(() => {
       page = getPage(getTestLayoutData().layoutData, variantGenerationMode);
 
       addComponentPreviewHandlerSpy = sinon.stub().callsFake((_importMap, callback) => {
-        fireEvent = callback;
+        callbackEvent = callback;
 
         return unsubscribeSpy;
       });
@@ -348,17 +352,17 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should render component when provided', async () => {
-      const rendered = render(
+      const rendered = await render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMap={defaultImportMap} />
+          <DesignLibrary importMapImport={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
 
-      fireEvent(null, TestComponent);
-
       // Wait for the useEffect to complete and component to render
       await waitFor(() => {
+        expect(addComponentPreviewHandlerSpy).to.have.been.called;
+        callbackEvent(null, TestComponent);
         expect(rendered.baseElement.innerHTML).to.contain('TestComponent');
       });
     });
@@ -366,7 +370,7 @@ describe('<DesignLibrary />', () => {
     it('should render loading preview when no component is provided', () => {
       const rendered = render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMap={defaultImportMap} />
+          <DesignLibrary importMapImport={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
@@ -378,14 +382,13 @@ describe('<DesignLibrary />', () => {
     it('should render error message when component fails to initialize', async () => {
       const rendered = render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMap={defaultImportMap} />
+          <DesignLibrary importMapImport={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
 
-      fireEvent('Error', null);
-
       await waitFor(() => {
+        callbackEvent('Error', null);
         expect(rendered.baseElement.innerHTML).to.contain('Error during component initialization');
       });
     });
@@ -393,16 +396,15 @@ describe('<DesignLibrary />', () => {
     it('should render error message when component fails to render', async () => {
       const rendered = render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMap={defaultImportMap} />
+          <DesignLibrary importMapImport={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
 
-      fireEvent(null, () => {
-        throw new Error('Error rendering component');
-      });
-
       await waitFor(() => {
+        callbackEvent(null, () => {
+          throw new Error('Error rendering component');
+        });
         expect(rendered.baseElement.innerHTML).to.contain('Error during component rendering');
       });
     });
@@ -413,7 +415,7 @@ describe('<DesignLibrary />', () => {
 
       const rendered = render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMap={defaultImportMap} />
+          <DesignLibrary importMapImport={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
@@ -433,22 +435,24 @@ describe('<DesignLibrary />', () => {
 
       await waitFor(() => {
         expect(rendered.baseElement.innerHTML).to.contain(
-          'No import map found. Please check your import map.'
+          'No dynamic import map loaded. Please check a dynamic import map function is passed into Design Library'
         );
       });
     });
 
-    it('should send postMessage events for import-map and component-props', () => {
+    it('should send postMessage events for import-map and component-props', async () => {
       render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMap={defaultImportMap} />
+          <DesignLibrary importMapImport={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
 
       // Check that postMessage was called (we can't easily mock the event functions)
-      expect(postMessageSpy.called).to.be.true;
-      expect(postMessageSpy.callCount).to.be.greaterThan(0);
+      await waitFor(() => {
+        expect(postMessageSpy.called).to.be.true;
+        expect(postMessageSpy.callCount).to.be.greaterThan(0);
+      });
     });
   });
 });

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -396,7 +396,7 @@ describe('<DesignLibrary />', () => {
       });
     });
 
-    it('should render error message when component fails to initialize due to failing import map promise', async () => {
+    it('should render error message when import map promise cannot be resolved', async () => {
       const initError = new Error('Failed to load import map');
       const errorImportMap = () =>
         new Promise((_, reject) => {
@@ -410,8 +410,9 @@ describe('<DesignLibrary />', () => {
       );
 
       await waitFor(() => {
-        callbackEvent('Error', null);
-        expect(rendered.baseElement.innerHTML).to.contain('Error during component initialization');
+        expect(rendered.baseElement.innerHTML).to.contain(
+          'No dynamic import map loaded. Please check a dynamic import map function is passed into Design Library'
+        );
         expect(consoleErrorSpy.calledWith('Error loading import map:', initError)).to.be.true;
       });
     });

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -23,7 +23,9 @@ import {
 import { __mockDependencies } from './DesignLibrary';
 
 describe('<DesignLibrary />', () => {
-  const postMessageSpy = sinon.spy(global.window, 'postMessage');
+  const sandbox = sinon.createSandbox();
+  const postMessageSpy = sandbox.spy(global.window, 'postMessage');
+  const consoleErrorSpy = sandbox.spy(console, 'error');
   const components = new Map<string, React.FC>();
 
   const mode: PageMode = {
@@ -315,8 +317,8 @@ describe('<DesignLibrary />', () => {
 
   describe('VariantGeneration', () => {
     const TestComponent = () => <div>TestComponent</div>;
-    const unsubscribeSpy = sinon.spy();
-    let addComponentPreviewHandlerSpy: sinon.SinonStub;
+    const unsubscribeSpy = sandbox.spy();
+    let addComponentPreviewHandlerSpy: sandbox.SinonStub;
     let page: Page;
 
     const defaultImportMap = () =>
@@ -336,7 +338,7 @@ describe('<DesignLibrary />', () => {
     beforeEach(() => {
       page = getPage(getTestLayoutData().layoutData, variantGenerationMode);
 
-      addComponentPreviewHandlerSpy = sinon.stub().callsFake((_importMap, callback) => {
+      addComponentPreviewHandlerSpy = sandbox.stub().callsFake((_importMap, callback) => {
         callbackEvent = callback;
 
         return unsubscribeSpy;
@@ -347,6 +349,7 @@ describe('<DesignLibrary />', () => {
 
     afterEach(() => {
       postMessageSpy.resetHistory();
+      consoleErrorSpy.resetHistory();
       addComponentPreviewHandlerSpy.resetHistory();
       unsubscribeSpy.resetHistory();
     });
@@ -354,7 +357,7 @@ describe('<DesignLibrary />', () => {
     it('should render component when provided', async () => {
       const rendered = await render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMapImport={defaultImportMap} />
+          <DesignLibrary loadImportMap={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
@@ -370,7 +373,7 @@ describe('<DesignLibrary />', () => {
     it('should render loading preview when no component is provided', () => {
       const rendered = render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMapImport={defaultImportMap} />
+          <DesignLibrary loadImportMap={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
@@ -382,7 +385,7 @@ describe('<DesignLibrary />', () => {
     it('should render error message when component fails to initialize', async () => {
       const rendered = render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMapImport={defaultImportMap} />
+          <DesignLibrary loadImportMap={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
@@ -393,10 +396,30 @@ describe('<DesignLibrary />', () => {
       });
     });
 
+    it('should render error message when component fails to initialize due to failing import map promise', async () => {
+      const initError = new Error('Failed to load import map');
+      const errorImportMap = () =>
+        new Promise((_, reject) => {
+          reject(initError);
+        });
+      const rendered = render(
+        <SitecoreProvider componentMap={components} api={api} page={page}>
+          <DesignLibrary loadImportMap={errorImportMap} />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+
+      await waitFor(() => {
+        callbackEvent('Error', null);
+        expect(rendered.baseElement.innerHTML).to.contain('Error during component initialization');
+        expect(consoleErrorSpy.calledWith('Error loading import map:', initError)).to.be.true;
+      });
+    });
+
     it('should render error message when component fails to render', async () => {
       const rendered = render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMapImport={defaultImportMap} />
+          <DesignLibrary loadImportMap={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
@@ -415,7 +438,7 @@ describe('<DesignLibrary />', () => {
 
       const rendered = render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMapImport={defaultImportMap} />
+          <DesignLibrary loadImportMap={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );
@@ -443,7 +466,7 @@ describe('<DesignLibrary />', () => {
     it('should send postMessage events for import-map and component-props', async () => {
       render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary importMapImport={defaultImportMap} />
+          <DesignLibrary loadImportMap={defaultImportMap} />
         </SitecoreProvider>,
         { container: document.body }
       );

--- a/packages/react/src/components/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary.tsx
@@ -149,7 +149,7 @@ type VariantGenerationProps = {
   /**
    * The import map to be used in variant generation mode.
    */
-  importMapImport?: () => Promise<ImportMapImport>;
+  loadImportMap?: () => Promise<ImportMapImport>;
 };
 
 /**
@@ -168,7 +168,7 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
   const [initError, setInitError] = useState<boolean>(false);
   const [Component, setComponent] = useState<DynamicComponent>(null);
 
-  if (!props.importMapImport) {
+  if (!props.loadImportMap) {
     return (
       <div>
         No dynamic import map loaded. Please check a dynamic import map function is passed into
@@ -190,10 +190,11 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
     const init = async () => {
       let importMap: codegen.ImportEntry[] = undefined;
       try {
-        importMap = (await props.importMapImport()).default;
+        importMap = (await props.loadImportMap()).default;
       } catch (error) {
         console.error('Error loading import map:', error);
-        importMap = [];
+        setInitError(true);
+        return;
       }
       // account for component being unmounted while resolving async import map
       if (cancelled) return;
@@ -234,7 +235,7 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
         unsubscribe();
       }
     };
-  }, [props.importMapImport]);
+  }, []);
 
   if (initError) {
     return <div key={renderKey}>Error during component initialization</div>;
@@ -259,10 +260,10 @@ type DesignLibraryProps = {
    * The dynamic import for import map to be used in variant generation mode.
    * Currently it's optional but it will be required in the next major version.
    */
-  importMapImport?: () => Promise<ImportMapImport>;
+  loadImportMap?: () => Promise<ImportMapImport>;
 };
 
-export const DesignLibrary = ({ importMapImport }: DesignLibraryProps): JSX.Element => {
+export const DesignLibrary = ({ loadImportMap }: DesignLibraryProps): JSX.Element => {
   const { page } = useSitecore();
   const { isDesignLibrary } = page.mode;
   const isVariantGeneration = page.mode.designLibrary?.isVariantGeneration;
@@ -272,7 +273,7 @@ export const DesignLibrary = ({ importMapImport }: DesignLibraryProps): JSX.Elem
   }
 
   if (isVariantGeneration) {
-    return <VariantGeneration importMapImport={importMapImport} />;
+    return <VariantGeneration loadImportMap={loadImportMap} />;
   }
 
   return <Preview />;

--- a/packages/react/src/components/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary.tsx
@@ -166,16 +166,8 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
   const rendering = route?.placeholders[EDITING_COMPONENT_PLACEHOLDER][0];
   const [renderKey, setRenderKey] = useState(0);
   const [initError, setInitError] = useState<boolean>(false);
+  const [importMapError, setImportMapError] = useState<boolean>(false);
   const [Component, setComponent] = useState<DynamicComponent>(null);
-
-  if (!props.loadImportMap) {
-    return (
-      <div>
-        No dynamic import map loaded. Please check a dynamic import map function is passed into
-        Design Library
-      </div>
-    );
-  }
 
   if (!rendering) {
     return <div>No component found in layout data. Please check your layout data.</div>;
@@ -189,11 +181,19 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
 
     const init = async () => {
       let importMap: codegen.ImportEntry[] = undefined;
+      if (!props.loadImportMap) {
+        console.error(
+          'No loadImportMap prop provided. Please provide a dynamic import map function for DesignLibrary.'
+        );
+        setImportMapError(true);
+        return;
+      }
       try {
-        importMap = (await props.loadImportMap()).default;
+        const importMapImport = await props.loadImportMap();
+        importMap = importMapImport.default;
       } catch (error) {
         console.error('Error loading import map:', error);
-        setInitError(true);
+        setImportMapError(true);
         return;
       }
       // account for component being unmounted while resolving async import map
@@ -236,6 +236,15 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
       }
     };
   }, []);
+
+  if (importMapError) {
+    return (
+      <div>
+        No dynamic import map loaded. Please check a dynamic import map function is passed into
+        Design Library
+      </div>
+    );
+  }
 
   if (initError) {
     return <div key={renderKey}>Error during component initialization</div>;

--- a/packages/react/src/components/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary.tsx
@@ -26,6 +26,10 @@ export const __mockDependencies = (mocks: any) => {
   addComponentPreviewHandler = mocks.addComponentPreviewHandler;
 };
 
+export type ImportMapImport = {
+  default: codegen.ImportEntry[];
+};
+
 /**
  * This component is used to render the component in preview mode.
  * It is used to send the rendered event to the parent window and render the component.
@@ -145,7 +149,7 @@ type VariantGenerationProps = {
   /**
    * The import map to be used in variant generation mode.
    */
-  importMap?: codegen.ImportEntry[];
+  importMapImport?: () => Promise<ImportMapImport>;
 };
 
 /**
@@ -164,8 +168,13 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
   const [initError, setInitError] = useState<boolean>(false);
   const [Component, setComponent] = useState<DynamicComponent>(null);
 
-  if (!props.importMap) {
-    return <div>No import map found. Please check your import map.</div>;
+  if (!props.importMapImport) {
+    return (
+      <div>
+        No dynamic import map loaded. Please check a dynamic import map function is passed into
+        Design Library
+      </div>
+    );
   }
 
   if (!rendering) {
@@ -173,37 +182,59 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
   }
 
   useEffect(() => {
-    const unsubscribe = addComponentPreviewHandler(props.importMap, (error, Component) => {
-      setRenderKey((key) => key + 1);
+    let cancelled = false;
+    // since import map is loaded lazily, we only need to add preview event handler once the import map is loaded
+    // unsubscribe function for useEffect cleanup will also be returned once importMap promise has been resolved or rejected
+    let unsubscribe: (() => void) | undefined = undefined;
 
-      if (error) {
-        setInitError(true);
-
-        return;
+    const init = async () => {
+      let importMap: codegen.ImportEntry[] = undefined;
+      try {
+        importMap = (await props.importMapImport()).default;
+      } catch (error) {
+        console.error('Error loading import map:', error);
+        importMap = [];
       }
+      // account for component being unmounted while resolving async import map
+      if (cancelled) return;
 
-      setInitError(false);
-      setComponent(() => Component as DynamicComponent);
-    });
+      unsubscribe = addComponentPreviewHandler(importMap, (error, Component) => {
+        setRenderKey((key) => key + 1);
+        if (error) {
+          setInitError(true);
 
-    const importMapEvent = getDesignLibraryImportMapEvent(rendering.uid, props.importMap);
+          return;
+        }
+        setInitError(false);
+        setComponent(() => Component as DynamicComponent);
+      });
 
-    console.debug('Component Library: sending event', importMapEvent);
+      const importMapEvent = getDesignLibraryImportMapEvent(rendering.uid, importMap);
 
-    window.parent.postMessage(importMapEvent, '*');
+      console.debug('Component Library: sending event', importMapEvent);
 
-    const componentPropsEvent = getDesignLibraryComponentPropsEvent(
-      rendering.uid,
-      rendering.fields,
-      rendering.params
-    );
+      window.parent.postMessage(importMapEvent, '*');
 
-    console.debug('Component Library: sending event', componentPropsEvent);
+      const componentPropsEvent = getDesignLibraryComponentPropsEvent(
+        rendering.uid,
+        rendering.fields,
+        rendering.params
+      );
 
-    window.top.postMessage(componentPropsEvent, '*');
+      console.debug('Component Library: sending event', componentPropsEvent);
 
-    return unsubscribe;
-  }, []);
+      window.top.postMessage(componentPropsEvent, '*');
+    };
+
+    init();
+    // return function that calls unsubsubribe - if the component was mounted correctly
+    return () => {
+      cancelled = true;
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [props.importMapImport]);
 
   if (initError) {
     return <div key={renderKey}>Error during component initialization</div>;
@@ -225,13 +256,13 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
 // @MAJOR-RELEASE-TODO - Make importMap required in next major version
 type DesignLibraryProps = {
   /**
-   * The import map to be used in variant generation mode.
+   * The dynamic import for import map to be used in variant generation mode.
    * Currently it's optional but it will be required in the next major version.
    */
-  importMap?: codegen.ImportEntry[];
+  importMapImport?: () => Promise<ImportMapImport>;
 };
 
-export const DesignLibrary = ({ importMap }: DesignLibraryProps): JSX.Element => {
+export const DesignLibrary = ({ importMapImport }: DesignLibraryProps): JSX.Element => {
   const { page } = useSitecore();
   const { isDesignLibrary } = page.mode;
   const isVariantGeneration = page.mode.designLibrary?.isVariantGeneration;
@@ -241,7 +272,7 @@ export const DesignLibrary = ({ importMap }: DesignLibraryProps): JSX.Element =>
   }
 
   if (isVariantGeneration) {
-    return <VariantGeneration importMap={importMap} />;
+    return <VariantGeneration importMapImport={importMapImport} />;
   }
 
   return <Preview />;


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Optimize client bundle size in a post import-map world. Lazy loading it will reduce the main chunk size:
from
<img width="552" height="176" alt="image" src="https://github.com/user-attachments/assets/e52112e5-2d62-48d2-a815-040a364c816a" />
to
<img width="648" height="237" alt="image" src="https://github.com/user-attachments/assets/8883246d-61bb-4370-9ae6-330f32e2adfd" />
And move some of the lazy loaded content into separate chunk.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
