### PR TITLE
[next.js] ImportMap incorrectly handles default exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Our versioning strategy is as follows:
 ### 🎉 New Features & Improvements
 
 * Code generation for Design Library enablers:
-  - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157) [#167](https://github.com/Sitecore/content-sdk/pull/167) [#170](https://github.com/Sitecore/content-sdk/pull/170) [#171](https://github.com/Sitecore/content-sdk/pull/171) [#175](https://github.com/Sitecore/content-sdk/pull/175))
+  - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157))([#167](https://github.com/Sitecore/content-sdk/pull/167))([#170](https://github.com/Sitecore/content-sdk/pull/170))([#171](https://github.com/Sitecore/content-sdk/pull/171))([#175](https://github.com/Sitecore/content-sdk/pull/175))([#177](https://github.com/Sitecore/content-sdk/pull/177))
     - New `writeImportMap()`, `combineImportEntries()` methods and `defaultImportEntries` export available from `@sitecore-content-sdk/nextjs/codegen`
   - Dynamic component rendering ([#163](https://github.com/Sitecore/content-sdk/pull/163))
   - Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))

--- a/packages/nextjs/src/editing/codegen/import-map.ts
+++ b/packages/nextjs/src/editing/codegen/import-map.ts
@@ -44,7 +44,7 @@ export const defaultImportEntries: ImportEntry[] = [
   {
     module: 'react',
     exports: [
-      { name: 'React', value: React },
+      { name: 'default', value: React },
       { name: 'Children', value: Children },
       { name: 'Fragment', value: Fragment },
       { name: 'createElement', value: createElement },

--- a/packages/nextjs/src/tools/codegen/import-map.test.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.test.ts
@@ -152,9 +152,8 @@ describe('Import Map Generation', () => {
             },
           ],
           defaultImports: [
-            { name: 'defaultExport', value: 'defaultExport' },
+            { name: 'default', value: 'defaultExport2' },
             { name: '*', value: 'everything' },
-            { name: 'defaultExport2', value: 'defaultExport2' },
           ],
         },
       ];

--- a/packages/nextjs/src/tools/codegen/import-map.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.ts
@@ -239,7 +239,7 @@ export const getImportMap = (paths: string[]) => {
               importModuleName,
               importValuesIndex
             );
-            importMap.get(importModuleName)!.defaultExports.set(imports.default, importValue);
+            importMap.get(importModuleName)!.defaultExports.set('default', importValue);
             importValuesIndex.set(importValue, importModuleName);
           }
         } else {
@@ -349,11 +349,11 @@ export const nextJsMapTemplate = (indexedImportMap: Map<string, ModuleExports>) 
     }
     if (entry.defaultExports.length > 0) {
       Array.from(entry.defaultExports).forEach((defaultExportEntry) => {
-        importStatements.push(
-          `import ${getSingleImport(defaultExportEntry.name, defaultExportEntry.value)} from '${
-            entry.module
-          }';`
-        );
+        if (defaultExportEntry.name === 'default') {
+          importStatements.push(`import ${defaultExportEntry.value} from '${entry.module}';`);
+        } else {
+          importStatements.push(`import * as ${defaultExportEntry.value} from '${entry.module}';`);
+        }
       });
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This bug affects the resolution of default exports in the generated import map. It consists of two issues:

Incorrect export type for React
In the default import map, React is incorrectly defined as a named export instead of a default export: https://github.com/Sitecore/content-sdk/blob/dev/packages/nextjs/src/editing/codegen/import-map.ts#L47 

Default imports are treated as named exports
The code that generates the import map ignores default imports and treats them as named.
For example, the following entry is generated:
```ts
{
  module: 'next/head',
  exports: [
    { name: 'Head', value: Head },
  ]
}
```
However, in the component code, Head is imported as a default export:
```ts
import Head from 'next/head';
```
This mismatch causes incorrect behavior when relying on the import map for module resolution.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
