### PR TITLE
[core] Restore back local connection (local.api creds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[core]` `[nextjs]` Restore proper local connection fallback ([#178](https://github.com/Sitecore/content-sdk/pull/178))
 * `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))
   - `SitecoreClient.getPreview` and `SitecoreClient.getDesignLibraryData` no longer request dictionary data. `Page` type is not affected.
   - Updated `EditingService.fetchEditingData`:

--- a/packages/core/src/config/define-config.test.ts
+++ b/packages/core/src/config/define-config.test.ts
@@ -68,19 +68,19 @@ describe('define-config', () => {
     expect(config.dictionary.caching.timeout).to.equal(fallback.dictionary.caching.timeout);
   });
 
-  it('throws when server-side contextId is missing', () => {
+  it('throws when server-side has neither Edge contextId nor Local credentials', () => {
     const badConfig: SitecoreConfigInput = {
-      ...mockConfig,
       api: {
         edge: {
           contextId: '',
-          clientContextId: 'client-id',
+          clientContextId: 'client-id', // client-only is NOT sufficient on the server
         },
+        // no local creds provided
       },
     };
 
     expect(() => defineConfig(badConfig)).to.throw(
-      'Configuration error: a server-side Edge contextId'
+      'Configuration error: provide either Edge contextId'
     );
   });
 
@@ -105,15 +105,7 @@ describe('define-config', () => {
     const cfg = defineConfig(mockConfig);
     // eslint-disable-next-line
     expect((cfg.retries.retryStrategy as DefaultRetryStrategy)['statusCodes']).to.deep.equal([
-      429,
-      502,
-      503,
-      504,
-      520,
-      521,
-      522,
-      523,
-      524,
+      429, 502, 503, 504, 520, 521, 522, 523, 524,
     ]);
   });
 
@@ -124,6 +116,8 @@ describe('define-config', () => {
       process.env.SITECORE_EDITING_SECRET = 'env-secret';
       process.env.PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT = '111';
       process.env.PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT = '222';
+      process.env.NEXT_PUBLIC_SITECORE_API_KEY = 'env-local-key';
+      process.env.NEXT_PUBLIC_SITECORE_API_HOST = 'https://env-local-host';
 
       const cfg = getFallbackConfig();
       expect(cfg.api.edge.contextId).to.equal('env-context');
@@ -131,6 +125,8 @@ describe('define-config', () => {
       expect(cfg.editingSecret).to.equal('env-secret');
       expect(cfg.personalize.edgeTimeout).to.equal(111);
       expect(cfg.personalize.cdpTimeout).to.equal(222);
+      expect(cfg.api.local.apiKey).to.equal('env-local-key');
+      expect(cfg.api.local.apiHost).to.equal('https://env-local-host');
     });
 
     it('falls back to defaults when env variables are absent', () => {
@@ -139,6 +135,8 @@ describe('define-config', () => {
       delete process.env.SITECORE_EDITING_SECRET;
       delete process.env.PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT;
       delete process.env.PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT;
+      delete process.env.NEXT_PUBLIC_SITECORE_API_KEY;
+      delete process.env.NEXT_PUBLIC_SITECORE_API_HOST;
 
       const cfg = getFallbackConfig();
       expect(cfg.api.edge.contextId).to.equal('');
@@ -146,6 +144,8 @@ describe('define-config', () => {
       expect(cfg.editingSecret).to.equal('editing-secret-missing');
       expect(cfg.personalize.edgeTimeout).to.equal(400);
       expect(cfg.personalize.cdpTimeout).to.equal(400);
+      expect(cfg.api.local.apiKey).to.equal('');
+      expect(cfg.api.local.apiHost).to.equal('');
     });
   });
 
@@ -206,26 +206,26 @@ describe('define-config', () => {
     expect(() => defineConfig(cfg)).to.not.throw();
   });
 
-  it('fails when only clientContextId is provided', () => {
+  it('fails when only clientContextId is provided (no local creds)', () => {
     const cfg: SitecoreConfigInput = {
       api: { edge: { contextId: '', clientContextId: 'client-id' } },
     };
-    expect(() => defineConfig(cfg)).to.throw('Configuration error: a server-side Edge contextId');
+    expect(() => defineConfig(cfg)).to.throw('Configuration error: provide either Edge contextId');
   });
 
-  it('fails when contextId is missing even with local API creds', () => {
+  it('allows local-only when contextId is missing', () => {
     const cfg: SitecoreConfigInput = {
       api: {
         edge: { contextId: '' },
         local: { apiKey: 'key', apiHost: 'host' },
       },
     };
-    expect(() => defineConfig(cfg)).to.throw('Configuration error: a server-side Edge contextId');
+    expect(() => defineConfig(cfg)).to.not.throw();
   });
 
   it('fails when API configuration is empty', () => {
     const cfg = { api: {} } as SitecoreConfigInput;
-    expect(() => defineConfig(cfg)).to.throw('Configuration error: a server-side Edge contextId');
+    expect(() => defineConfig(cfg)).to.throw('Configuration error: provide either Edge contextId');
   });
 
   describe('validateConfig server-side behaviour', () => {
@@ -233,21 +233,28 @@ describe('define-config', () => {
 
     beforeEach(() => {
       originalWindow = (global as any).window;
-      delete (global as any).window;
+      delete (global as any).window; // simulate server
     });
     afterEach(() => {
       if (originalWindow !== undefined) (global as any).window = originalWindow;
     });
 
-    it('logs warning but does not throw when clientContextId is missing', () => {
+    it('logs warning but does not throw when clientContextId is missing (Edge server-only)', () => {
       const cfg = { api: { edge: { contextId: 'server-id' } } };
       expect(() => defineConfig(cfg)).to.not.throw();
       expect(defineConfig(cfg).api.edge.clientContextId).to.equal('');
     });
 
-    it('requires contextId even if clientContextId is present', () => {
+    it('requires Edge or Local; clientContextId alone is insufficient', () => {
       const cfg = { api: { edge: { contextId: '', clientContextId: 'client-id' } } };
-      expect(() => defineConfig(cfg)).to.throw('Configuration error: a server-side Edge contextId');
+      expect(() => defineConfig(cfg)).to.throw(
+        'Configuration error: provide either Edge contextId'
+      );
+    });
+
+    it('accepts local-only on the server', () => {
+      const cfg = { api: { edge: { contextId: '' }, local: { apiKey: 'k', apiHost: 'h' } } };
+      expect(() => defineConfig(cfg as any)).to.not.throw();
     });
   });
 });

--- a/packages/core/src/config/define-config.test.ts
+++ b/packages/core/src/config/define-config.test.ts
@@ -105,7 +105,15 @@ describe('define-config', () => {
     const cfg = defineConfig(mockConfig);
     // eslint-disable-next-line
     expect((cfg.retries.retryStrategy as DefaultRetryStrategy)['statusCodes']).to.deep.equal([
-      429, 502, 503, 504, 520, 521, 522, 523, 524,
+      429,
+      502,
+      503,
+      504,
+      520,
+      521,
+      522,
+      523,
+      524,
     ]);
   });
 

--- a/packages/core/src/config/define-config.ts
+++ b/packages/core/src/config/define-config.ts
@@ -14,8 +14,8 @@ export const getFallbackConfig = (): SitecoreConfig => ({
       edgeUrl: process.env.SITECORE_EDGE_URL || SITECORE_EDGE_URL_DEFAULT,
     },
     local: {
-      apiKey: process.env.NEXT_PUBLIC_SITECORE_API_KEY || '',
-      apiHost: process.env.NEXT_PUBLIC_SITECORE_API_HOST || '',
+      apiKey: process.env.SITECORE_API_KEY || process.env.NEXT_PUBLIC_SITECORE_API_KEY || '',
+      apiHost: process.env.SITECORE_API_HOST || process.env.NEXT_PUBLIC_SITECORE_API_HOST || '',
       path: '/sitecore/api/graph/edge',
     },
   },

--- a/packages/core/src/config/define-config.ts
+++ b/packages/core/src/config/define-config.ts
@@ -14,8 +14,8 @@ export const getFallbackConfig = (): SitecoreConfig => ({
       edgeUrl: process.env.SITECORE_EDGE_URL || SITECORE_EDGE_URL_DEFAULT,
     },
     local: {
-      apiKey: '',
-      apiHost: '',
+      apiKey: process.env.NEXT_PUBLIC_SITECORE_API_KEY || '',
+      apiHost: process.env.NEXT_PUBLIC_SITECORE_API_HOST || '',
       path: '/sitecore/api/graph/edge',
     },
   },
@@ -116,21 +116,22 @@ const validateConfig = (config: SitecoreConfigInput): void => {
   const isBrowser = typeof window !== 'undefined';
   const hasEdgeContextId = !!config.api?.edge?.contextId;
   const hasClientContextId = !!config.api?.edge?.clientContextId;
+  const hasLocalCreds = !!config.api?.local?.apiHost && !!config.api?.local?.apiKey;
 
-  // Server-side check
-  if (typeof window === 'undefined') {
-    if (!hasEdgeContextId) {
+  // Server-side: allow Edge OR Local; clientContextId alone is NOT sufficient
+  if (!isBrowser) {
+    if (!hasEdgeContextId && !hasLocalCreds) {
       throw new Error(
-        `Configuration error: a server-side Edge contextId (api.edge.contextId) is required.
-Supplying only clientContextId or local-API credentials is not sufficient`
+        'Configuration error: provide either Edge contextId (api.edge.contextId) or local credentials (api.local.apiHost + api.local.apiKey).'
       );
     }
-    if (!hasClientContextId) {
+    if (hasEdgeContextId && !hasClientContextId) {
       // eslint-disable-next-line no-console
-      console.warn(
-        `Warning: only a server-side contextId is provided.
-If your app makes client-side requests, they will fail unless you also set a clientContextId.`
-      );
+      if (process.env.NODE_ENV === 'development') {
+        console.warn(
+          'Warning: only a server-side edge contextId is provided. Client-side requests will require api.edge.clientContextId or a proxy.'
+        );
+      }
     }
     return; // validation complete on the server
   }
@@ -138,10 +139,12 @@ If your app makes client-side requests, they will fail unless you also set a cli
   // Browser-side warning (runs only if contextId exists but clientContextId is missing)
   if (isBrowser && !hasClientContextId) {
     // eslint-disable-next-line no-console
-    console.warn(
-      `Warning: clientContextId is missing. The browser will use contextId instead.
-Client Side functionalities (like Tracking and Personalization) may be limited.`
-    );
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(
+        `Warning: clientContextId is missing. The browser will use contextId instead.
+  Client Side functionalities (like Tracking and Personalization) may be limited.`
+      );
+    }
   }
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR restores the local API fallback when contextId is missing (when users want to use local connection first), ensuring correct Edge/local connection priority and updated error messages.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
