### PR TITLE
[create-content-sdk-app] Add extra fix for GQL Client error when only local api is provided

### DIFF
--- a/packages/create-content-sdk-app/src/templates/nextjs/src/middleware.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/middleware.ts
@@ -17,23 +17,43 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
 
   // Instantiate AFTER the guard so constructors don’t run in local-only mode
   const multisite = new MultisiteMiddleware({
+    /**
+    * List of sites for site resolver to work with
+    */
     sites,
     ...scConfig.api.edge,
     ...scConfig.multisite,
+    // This function determines if the middleware should be turned off on per-request basis.
+    // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to disable more.
+    // This is an important performance consideration since Next.js Edge middleware runs on every request.
     skip: () => false,
   });
 
   const redirects = new RedirectsMiddleware({
+    /**
+    * List of sites for site resolver to work with
+    */
     sites,
     ...scConfig.api.edge,
     ...scConfig.redirects,
+    // This function determines if the middleware should be turned off on per-request basis.
+    // Certain paths are ignored by default (e.g. Next.js API routes), but you may wish to disable more.
+    // By default it is disabled while in development mode.
+    // This is an important performance consideration since Next.js Edge middleware runs on every request.
     skip: () => false,
   });
 
   const personalize = new PersonalizeMiddleware({
+    /**
+    * List of sites for site resolver to work with
+    */
     sites,
     ...scConfig.api.edge,
     ...scConfig.personalize,
+    // This function determines if the middleware should be turned off on per-request basis.
+    // Certain paths are ignored by default (e.g. Next.js API routes), but you may wish to disable more.
+    // By default it is disabled while in development mode.
+    // This is an important performance consideration since Next.js Edge middleware runs on every request
     skip: () => false,
   });
 
@@ -52,5 +72,3 @@ export const config = {
    */
   matcher: ['/', '/((?!api/|_next/|healthz|sitecore/api/|-/|favicon.ico|sc_logo.svg).*)'],
 };
-
-

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/middleware.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/middleware.ts
@@ -1,4 +1,4 @@
-import { type NextRequest, type NextFetchEvent } from 'next/server';
+import { type NextRequest, type NextFetchEvent, NextResponse } from 'next/server';
 import {
   defineMiddleware,
   MultisiteMiddleware,
@@ -8,52 +8,40 @@ import {
 import sites from '.sitecore/sites.json';
 import scConfig from 'sitecore.config';
 
-const multisite = new MultisiteMiddleware({
-  /**
-   * List of sites for site resolver to work with
-   */
-  sites,
-  ...scConfig.api.edge,
-  ...scConfig.multisite,
-  // This function determines if the middleware should be turned off on per-request basis.
-  // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to disable more.
-  // This is an important performance consideration since Next.js Edge middleware runs on every request.
-  skip: () => false,
-});
-const redirects = new RedirectsMiddleware({
-  /**
-   * List of sites for site resolver to work with
-   */
-  sites,
-  ...scConfig.api.edge,
-  ...scConfig.redirects,
-  // This function determines if the middleware should be turned off on per-request basis.
-  // Certain paths are ignored by default (e.g. Next.js API routes), but you may wish to disable more.
-  // By default it is disabled while in development mode.
-  // This is an important performance consideration since Next.js Edge middleware runs on every request.
-  skip: () => false,
-});
-
-const personalize = new PersonalizeMiddleware({
-  /**
-   * List of sites for site resolver to work with
-   */
-  sites,
-  ...scConfig.api.edge,
-  ...scConfig.personalize,
-  // This function determines if the middleware should be turned off on per-request basis.
-  // Certain paths are ignored by default (e.g. Next.js API routes), but you may wish to disable more.
-  // By default it is disabled while in development mode.
-  // This is an important performance consideration since Next.js Edge middleware runs on every request.
-  skip: () => false,
-});
-
 export function middleware(req: NextRequest, ev: NextFetchEvent) {
+  // If no Edge server contextId, skip Edge middlewares entirely.
+  // (SSR/API can still use Local creds; no crash in Edge runtime.)
+  if (!scConfig.api?.edge?.contextId) {
+    return NextResponse.next();
+  }
+
+  // Instantiate AFTER the guard so constructors don’t run in local-only mode
+  const multisite = new MultisiteMiddleware({
+    sites,
+    ...scConfig.api.edge,
+    ...scConfig.multisite,
+    skip: () => false,
+  });
+
+  const redirects = new RedirectsMiddleware({
+    sites,
+    ...scConfig.api.edge,
+    ...scConfig.redirects,
+    skip: () => false,
+  });
+
+  const personalize = new PersonalizeMiddleware({
+    sites,
+    ...scConfig.api.edge,
+    ...scConfig.personalize,
+    skip: () => false,
+  });
+
   return defineMiddleware(multisite, redirects, personalize).exec(req, ev);
 }
 
 export const config = {
-  /*
+    /*
    * Match all paths except for:
    * 1. /api routes
    * 2. /_next (Next.js internals)
@@ -64,3 +52,5 @@ export const config = {
    */
   matcher: ['/', '/((?!api/|_next/|healthz|sitecore/api/|-/|favicon.ico|sc_logo.svg).*)'],
 };
+
+

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/middleware.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/middleware.ts
@@ -41,7 +41,7 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
 }
 
 export const config = {
-    /*
+  /*
    * Match all paths except for:
    * 1. /api routes
    * 2. /_next (Next.js internals)


### PR DESCRIPTION
- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Follow-up fix for restoring the local connection back to CSDK. This PR is a possible fix for the GQL Client errors when only `local api host` and `local api key` are provided. 

Related to: https://github.com/Sitecore/content-sdk/pull/178

To make the changes a bit clearer, what changed with this PR can be summed up below:

- Next.js `middleware.ts`: skip Edge middlewares when no `edge.contextId` (avoids Edge runtime errors).

- Kept existing behavior when `edge.contextId` is present (ContextId (Edge) is still preferred when both exist).

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
