### PR TITLE
[all] Eslint config adjustments to fix cannot convert type warning

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,16 +64,16 @@ export default defineConfig([
       jsdoc,
     },
     rules: {
-      ...pluginNext.configs.recommended.rules,
-      ...pluginNext.configs['core-web-vitals'].rules,
+      ...(pluginNext.configs?.recommended?.rules ?? {}),
+      ...(pluginNext.configs?.['core-web-vitals']?.rules ?? {}),
       '@next/next/no-html-link-for-pages': 'off',
       '@next/next/no-img-element': 'off',
       '@next/next/no-sync-scripts': 'off',
       '@next/next/no-assign-module-variable': 'off',
       // Include ESLint recommended rules
-      ...js.configs.recommended.rules,
+      ...(js.configs?.recommended?.rules ?? {}),
       // Include JSDoc recommended rules
-      ...jsdoc.configs.recommended.rules,
+      ...(jsdoc.configs?.recommended?.rules ?? {}),
       // JSDoc relaxations
       'jsdoc/newline-after-description': 'off',
       'jsdoc/require-property-description': 'off',

--- a/packages/create-content-sdk-app/src/templates/nextjs/eslint.config.mjs
+++ b/packages/create-content-sdk-app/src/templates/nextjs/eslint.config.mjs
@@ -1,35 +1,33 @@
-// eslint.config.mjs (updated)
+// packages/create-content-sdk-app/src/templates/nextjs/eslint.config.mjs
 import { defineConfig } from 'eslint/config'
 import js from '@eslint/js'
-import * as nextNS from '@next/eslint-plugin-next'
+import * as nextEslintPlugin from '@next/eslint-plugin-next'
 import tsParser from '@typescript-eslint/parser'
-import * as tsNS from '@typescript-eslint/eslint-plugin'
-import * as importNS from 'eslint-plugin-import'
-import * as hooksNS from 'eslint-plugin-react-hooks'
+import * as tsEslintPlugin from '@typescript-eslint/eslint-plugin'
+import * as importEslintPlugin from 'eslint-plugin-import'
+import * as reactHooksEslintPlugin from 'eslint-plugin-react-hooks'
 import globals from 'globals'
 
-// normalize CJS/ESM shapes
-const pluginNext = nextNS.default ?? nextNS
-const tsPlugin = tsNS.default ?? tsNS
-const importPlugin = importNS.default ?? importNS
-const reactHooks = hooksNS.default ?? hooksNS
+// Normalize ESM/CJS shapes to plugin objects
+const nextPlugin = nextEslintPlugin.default ?? nextEslintPlugin
+const tsPlugin = tsEslintPlugin.default ?? tsEslintPlugin
+const importPlugin = importEslintPlugin.default ?? importEslintPlugin
+const reactHooksPlugin = reactHooksEslintPlugin.default ?? reactHooksEslintPlugin
 
 export default defineConfig([
-  // common ignores
-  {
-    ignores: ['node_modules/**', '.next/**', 'dist/**', 'build/**', 'coverage/**'],
-  },
+  // ignores
+  { ignores: ['node_modules/**', '.next/**', 'dist/**', 'build/**', 'coverage/**'] },
 
-  // core ESLint recommended rules
+  // core ESLint recommended
   js.configs.recommended,
 
   // register plugins (applies to all files)
   {
     plugins: {
-      '@next/next': pluginNext,
+      '@next/next': nextPlugin,
       '@typescript-eslint': tsPlugin,
       import: importPlugin,
-      'react-hooks': reactHooks,
+      'react-hooks': reactHooksPlugin,
     },
   },
 
@@ -51,13 +49,12 @@ export default defineConfig([
       },
     },
     settings: {
-      // helps eslint-plugin-import resolve TS paths
       'import/resolver': { typescript: {} },
     },
     rules: {
       // Next.js
-      ...(pluginNext.configs?.recommended?.rules ?? {}),
-      ...(pluginNext.configs?.['core-web-vitals']?.rules ?? {}),
+      ...(nextPlugin.configs?.recommended?.rules ?? {}),
+      ...(nextPlugin.configs?.['core-web-vitals']?.rules ?? {}),
       '@next/next/no-html-link-for-pages': 'off',
       '@next/next/no-img-element': 'off',
       '@next/next/no-sync-scripts': 'off',

--- a/packages/create-content-sdk-app/src/templates/nextjs/eslint.config.mjs
+++ b/packages/create-content-sdk-app/src/templates/nextjs/eslint.config.mjs
@@ -1,13 +1,29 @@
-import { defineConfig } from 'eslint/config';
-import js from '@eslint/js';
-import pluginNext from '@next/eslint-plugin-next';
-import tsParser from '@typescript-eslint/parser';
-import tsPlugin from '@typescript-eslint/eslint-plugin';
-import importPlugin from 'eslint-plugin-import';
-import reactHooks from 'eslint-plugin-react-hooks';
-import globals from 'globals';
+// eslint.config.mjs (updated)
+import { defineConfig } from 'eslint/config'
+import js from '@eslint/js'
+import * as nextNS from '@next/eslint-plugin-next'
+import tsParser from '@typescript-eslint/parser'
+import * as tsNS from '@typescript-eslint/eslint-plugin'
+import * as importNS from 'eslint-plugin-import'
+import * as hooksNS from 'eslint-plugin-react-hooks'
+import globals from 'globals'
+
+// normalize CJS/ESM shapes
+const pluginNext = nextNS.default ?? nextNS
+const tsPlugin = tsNS.default ?? tsNS
+const importPlugin = importNS.default ?? importNS
+const reactHooks = hooksNS.default ?? hooksNS
 
 export default defineConfig([
+  // common ignores
+  {
+    ignores: ['node_modules/**', '.next/**', 'dist/**', 'build/**', 'coverage/**'],
+  },
+
+  // core ESLint recommended rules
+  js.configs.recommended,
+
+  // register plugins (applies to all files)
   {
     plugins: {
       '@next/next': pluginNext,
@@ -16,6 +32,8 @@ export default defineConfig([
       'react-hooks': reactHooks,
     },
   },
+
+  // project rules
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
     languageOptions: {
@@ -26,31 +44,38 @@ export default defineConfig([
         ecmaFeatures: { jsx: true },
       },
       globals: {
-        // bring in Node + Browser + modern JS globals
-        ...globals.node,
-        ...globals.browser,
-        ...globals.es2021,
-        // ensure URL is defined
+        ...(globals.node ?? {}),
+        ...(globals.browser ?? {}),
+        ...(globals.es2021 ?? {}), // guarded to avoid "Cannot convert undefined or null to object"
         URL: 'readonly',
       },
     },
+    settings: {
+      // helps eslint-plugin-import resolve TS paths
+      'import/resolver': { typescript: {} },
+    },
     rules: {
-      // ESLint’s own recommended JS rules
-      ...js.configs.recommended.rules,
-      // Next.js “recommended” + “core-web-vitals”
-      ...pluginNext.configs.recommended.rules,
-      ...pluginNext.configs['core-web-vitals'].rules,
-      // TypeScript-specific unused‐vars rule
+      // Next.js
+      ...(pluginNext.configs?.recommended?.rules ?? {}),
+      ...(pluginNext.configs?.['core-web-vitals']?.rules ?? {}),
+      '@next/next/no-html-link-for-pages': 'off',
+      '@next/next/no-img-element': 'off',
+      '@next/next/no-sync-scripts': 'off',
+      '@next/next/no-assign-module-variable': 'off',
+
+      // TypeScript
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       'no-unused-vars': 'off',
       'no-undef': 'off',
-      // import+react-hooks rules now that the plugins are loaded
+
+      // Plugins
       'import/no-anonymous-default-export': 'error',
       'react-hooks/exhaustive-deps': 'warn',
       'react-hooks/rules-of-hooks': 'error',
-      // custom prefs
+
+      // Preferences
       'prefer-const': 'error',
       'no-var': 'error',
     },
   },
-]);
+])


### PR DESCRIPTION
- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR fixes ESLint warning in editor by guarding globals spreads. More specifically, it prevents Prevent ESLint server error “Cannot convert undefined or null to object” by guarding `globals.es2021` (and others) in `eslint.config.mjs`.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
