### PR TITLE
[core] Revert generating SSG paths for display names paths separately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Our versioning strategy is as follows:
   - Ensure editing state is enabled in Design Library mode ([#181](https://github.com/Sitecore/content-sdk/pull/181))
 * `[core]` Ensure displayName paths are properly UTF-8 encoded. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
 
-
 ### 🐛 Bug Fixes
 
 * `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,9 @@ Our versioning strategy is as follows:
     - New `writeImportMap()`, `combineImportEntries()` methods and `defaultImportEntries` export available from `@sitecore-content-sdk/nextjs/codegen`
   - Dynamic component rendering ([#163](https://github.com/Sitecore/content-sdk/pull/163))
   - Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))
-<<<<<<< Updated upstream
   - Ensure editing state is enabled in Design Library mode ([#181](https://github.com/Sitecore/content-sdk/pull/181))
-* `[sitecore-jss-nextjs]` Introduced support for using `displayName` values in route generation for statically built pages in JSS Next.js apps. This enables localized and user-friendly URLs when SXA link provider is configured to use display names.  Ensured `displayName` paths are UTF-8 encoded. This feature can be enabled by setting the `enableDisplayNameRouting` flag to true. By default, it is set to false. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
-=======
 * `[core]` Ensure displayName paths are properly UTF-8 encoded. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
->>>>>>> Stashed changes
+
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,12 @@ Our versioning strategy is as follows:
     - New `writeImportMap()`, `combineImportEntries()` methods and `defaultImportEntries` export available from `@sitecore-content-sdk/nextjs/codegen`
   - Dynamic component rendering ([#163](https://github.com/Sitecore/content-sdk/pull/163))
   - Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))
+<<<<<<< Updated upstream
   - Ensure editing state is enabled in Design Library mode ([#181](https://github.com/Sitecore/content-sdk/pull/181))
 * `[sitecore-jss-nextjs]` Introduced support for using `displayName` values in route generation for statically built pages in JSS Next.js apps. This enables localized and user-friendly URLs when SXA link provider is configured to use display names.  Ensured `displayName` paths are UTF-8 encoded. This feature can be enabled by setting the `enableDisplayNameRouting` flag to true. By default, it is set to false. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
+=======
+* `[core]` Ensure displayName paths are properly UTF-8 encoded. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
+>>>>>>> Stashed changes
 
 ### 🐛 Bug Fixes
 

--- a/packages/core/src/site/sitepath-service.test.ts
+++ b/packages/core/src/site/sitepath-service.test.ts
@@ -32,9 +32,7 @@ describe('SitePathService', () => {
     nock.cleanAll();
   });
 
-  const mockPathsRequest = (
-    results?: { path: string; route?: { displayName?: string | null } }[]
-  ) => {
+  const mockPathsRequest = (results?: { url: { path: string } }[]) => {
     nock(endpoint)
       .post('/', /DefaultSitemapQuery/gi)
       .reply(
@@ -50,10 +48,7 @@ describe('SitePathService', () => {
                       pageInfo: {
                         hasNext: false,
                       },
-                      results: results.map((item) => ({
-                        path: item.path,
-                        route: item.route || { displayName: null },
-                      })),
+                      results,
                     },
                   },
                 },
@@ -149,58 +144,29 @@ describe('SitePathService', () => {
       ]);
     });
 
-    it('should return both itemName and encoded displayName paths for routes with displayName (no personalization)', async () => {
-      const multipleSites = ['site1', 'site2'];
+    it('should return encoded paths when special characters are used', async () => {
       const lang = 'en';
 
       nock(endpoint)
-        .persist()
-        .post('/', (body) => body.variables.siteName === multipleSites[0])
+        .post('/', /DefaultSitemapQuery/gi)
         .reply(200, {
           data: {
             site: {
               siteInfo: {
                 routes: {
-                  total: 2,
+                  total: 3,
                   pageInfo: {
                     hasNext: false,
                   },
                   results: [
                     {
-                      path: '/About',
-                      route: { displayName: 'New-about' },
+                      path: '/Åbout',
+                    },
+                    {
+                      path: '/Tëâm',
                     },
                     {
                       path: '/',
-                      route: { displayName: 'Home' },
-                    },
-                  ],
-                },
-              },
-            },
-          },
-        });
-
-      nock(endpoint)
-        .persist()
-        .post('/', (body) => body.variables.siteName === multipleSites[1])
-        .reply(200, {
-          data: {
-            site: {
-              siteInfo: {
-                routes: {
-                  total: 2,
-                  pageInfo: {
-                    hasNext: false,
-                  },
-                  results: [
-                    {
-                      path: 'Test',
-                      route: { displayName: 'New-Test' },
-                    },
-                    {
-                      path: '/',
-                      route: { displayName: 'Home' },
                     },
                   ],
                 },
@@ -211,132 +177,27 @@ describe('SitePathService', () => {
 
       const service = new SitePathService({
         clientFactory,
-        enableDisplayNameRouting: true,
-      });
-
-      const sitemap = await service.fetchSiteRoutes(multipleSites, [lang]);
-
-      expect(sitemap).to.have.deep.members([
-        {
-          params: { path: ['_site_site1', 'About'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site1', 'New-about'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['Home', 'About'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['Home', 'New-about'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site1'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['Home'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site2', 'Test'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site2', 'New-Test'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['Home', 'Test'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['Home', 'New-Test'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['Home'] },
-          locale: 'en',
-        },
-      ]);
-
-      return expect(nock.isDone()).to.be.true;
-    });
-
-    it('should return encoded displayName paths when special characters are used', async () => {
-      const lang = 'en';
-
-      // Å → %C3%85, ü → %C3%BC, ç → %C3%A7
-      const results = [
-        {
-          path: '/about',
-          route: { displayName: 'Åbout' },
-        },
-        {
-          path: '/team',
-          route: { displayName: 'Tëâm' },
-        },
-        {
-          path: '/',
-          route: { displayName: 'Hôme' },
-        },
-      ];
-
-      mockPathsRequest(results);
-
-      const service = new SitePathService({
-        clientFactory,
-        enableDisplayNameRouting: true,
       });
 
       const sitemap = await service.fetchSiteRoutes(sites, [lang]);
 
-      expect(sitemap).to.have.deep.members([
+      expect(sitemap).to.deep.equal([
         {
-          params: { path: ['_site_site-name', 'about'] },
+          params: {
+            path: ['_site_site-name', 'Åbout'],
+          },
           locale: 'en',
         },
         {
-          params: { path: ['_site_site-name', '%C3%85bout'] },
+          params: {
+            path: ['_site_site-name', 'Tëâm'],
+          },
           locale: 'en',
         },
         {
-          params: { path: ['H%C3%B4me', 'about'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['H%C3%B4me', '%C3%85bout'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site-name', 'team'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site-name', 'T%C3%AB%C3%A2m'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['H%C3%B4me', 'team'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['H%C3%B4me', 'T%C3%AB%C3%A2m'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site-name'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['H%C3%B4me'] },
+          params: {
+            path: ['_site_site-name'],
+          },
           locale: 'en',
         },
       ]);
@@ -566,209 +427,6 @@ describe('SitePathService', () => {
           locale: lang,
         },
       ]);
-      return expect(nock.isDone()).to.be.true;
-    });
-
-    it('should return aggregated display name and item name paths for multiple sites and personalized sites', async () => {
-      const multipleSites = ['site1', 'site2'];
-      const lang = 'en';
-
-      nock(endpoint)
-        .post('/', (body) => {
-          return body.variables.siteName === multipleSites[0];
-        })
-        .reply(200, {
-          data: {
-            site: {
-              siteInfo: {
-                routes: {
-                  total: 2,
-                  pageInfo: {
-                    hasNext: false,
-                  },
-                  results: [
-                    {
-                      path: '/x1',
-                      route: {
-                        displayName: 'X-One',
-                        personalization: {
-                          variantIds: ['green'],
-                        },
-                      },
-                    },
-                    {
-                      path: '/y1/y2',
-                      route: {
-                        displayName: 'Y-Two',
-                        personalization: {
-                          variantIds: ['red', 'blue'],
-                        },
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-          },
-        });
-
-      nock(endpoint)
-        .post('/', (body) => {
-          return body.variables.siteName === multipleSites[1];
-        })
-        .reply(200, {
-          data: {
-            site: {
-              siteInfo: {
-                routes: {
-                  total: 2,
-                  pageInfo: {
-                    hasNext: false,
-                  },
-                  results: [
-                    {
-                      path: '/y1',
-                      route: {
-                        displayName: 'Y-One',
-                        personalization: {
-                          variantIds: ['green'],
-                        },
-                      },
-                    },
-                    {
-                      path: '/y1/y2',
-                      route: {
-                        displayName: 'Y-Two',
-                        personalization: {
-                          variantIds: ['red', 'blue'],
-                        },
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-          },
-        });
-
-      const service = new SitePathService({
-        clientFactory,
-        includePersonalizedRoutes: true,
-        enableDisplayNameRouting: true,
-      });
-
-      const sitemap = await service.fetchSiteRoutes(multipleSites, [lang]);
-
-      expect(sitemap).to.have.deep.members([
-        // Site1 paths
-        {
-          params: { path: ['_site_site1', 'x1'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site1', 'X-One'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_green', '_site_site1', 'x1'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_green', '_site_site1', 'X-One'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site1', 'y1', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site1', 'y1', 'Y-Two'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_red', '_site_site1', 'y1', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_red', '_site_site1', 'y1', 'Y-Two'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_blue', '_site_site1', 'y1', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_blue', '_site_site1', 'y1', 'Y-Two'] },
-          locale: 'en',
-        },
-
-        // Site2 paths
-        {
-          params: { path: ['_site_site2', 'y1'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site2', 'Y-One'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_green', '_site_site2', 'y1'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_green', '_site_site2', 'Y-One'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site2', 'y1', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site2', 'y1', 'Y-Two'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site2', 'Y-One', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_site_site2', 'Y-One', 'Y-Two'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_red', '_site_site2', 'y1', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_red', '_site_site2', 'y1', 'Y-Two'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_red', '_site_site2', 'Y-One', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_red', '_site_site2', 'Y-One', 'Y-Two'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_blue', '_site_site2', 'y1', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_blue', '_site_site2', 'y1', 'Y-Two'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_blue', '_site_site2', 'Y-One', 'y2'] },
-          locale: 'en',
-        },
-        {
-          params: { path: ['_variantId_blue', '_site_site2', 'Y-One', 'Y-Two'] },
-          locale: 'en',
-        },
-      ]);
-
       return expect(nock.isDone()).to.be.true;
     });
 

--- a/packages/core/src/site/sitepath-service.ts
+++ b/packages/core/src/site/sitepath-service.ts
@@ -238,7 +238,7 @@ export class SitePathService {
       aggregatedPaths.push(formatStaticPath(toSegments(item.path), language));
 
       const variantIds = item.route?.personalization?.variantIds?.filter(
-        (variantId) => !variantId.includes('_')
+        (variantId) => !variantId.includes('_') // exclude component A/B test
       );
 
       if (variantIds?.length) {

--- a/packages/core/src/site/sitepath-service.ts
+++ b/packages/core/src/site/sitepath-service.ts
@@ -47,9 +47,6 @@ query ${usesPersonalize ? 'PersonalizeSitemapQuery' : 'DefaultSitemapQuery'}(
         }
         results {
           path: routePath
-          route {
-            displayName
-          }
           ${
             usesPersonalize
               ? `
@@ -120,7 +117,6 @@ export interface SiteRouteQueryResult<T> {
 export type RouteListQueryResult = {
   path: string;
   route?: {
-    displayName: string;
     personalization?: {
       variantIds: string[];
     };
@@ -139,10 +135,6 @@ export interface SitePathServiceConfig
    */
   includePersonalizedRoutes?: boolean;
   /**
-   * Gets a flag indicating whether display name routing is enabled.
-   */
-  enableDisplayNameRouting?: boolean;
-  /**
    * A GraphQL Request Client Factory is a function that accepts configuration and returns an instance of a GraphQLRequestClient.
    * This factory function is used to create and configure GraphQL clients for making GraphQL API requests.
    */
@@ -157,7 +149,6 @@ export interface SitePathServiceConfig
  */
 export class SitePathService {
   private _graphQLClient: GraphQLClient;
-  private _enableDisplayNameRouting: boolean;
 
   /**
    * Creates an instance of graphQL sitemap service with the provided options
@@ -165,7 +156,6 @@ export class SitePathService {
    */
   constructor(public options: SitePathServiceConfig) {
     this._graphQLClient = this.getGraphQLClient();
-    this._enableDisplayNameRouting = options.enableDisplayNameRouting ?? false;
   }
 
   /**
@@ -235,105 +225,30 @@ export class SitePathService {
     formatStaticPath: (path: string[], language: string) => StaticPath,
     language: string
   ): Promise<StaticPath[]> {
+    const toSegments = (p: string) =>
+      decodeURI(p)
+        .replace(/^\/|\/$/g, '')
+        .split('/');
+
     const aggregatedPaths: StaticPath[] = [];
 
-    /**
-     * Build a map of the last segment of each path to its encoded display name.
-     * This is used later to substitute the final segment with a display name if available.
-     */
-    const displayNameMap = new Map<string, string>();
-    if (this._enableDisplayNameRouting) {
-      for (const item of sitePaths) {
-        if (!item || typeof item.path !== 'string') continue;
+    sitePaths.forEach((item) => {
+      if (!item) return;
 
-        const segments = item.path.replace(/^\/|\/$/g, '').split('/');
-        const lastSegment = segments[segments.length - 1];
-        const displayName = item.route?.displayName;
+      aggregatedPaths.push(formatStaticPath(toSegments(item.path), language));
 
-        if (displayName) {
-          displayNameMap.set(lastSegment, encodeURIComponent(displayName));
-        }
-      }
-    }
-
-    /**
-     * Recursively generate all path combinations using either:
-     * - The item name segment (default)
-     * - Or the display name (if available in the map)
-     *
-     * For example: if path is ['about', 'team'] and displayName for 'team' is 'Team-Page',
-     * it will generate:
-     * - ['about', 'team']
-     * - ['about', 'Team-Page']
-     * @param {string[]} segments
-     */
-    const generateCombinations = (segments: string[]): string[][] => {
-      if (!this._enableDisplayNameRouting) {
-        return [segments];
-      }
-
-      const results: string[][] = [];
-
-      const helper = (index: number, current: string[]) => {
-        if (index === segments.length) {
-          results.push([...current]);
-          return;
-        }
-
-        const segment = segments[index];
-        const display = displayNameMap.get(segment);
-
-        // Item name segment
-        current.push(segment);
-        helper(index + 1, current);
-        current.pop();
-
-        // Display name segment (if available and different)
-        if (display && display !== segment) {
-          current.push(display);
-          helper(index + 1, current);
-          current.pop();
-        }
-      };
-
-      helper(0, []);
-      return results;
-    };
-
-    /**
-     * Process each route in the result set to:
-     * - Add itemName-based and displayName-based paths
-     * - Add personalized variants (if applicable) for each of those paths
-     */
-    for (const item of sitePaths) {
-      if (!item || typeof item.path !== 'string') continue;
-
-      const itemPath = item.path.replace(/^\/|\/$/g, '');
-      const segments = itemPath ? itemPath.split('/') : [];
-
-      // Generate all display/item name path combinations
-      const allCombinations = generateCombinations(segments);
-
-      // Add plain paths to the aggregated paths list
-      for (const combination of allCombinations) {
-        aggregatedPaths.push(formatStaticPath(combination, language));
-      }
-
-      // Check for personalization variants
       const variantIds = item.route?.personalization?.variantIds?.filter(
-        (variantId) => !variantId.includes('_') // exclude component A/B test
+        (variantId) => !variantId.includes('_')
       );
 
       if (variantIds?.length) {
-        for (const variantId of variantIds) {
-          for (const combination of allCombinations) {
-            const rewritePath = getPersonalizedRewrite('/' + combination.join('/'), [variantId]);
-            const variantSegments = rewritePath.replace(/^\/|\/$/g, '').split('/');
-            aggregatedPaths.push(formatStaticPath(variantSegments, language));
-          }
-        }
+        aggregatedPaths.push(
+          ...variantIds.map((varId) =>
+            formatStaticPath(toSegments(getPersonalizedRewrite(item.path, [varId])), language)
+          )
+        );
       }
-    }
+    });
 
     return aggregatedPaths;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Enabling display name routes through a patch config removes the need to manually generate SSG paths, since our existing logic already supports both display name–based and item name–based routes.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
