### PR TITLE
[react] Send a `component:status` message during variant generation in Design Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🎉 New Features & Improvements
+
+* `[react]` Adds `component:status`events for VariantGeneration so the host can reliably track component lifecycle ([#190](https://github.com/Sitecore/content-sdk/pull/190))
+
 ## 1.1.0
 
 ### 🎉 New Features & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[react]` Add `component:status`events for VariantGeneration so the host can reliably track component lifecycle ([#190](https://github.com/Sitecore/content-sdk/pull/190))
+* `[react]` Add `component:status` events for VariantGeneration ([#190](https://github.com/Sitecore/content-sdk/pull/190))
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[react]` Adds `component:status`events for VariantGeneration so the host can reliably track component lifecycle ([#190](https://github.com/Sitecore/content-sdk/pull/190))
+* `[react]` Add `component:status`events for VariantGeneration so the host can reliably track component lifecycle ([#190](https://github.com/Sitecore/content-sdk/pull/190))
 
 ## 1.1.0
 

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import { Page, PageMode } from '@sitecore-content-sdk/core/client';
 import { LayoutServiceData } from '@sitecore-content-sdk/core/layout';
-import { fireEvent, render, waitFor, act } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { DesignLibrary } from './DesignLibrary';
 import { getTestLayoutData } from '../test-data/component-editing-data';
 import { SitecoreProvider } from './SitecoreProvider';

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -21,6 +21,10 @@ import {
   DesignLibraryMode,
 } from '@sitecore-content-sdk/core/editing';
 import { __mockDependencies } from './DesignLibrary';
+import {
+  DesignLibraryPreviewError,
+  getDesignLibraryComponentPreviewErrorEvent,
+} from '@sitecore-content-sdk/core/codegen';
 
 describe('<DesignLibrary />', () => {
   const sandbox = sinon.createSandbox();
@@ -335,53 +339,6 @@ describe('<DesignLibrary />', () => {
 
     let callbackEvent: any = null;
 
-    type PreviewPayload = {
-      name: 'component:generation:component-preview';
-      message: {
-        uid: string;
-        code: { type: 'function'; content: string };
-        styles?: unknown;
-        imports?: unknown[];
-      };
-    };
-
-    async function sendUpdateEvent(
-      input: ComponentUpdateEventArgs['details'] | string | PreviewPayload
-    ): Promise<void> {
-      let payload: unknown;
-
-      if (typeof input === 'string') {
-        payload = JSON.parse(input);
-      } else if ((input as any)?.name === 'component:generation:component-preview') {
-        payload = input;
-      } else {
-        payload = {
-          name: 'component:update',
-          details: input as ComponentUpdateEventArgs['details'],
-        };
-      }
-
-      try {
-        (window as any).postMessage(payload, '*');
-      } catch {
-        try {
-          const evt = new (window as any).MessageEvent('message', {
-            data: payload,
-            origin: window.location.origin,
-          });
-          window.dispatchEvent(evt as Event);
-        } catch {
-          const evt = document.createEvent('Event');
-          evt.initEvent('message', false, true);
-          (evt as any).data = payload;
-          (evt as any).origin = window.location.origin;
-          window.dispatchEvent(evt as any);
-        }
-      }
-
-      await Promise.resolve();
-    }
-
     beforeEach(() => {
       page = getPage(getTestLayoutData().layoutData, variantGenerationMode);
 
@@ -429,13 +386,13 @@ describe('<DesignLibrary />', () => {
       expect(rendered.baseElement.innerHTML).to.contain('Loading preview...');
     });
 
-    it('should fire component:ready event', () => {
+    it('should fire component:ready event', async () => {
       const expectedReadyMessage = getDesignLibraryStatusEvent(
         DesignLibraryStatus.READY,
         'test-content'
       );
 
-      const rendered = render(
+      const rendered = await render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary loadImportMap={defaultImportMap} />
         </SitecoreProvider>,
@@ -454,60 +411,26 @@ describe('<DesignLibrary />', () => {
     });
 
     it('should post "rendered" after a valid component preview is received', async () => {
-      const uid = 'test-content';
-
-      const sandbox = sinon.createSandbox();
-      const target: any = window.top ?? window;
-      if ((target.postMessage as any)?.restore) (target.postMessage as any).restore();
-      const postMessageSpy = sandbox.spy(target, 'postMessage');
-
-      render(
+      await render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary loadImportMap={defaultImportMap} />
         </SitecoreProvider>
       );
 
-      const previewJson = `{
-        "name": "component:generation:component-preview",
-        "message": {
-          "uid": "${uid}",
-          "code": {
-            "type": "function",
-            "content": "const Component=(props)=>React.createElement('div',{id:'test-id'},'QA Testing');\\nexports.Component=Component;"
-          },
-          "styles": { "type": "style-element", "content": "" },
-          "imports": [ { "module": "react", "export": "default", "alias": "React" } ]
-        }
-      }`;
-
-      await sendUpdateEvent(previewJson);
-
-      expect(
-        postMessageSpy
-          .getCalls()
-          .some((call) =>
-            JSON.stringify(call.args[0]).includes(
-              JSON.stringify(
-                getDesignLibraryStatusEvent(DesignLibraryStatus.RENDERED, 'test-content')
+      await waitFor(() => {
+        expect(addComponentPreviewHandlerSpy).to.have.been.called;
+        callbackEvent(null, TestComponent);
+        expect(
+          postMessageSpy
+            .getCalls()
+            .some((call) =>
+              JSON.stringify(call.args[0]).includes(
+                JSON.stringify(
+                  getDesignLibraryStatusEvent(DesignLibraryStatus.RENDERED, 'test-content')
+                )
               )
             )
-          )
-      ).to.be.true;
-
-      sandbox.restore();
-    });
-
-    it('should render error message when component fails to initialize', async () => {
-      const rendered = render(
-        <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary loadImportMap={defaultImportMap} />
-        </SitecoreProvider>,
-        { container: document.body }
-      );
-
-      await waitFor(() => {
-        callbackEvent('Error', null);
-        expect(rendered.baseElement.innerHTML).to.contain('Error during component initialization');
+        ).to.be.true;
       });
     });
 
@@ -517,7 +440,7 @@ describe('<DesignLibrary />', () => {
         new Promise((_, reject) => {
           reject(initError);
         });
-      const rendered = render(
+      await render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary loadImportMap={errorImportMap} />
         </SitecoreProvider>,
@@ -525,10 +448,21 @@ describe('<DesignLibrary />', () => {
       );
 
       await waitFor(() => {
-        expect(rendered.baseElement.innerHTML).to.contain(
-          'No dynamic import map loaded. Please check a dynamic import map function is passed into Design Library'
-        );
-        expect(consoleErrorSpy.calledWith('Error loading import map:', initError)).to.be.true;
+        expect(
+          postMessageSpy
+            .getCalls()
+            .some((call) =>
+              JSON.stringify(call.args[0]).includes(
+                JSON.stringify(
+                  getDesignLibraryComponentPreviewErrorEvent(
+                    'test-content',
+                    'Error loading import map: Error: Failed to load import map',
+                    DesignLibraryPreviewError.RenderInit
+                  )
+                )
+              )
+            )
+        ).to.be.true;
       });
     });
 
@@ -548,24 +482,8 @@ describe('<DesignLibrary />', () => {
       });
     });
 
-    it('should render error message when no rendering is found', () => {
-      // Set to empty array to simulate no rendering found
-      page.layout.sitecore.route!.placeholders['editing-componentmode-placeholder'] = [];
-
-      const rendered = render(
-        <SitecoreProvider componentMap={components} api={api} page={page}>
-          <DesignLibrary loadImportMap={defaultImportMap} />
-        </SitecoreProvider>,
-        { container: document.body }
-      );
-
-      expect(rendered.baseElement.innerHTML).to.contain(
-        'No component found in layout data. Please check your layout data.'
-      );
-    });
-
     it('should render error message when no import map is provided', async () => {
-      const rendered = render(
+      await render(
         <SitecoreProvider componentMap={components} api={api} page={page}>
           <DesignLibrary />
         </SitecoreProvider>,
@@ -573,9 +491,21 @@ describe('<DesignLibrary />', () => {
       );
 
       await waitFor(() => {
-        expect(rendered.baseElement.innerHTML).to.contain(
-          'No dynamic import map loaded. Please check a dynamic import map function is passed into Design Library'
-        );
+        expect(
+          postMessageSpy
+            .getCalls()
+            .some((call) =>
+              JSON.stringify(call.args[0]).includes(
+                JSON.stringify(
+                  getDesignLibraryComponentPreviewErrorEvent(
+                    'test-content',
+                    'No loadImportMap prop provided. Please provide a dynamic import map function for DesignLibrary.',
+                    DesignLibraryPreviewError.RenderInit
+                  )
+                )
+              )
+            )
+        ).to.be.true;
       });
     });
 

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import { Page, PageMode } from '@sitecore-content-sdk/core/client';
 import { LayoutServiceData } from '@sitecore-content-sdk/core/layout';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor, act } from '@testing-library/react';
 import { DesignLibrary } from './DesignLibrary';
 import { getTestLayoutData } from '../test-data/component-editing-data';
 import { SitecoreProvider } from './SitecoreProvider';
@@ -22,7 +22,7 @@ import {
 } from '@sitecore-content-sdk/core/editing';
 import { __mockDependencies } from './DesignLibrary';
 
-describe('<DesignLibrary />', () => {
+describe.only('<DesignLibrary />', () => {
   const sandbox = sinon.createSandbox();
   const postMessageSpy = sandbox.spy(global.window, 'postMessage');
   const consoleErrorSpy = sandbox.spy(console, 'error');
@@ -335,6 +335,53 @@ describe('<DesignLibrary />', () => {
 
     let callbackEvent: any = null;
 
+    type PreviewPayload = {
+      name: 'component:generation:component-preview';
+      message: {
+        uid: string;
+        code: { type: 'function'; content: string };
+        styles?: unknown;
+        imports?: unknown[];
+      };
+    };
+
+    async function sendUpdateEvent(
+      input: ComponentUpdateEventArgs['details'] | string | PreviewPayload
+    ): Promise<void> {
+      let payload: unknown;
+
+      if (typeof input === 'string') {
+        payload = JSON.parse(input);
+      } else if ((input as any)?.name === 'component:generation:component-preview') {
+        payload = input;
+      } else {
+        payload = {
+          name: 'component:update',
+          details: input as ComponentUpdateEventArgs['details'],
+        };
+      }
+
+      try {
+        (window as any).postMessage(payload, '*');
+      } catch {
+        try {
+          const evt = new (window as any).MessageEvent('message', {
+            data: payload,
+            origin: window.location.origin,
+          });
+          window.dispatchEvent(evt as Event);
+        } catch {
+          const evt = document.createEvent('Event');
+          evt.initEvent('message', false, true);
+          (evt as any).data = payload;
+          (evt as any).origin = window.location.origin;
+          window.dispatchEvent(evt as any);
+        }
+      }
+
+      await Promise.resolve();
+    }
+
     beforeEach(() => {
       page = getPage(getTestLayoutData().layoutData, variantGenerationMode);
 
@@ -380,6 +427,74 @@ describe('<DesignLibrary />', () => {
 
       // Check that we are in variant generation mode and rendering loading state
       expect(rendered.baseElement.innerHTML).to.contain('Loading preview...');
+    });
+
+    it('should fire component:ready event', () => {
+      const expectedReadyMessage = getDesignLibraryStatusEvent(
+        DesignLibraryStatus.READY,
+        'test-content'
+      );
+
+      const rendered = render(
+        <SitecoreProvider componentMap={components} api={api} page={page}>
+          <DesignLibrary loadImportMap={defaultImportMap} />
+        </SitecoreProvider>,
+        { container: document.body }
+      );
+
+      expect(rendered.baseElement.innerHTML).to.contain(
+        ['<main><div>Loading preview...</div></main>'].join('')
+      );
+
+      expect(
+        postMessageSpy
+          .getCalls()
+          .some((call) => JSON.stringify(call.args[0]) === JSON.stringify(expectedReadyMessage))
+      ).to.be.true;
+    });
+
+    it('should post "rendered" after a valid component preview is received', async () => {
+      const uid = 'test-content';
+
+      const sandbox = sinon.createSandbox();
+      const target: any = window.top ?? window;
+      if ((target.postMessage as any)?.restore) (target.postMessage as any).restore();
+      const postMessageSpy = sandbox.spy(target, 'postMessage');
+
+      render(
+        <SitecoreProvider componentMap={components} api={api} page={page}>
+          <DesignLibrary loadImportMap={defaultImportMap} />
+        </SitecoreProvider>
+      );
+
+      const previewJson = `{
+        "name": "component:generation:component-preview",
+        "message": {
+          "uid": "${uid}",
+          "code": {
+            "type": "function",
+            "content": "const Component=(props)=>React.createElement('div',{id:'test-id'},'QA Testing');\\nexports.Component=Component;"
+          },
+          "styles": { "type": "style-element", "content": "" },
+          "imports": [ { "module": "react", "export": "default", "alias": "React" } ]
+        }
+      }`;
+
+      await sendUpdateEvent(previewJson);
+
+      expect(
+        postMessageSpy
+          .getCalls()
+          .some((call) =>
+            JSON.stringify(call.args[0]).includes(
+              JSON.stringify(
+                getDesignLibraryStatusEvent(DesignLibraryStatus.RENDERED, 'test-content')
+              )
+            )
+          )
+      ).to.be.true;
+
+      sandbox.restore();
     });
 
     it('should render error message when component fails to initialize', async () => {

--- a/packages/react/src/components/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary.test.tsx
@@ -22,7 +22,7 @@ import {
 } from '@sitecore-content-sdk/core/editing';
 import { __mockDependencies } from './DesignLibrary';
 
-describe.only('<DesignLibrary />', () => {
+describe('<DesignLibrary />', () => {
   const sandbox = sinon.createSandbox();
   const postMessageSpy = sandbox.spy(global.window, 'postMessage');
   const consoleErrorSpy = sandbox.spy(console, 'error');

--- a/packages/react/src/components/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary.tsx
@@ -1,6 +1,6 @@
 ﻿/* eslint-disable jsdoc/require-param */
 /* eslint-disable prefer-const */
-import React, { useEffect, useMemo, useState, JSX } from 'react';
+import React, { useEffect, useMemo, useState, JSX, useRef } from 'react';
 import { Placeholder } from './Placeholder';
 import {
   ComponentFields,
@@ -168,6 +168,8 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
   const [initError, setInitError] = useState<boolean>(false);
   const [importMapError, setImportMapError] = useState<boolean>(false);
   const [Component, setComponent] = useState<DynamicComponent>(null);
+  const postedReady = useRef(false);
+  const postedRenderedForKey = useRef<number | null>(null);
 
   if (!rendering) {
     return <div>No component found in layout data. Please check your layout data.</div>;
@@ -237,6 +239,29 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
       }
     };
   }, []);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    postedReady.current = true;
+    window.top?.postMessage(
+      getDesignLibraryStatusEvent(DesignLibraryStatus.READY, rendering.uid),
+      '*'
+    );
+  }, [rendering?.uid]);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    if (initError || importMapError) return undefined;
+
+    // prevent duplicates
+    if (postedRenderedForKey.current === renderKey) return undefined;
+    postedRenderedForKey.current = renderKey;
+
+    window.top?.postMessage(
+      getDesignLibraryStatusEvent(DesignLibraryStatus.RENDERED, rendering.uid),
+      '*'
+    );
+  }, [renderKey, Component, initError, importMapError, rendering?.uid]);
 
   if (importMapError) {
     return (

--- a/packages/react/src/components/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary.tsx
@@ -1,6 +1,6 @@
 ﻿/* eslint-disable jsdoc/require-param */
 /* eslint-disable prefer-const */
-import React, { useEffect, useMemo, useState, JSX, useRef } from 'react';
+import React, { useEffect, useMemo, useState, JSX } from 'react';
 import { Placeholder } from './Placeholder';
 import {
   ComponentFields,
@@ -109,6 +109,14 @@ type ErrorBoundaryProps = {
   renderKey: number;
 };
 
+const sendErrorEvent = (uid: string, error: unknown, type: codegen.DesignLibraryPreviewError) => {
+  const errorEvent = codegen.getDesignLibraryComponentPreviewErrorEvent(uid, error, type);
+
+  console.error('Component Library: sending error event', errorEvent);
+
+  window.top.postMessage(errorEvent, '*');
+};
+
 class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
   state = {
     hasError: false,
@@ -125,15 +133,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
   }
 
   componentDidCatch(error: Error) {
-    const errorEvent = codegen.getDesignLibraryComponentPreviewErrorEvent(
-      this.props.uid,
-      error,
-      codegen.DesignLibraryPreviewError.Render
-    );
-
-    console.debug('Component Library: sending error event', errorEvent);
-
-    window.top.postMessage(errorEvent, '*');
+    sendErrorEvent(this.props.uid, error, codegen.DesignLibraryPreviewError.Render);
   }
 
   render() {
@@ -165,15 +165,7 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
   } = page;
   const rendering = route?.placeholders[EDITING_COMPONENT_PLACEHOLDER][0];
   const [renderKey, setRenderKey] = useState(0);
-  const [initError, setInitError] = useState<boolean>(false);
-  const [importMapError, setImportMapError] = useState<boolean>(false);
-  const [Component, setComponent] = useState<DynamicComponent>(null);
-  const postedReady = useRef(false);
-  const postedRenderedForKey = useRef<number | null>(null);
-
-  if (!rendering) {
-    return <div>No component found in layout data. Please check your layout data.</div>;
-  }
+  const [Component, setComponent] = useState<DynamicComponent | null>(null);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
@@ -185,31 +177,29 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
     const init = async () => {
       let importMap: codegen.ImportEntry[] = undefined;
       if (!props.loadImportMap) {
-        console.error(
-          'No loadImportMap prop provided. Please provide a dynamic import map function for DesignLibrary.'
-        );
-        setImportMapError(true);
+        const errorMessage =
+          'No loadImportMap prop provided. Please provide a dynamic import map function for DesignLibrary.';
+        sendErrorEvent(rendering.uid, errorMessage, codegen.DesignLibraryPreviewError.RenderInit);
         return;
       }
       try {
         const importMapImport = await props.loadImportMap();
         importMap = importMapImport.default;
       } catch (error) {
-        console.error('Error loading import map:', error);
-        setImportMapError(true);
+        const errorMessage = `Error loading import map: ${error}`;
+        sendErrorEvent(rendering.uid, errorMessage, codegen.DesignLibraryPreviewError.RenderInit);
         return;
       }
       // account for component being unmounted while resolving async import map
       if (cancelled) return;
 
       unsubscribe = addComponentPreviewHandler(importMap, (error, Component) => {
-        setRenderKey((key) => key + 1);
+        // Error event is already sent in the addComponentPreviewHandler
         if (error) {
-          setInitError(true);
-
           return;
         }
-        setInitError(false);
+
+        setRenderKey((key) => key + 1);
         setComponent(() => Component as DynamicComponent);
       });
 
@@ -228,6 +218,12 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
       console.debug('Component Library: sending event', componentPropsEvent);
 
       window.top.postMessage(componentPropsEvent, '*');
+
+      const readyEvent = getDesignLibraryStatusEvent(DesignLibraryStatus.READY, rendering.uid);
+
+      console.debug('Component Library: sending event', readyEvent);
+
+      window.top?.postMessage(readyEvent, '*');
     };
 
     init();
@@ -242,39 +238,15 @@ export const VariantGeneration = (props: VariantGenerationProps) => {
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
-    postedReady.current = true;
-    window.top?.postMessage(
-      getDesignLibraryStatusEvent(DesignLibraryStatus.READY, rendering.uid),
-      '*'
-    );
-  }, [rendering?.uid]);
+    // Send a rendered event only as effect of a component update command
+    if (renderKey === 0) return undefined;
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  useEffect(() => {
-    if (initError || importMapError) return undefined;
+    const renderedEvent = getDesignLibraryStatusEvent(DesignLibraryStatus.RENDERED, rendering.uid);
 
-    // prevent duplicates
-    if (postedRenderedForKey.current === renderKey) return undefined;
-    postedRenderedForKey.current = renderKey;
+    console.debug('Component Library: sending event', renderedEvent);
 
-    window.top?.postMessage(
-      getDesignLibraryStatusEvent(DesignLibraryStatus.RENDERED, rendering.uid),
-      '*'
-    );
-  }, [renderKey, Component, initError, importMapError, rendering?.uid]);
-
-  if (importMapError) {
-    return (
-      <div>
-        No dynamic import map loaded. Please check a dynamic import map function is passed into
-        Design Library
-      </div>
-    );
-  }
-
-  if (initError) {
-    return <div key={renderKey}>Error during component initialization</div>;
-  }
+    window.top?.postMessage(renderedEvent, '*');
+  }, [renderKey, rendering?.uid]);
 
   return (
     <main>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Adds `component:status` events for `VariantGeneration` so the host can reliably track component lifecycle:

 - `READY` : fired once per uid when `VariantGeneration` has initialized, loaded the import map, and registered the preview handler.

 - `RENDERED` : fired once per successful preview render (per `renderKey`) after a valid component is set

**New:** we don't render custom error messages anymore, instead they should be sent to Design Library

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
