### PR TITLE
[nextjs] Optimize editing render middleware - follow up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,12 @@ Our versioning strategy is as follows:
   - Ensure editing state is enabled in Design Library mode ([#181](https://github.com/Sitecore/content-sdk/pull/181))
 * `[core]` Ensure displayName paths are properly UTF-8 encoded. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
 * `[react]` Enhanced the Design Library cache buster format to hh-dd-mm-yyyy ([#188](https://github.com/Sitecore/content-sdk/pull/188))
-* `[nextjs]` Optimization for editing render middleware: issue an internal server request for fetching page data during editing instead of doing temporary redirect ([#195](https://github.com/Sitecore/content-sdk/pull/195))
+* `[nextjs]` Optimization for editing render middleware: issue an internal server request for fetching page data during editing instead of doing temporary redirect ([#195](https://github.com/Sitecore/content-sdk/pull/195)) ([#196](https://github.com/Sitecore/content-sdk/pull/196))
   - added new environment variable `SITECORE_INTERNAL_EDITING_HOST_URL` - the internal host URL for the Next.js application, used for server-side requests for page rendering during editing
   - added a new setting in _sitecore.config_: _sitecoreInternalEditingHostUrl_. This setting allows you to define the internal host URL explicitly, overriding the corresponding environment variable.
-  - if none of the above is set the host header of the incoming request will be used to make the internal request
+  - if none of the above is set:
+     - in XMC environment server request will be issued to `http://localhost:3000`
+     - in Vercel or Netlify scenarios, the host header of the incoming request will be used to make the internal request
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Our versioning strategy is as follows:
   - added new environment variable `SITECORE_INTERNAL_EDITING_HOST_URL` - the internal host URL for the Next.js application, used for server-side requests for page rendering during editing
   - added a new setting in _sitecore.config_: _sitecoreInternalEditingHostUrl_. This setting allows you to define the internal host URL explicitly, overriding the corresponding environment variable.
   - if none of the above is set:
-     - in XMC environment server request will be issued to `http://localhost:3000`
+     - in XM Cloud environment server request will be issued to `http://localhost:3000`
      - in Vercel or Netlify scenarios, the host header of the incoming request will be used to make the internal request
 
 ### 🐛 Bug Fixes

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -578,7 +578,7 @@ describe('EditingRenderMiddleware', () => {
     });
   });
 
-  describe('intrnal server request host resolution', () => {
+  describe('internal server request host resolution', () => {
     it('should use host header for making the internal request if config setting or env is not provided and we are not in XMC env', async () => {
       const req = mockRequest({ query });
       const reqHost = 'some-other-host';

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -74,7 +74,6 @@ const mockResponse = () => {
   res.setPreviewData = spy(() => {
     return res;
   });
-  res.redirect = spy();
   return res;
 };
 

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -534,6 +534,40 @@ describe('EditingRenderMiddleware', () => {
     expect(res.send).to.be.calledOnceWith(`<div>some html ${SERVER_PROPS_ID}</div>`);
   });
 
+  it('should respondWith 500 if rendered html empty', async () => {
+    const req = mockRequest({ query });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '' });
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(500);
+    expect(res.send).to.have.been.calledOnce;
+  });
+
+  it('should respondWith 500 if internal request fails', async () => {
+    const req = mockRequest({ query });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    sinon.stub(middleware['dataFetcher'], 'get').throws(new Error('Request failed'));
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(500);
+    expect(res.send).to.have.been.calledOnce;
+  });
+
   describe('Design Library handling', () => {
     const query = {
       mode: DesignLibraryMode.Normal,

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -425,6 +425,115 @@ describe('EditingRenderMiddleware', () => {
     );
   });
 
+  it('should issue internal request propagating allowed query parameters', async () => {
+    const protectedQuery = {} as Query;
+    protectedQuery[QUERY_PARAM_VERCEL_PROTECTION_BYPASS] = 'bypass123';
+    protectedQuery[QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE] = 'true';
+    protectedQuery['someOtherParam'] = 'shouldNotBeIncluded';
+    const req = mockRequest({ query: { ...query, ...protectedQuery } });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+
+    const handler = middleware.getHandler();
+
+    const fetcherGetStub = sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+    await handler(req, res);
+
+    const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
+    expect(fetchRequestUrl.includes(`${QUERY_PARAM_VERCEL_PROTECTION_BYPASS}=bypass123`)).to.be
+      .true;
+    expect(fetchRequestUrl.includes(`${QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE}=true`)).to.be.true;
+    expect(fetchRequestUrl.includes('someOtherParam=shouldNotBeIncluded')).to.be.false;
+  });
+
+  it('should issue intrnal request propagating allowed headers', async () => {
+    const req = mockRequest({
+      query,
+      headers: {
+        authorization: 'yes',
+        cookie: 'sc_another_cookie=12345',
+        otherHeader: 'shouldNotBeIncluded',
+      },
+    });
+
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    const fetcherGetStub = sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+    await handler(req, res);
+
+    const fetchRequestHeaders = fetcherGetStub.getCall(0).args[1]?.headers;
+
+    expect(fetchRequestHeaders).to.not.be.undefined;
+    expect(fetchRequestHeaders).to.have.property(
+      'cookie',
+      'sc_another_cookie=12345;__prerender_bypass=1122334455; Path=/; SameSite=Lax;__next_preview_data=6677889900; Path=/; SameSite=Lax'
+    );
+    expect(fetchRequestHeaders).to.have.property('authorization', 'yes');
+    expect(fetchRequestHeaders).to.not.have.property('otherHeader');
+  });
+
+  it('should return 200 if internal request successful', async () => {
+    const req = mockRequest({ query });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+    await handler(req, res);
+
+    expect(res.status).to.be.calledOnceWith(200);
+  });
+
+  it('should remove nextjs preview cookies before responding to browser', async () => {
+    const req = mockRequest({ query });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+    await handler(req, res);
+
+    expect(res.setHeader).to.have.been.calledWith('Set-Cookie', []);
+    expect(res.status).to.be.calledOnceWith(200);
+  });
+
+  it('should replace static props id in html before responding to browser', async () => {
+    const req = mockRequest({ query });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    sinon.stub(middleware['dataFetcher'], 'get').resolves({
+      status: 200,
+      statusText: 'success',
+      data: `<div>some html ${STATIC_PROPS_ID}</div>`,
+    });
+
+    await handler(req, res);
+
+    expect(res.status).to.be.calledOnceWith(200);
+    expect(res.send).to.be.calledOnceWith(`<div>some html ${SERVER_PROPS_ID}</div>`);
+  });
+
   describe('Design Library handling', () => {
     const query = {
       mode: DesignLibraryMode.Normal,
@@ -667,117 +776,6 @@ describe('EditingRenderMiddleware', () => {
       const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
       expect(fetchRequestUrl.includes(reqHostConfig)).to.be.true;
       delete process.env.SITECORE_INTERNAL_EDITING_HOST_URL;
-    });
-  });
-
-  describe('internal server request', () => {
-    it('should issue internal request propagating allowed query parameters', async () => {
-      const protectedQuery = {} as Query;
-      protectedQuery[QUERY_PARAM_VERCEL_PROTECTION_BYPASS] = 'bypass123';
-      protectedQuery[QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE] = 'true';
-      protectedQuery['someOtherParam'] = 'shouldNotBeIncluded';
-      const req = mockRequest({ query: { ...query, ...protectedQuery } });
-      const res = mockResponse();
-
-      const middleware = new EditingRenderMiddleware();
-
-      const handler = middleware.getHandler();
-
-      const fetcherGetStub = sinon
-        .stub(middleware['dataFetcher'], 'get')
-        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
-
-      await handler(req, res);
-
-      const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
-      expect(fetchRequestUrl.includes(`${QUERY_PARAM_VERCEL_PROTECTION_BYPASS}=bypass123`)).to.be
-        .true;
-      expect(fetchRequestUrl.includes(`${QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE}=true`)).to.be.true;
-      expect(fetchRequestUrl.includes('someOtherParam=shouldNotBeIncluded')).to.be.false;
-    });
-
-    it('should issue intrnal request propagating allowed headers', async () => {
-      const req = mockRequest({
-        query,
-        headers: {
-          authorization: 'yes',
-          cookie: 'sc_another_cookie=12345',
-          otherHeader: 'shouldNotBeIncluded',
-        },
-      });
-
-      const res = mockResponse();
-
-      const middleware = new EditingRenderMiddleware();
-      const handler = middleware.getHandler();
-
-      const fetcherGetStub = sinon
-        .stub(middleware['dataFetcher'], 'get')
-        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
-
-      await handler(req, res);
-
-      const fetchRequestHeaders = fetcherGetStub.getCall(0).args[1]?.headers;
-
-      expect(fetchRequestHeaders).to.not.be.undefined;
-      expect(fetchRequestHeaders).to.have.property(
-        'cookie',
-        'sc_another_cookie=12345;__prerender_bypass=1122334455; Path=/; SameSite=Lax;__next_preview_data=6677889900; Path=/; SameSite=Lax'
-      );
-      expect(fetchRequestHeaders).to.have.property('authorization', 'yes');
-      expect(fetchRequestHeaders).to.not.have.property('otherHeader');
-    });
-
-    it('should return 200 if internal request successful', async () => {
-      const req = mockRequest({ query });
-      const res = mockResponse();
-
-      const middleware = new EditingRenderMiddleware();
-      const handler = middleware.getHandler();
-
-      sinon
-        .stub(middleware['dataFetcher'], 'get')
-        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
-
-      await handler(req, res);
-
-      expect(res.status).to.be.calledOnceWith(200);
-    });
-
-    it('should remove nextjs preview cookies before responding to browser', async () => {
-      const req = mockRequest({ query });
-      const res = mockResponse();
-
-      const middleware = new EditingRenderMiddleware();
-      const handler = middleware.getHandler();
-
-      sinon
-        .stub(middleware['dataFetcher'], 'get')
-        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
-
-      await handler(req, res);
-
-      expect(res.setHeader).to.have.been.calledWith('Set-Cookie', []);
-      expect(res.status).to.be.calledOnceWith(200);
-    });
-
-    it('should replace static props id in html before responding to browser', async () => {
-      const req = mockRequest({ query });
-      const res = mockResponse();
-
-      const middleware = new EditingRenderMiddleware();
-      const handler = middleware.getHandler();
-
-      sinon.stub(middleware['dataFetcher'], 'get').resolves({
-        status: 200,
-        statusText: 'success',
-        data: `<div>some html ${STATIC_PROPS_ID}</div>`,
-      });
-
-      await handler(req, res);
-
-      expect(res.status).to.be.calledOnceWith(200);
-      expect(res.send).to.be.calledOnceWith(`<div>some html ${SERVER_PROPS_ID}</div>`);
     });
   });
 });

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect, use } from 'chai';
 import { NextApiResponse } from 'next';
+import { STATIC_PROPS_ID, SERVER_PROPS_ID } from 'next/constants';
 import {
   EDITING_ALLOWED_ORIGINS,
   QUERY_PARAM_EDITING_SECRET,
@@ -13,6 +14,11 @@ import {
 import { EditingRenderMiddleware, EditingNextApiRequest } from './editing-render-middleware';
 import { spy } from 'sinon';
 import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import {
+  QUERY_PARAM_VERCEL_PROTECTION_BYPASS,
+  QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE,
+} from './constants';
 
 use(sinonChai);
 
@@ -207,6 +213,10 @@ describe('EditingRenderMiddleware', () => {
     const middleware = new EditingRenderMiddleware();
     const handler = middleware.getHandler();
 
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
     await handler(req, res);
 
     expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({
@@ -219,8 +229,8 @@ describe('EditingRenderMiddleware', () => {
       layoutKind: 'shared',
     });
 
-    expect(res.redirect).to.have.been.calledOnce;
-    expect(res.redirect).to.have.been.calledWith('/styleguide');
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith('<div>some html</div>');
     expect(res.setHeader).to.have.been.calledWith(
       'Content-Security-Policy',
       `frame-ancestors 'self' https://allowed.com ${EDITING_ALLOWED_ORIGINS.join(' ')}`
@@ -243,6 +253,10 @@ describe('EditingRenderMiddleware', () => {
 
     const middleware = new EditingRenderMiddleware();
     const handler = middleware.getHandler();
+
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
 
     await handler(req, res);
 
@@ -272,6 +286,10 @@ describe('EditingRenderMiddleware', () => {
     const middleware = new EditingRenderMiddleware();
     const handler = middleware.getHandler();
 
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
     await handler(req, res);
 
     expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({
@@ -284,8 +302,9 @@ describe('EditingRenderMiddleware', () => {
       layoutKind: undefined,
     });
 
-    expect(res.redirect).to.have.been.calledOnce;
-    expect(res.redirect).to.have.been.calledWith('/styleguide');
+    expect(res.status).to.be.calledOnceWith(200);
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith('<div>some html</div>');
     expect(res.setHeader).to.have.been.calledWith(
       'Content-Security-Policy',
       `frame-ancestors 'self' https://allowed.com ${EDITING_ALLOWED_ORIGINS.join(' ')}`
@@ -304,6 +323,10 @@ describe('EditingRenderMiddleware', () => {
 
     const handler = middleware.getHandler();
 
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
     await handler(req, res);
 
     expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({
@@ -316,8 +339,9 @@ describe('EditingRenderMiddleware', () => {
       layoutKind: 'shared',
     });
 
-    expect(res.redirect).to.have.been.calledOnce;
-    expect(res.redirect).to.have.been.calledWith('/custom/path/styleguide');
+    expect(res.status).to.be.calledOnceWith(200);
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith('<div>some html</div>');
   });
 
   it('should handle request with special characters in route', async () => {
@@ -339,6 +363,10 @@ describe('EditingRenderMiddleware', () => {
     const middleware = new EditingRenderMiddleware();
     const handler = middleware.getHandler();
 
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
     await handler(req, res);
 
     expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({
@@ -351,8 +379,8 @@ describe('EditingRenderMiddleware', () => {
       layoutKind: 'shared',
     });
 
-    expect(res.redirect).to.have.been.calledOnce;
-    expect(res.redirect).to.have.been.calledWith('/%C3%85bout');
+    expect(res.status).to.be.calledOnceWith(200);
+    expect(res.send).to.have.been.calledOnceWith('<div>some html</div>');
     expect(res.setHeader).to.have.been.calledWith(
       'Content-Security-Policy',
       `frame-ancestors 'self' https://allowed.com ${EDITING_ALLOWED_ORIGINS.join(' ')}`
@@ -376,21 +404,6 @@ describe('EditingRenderMiddleware', () => {
     });
   });
 
-  it('should modify the Set-Cookie header', async () => {
-    const req = mockRequest({ query });
-    const res = mockResponse();
-
-    const middleware = new EditingRenderMiddleware();
-    const handler = middleware.getHandler();
-
-    await handler(req, res);
-
-    expect(res.setHeader).to.have.been.calledWith('Set-Cookie', [
-      '__prerender_bypass=1122334455; Path=/; SameSite=None; Secure',
-      '__next_preview_data=6677889900; Path=/; SameSite=None; Secure',
-    ]);
-  });
-
   it('should set allowed origins when multiple allowed origins are provided in env variable', async () => {
     process.env.JSS_ALLOWED_ORIGINS = 'https://allowed.com,https://anotherallowed.com';
     const req = mockRequest({ query });
@@ -398,6 +411,10 @@ describe('EditingRenderMiddleware', () => {
 
     const middleware = new EditingRenderMiddleware();
     const handler = middleware.getHandler();
+
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
 
     await handler(req, res);
 
@@ -430,6 +447,10 @@ describe('EditingRenderMiddleware', () => {
       const middleware = new EditingRenderMiddleware();
       const handler = middleware.getHandler();
 
+      sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
       await handler(req, res);
 
       expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({
@@ -443,7 +464,8 @@ describe('EditingRenderMiddleware', () => {
         version: query.sc_version,
       });
 
-      expect(res.redirect).to.have.been.calledOnce;
+      expect(res.status).to.be.calledOnceWith(200);
+      expect(res.send).to.have.been.calledOnceWith('<div>some html</div>');
       expect(res.setHeader).to.have.been.calledWith(
         'Content-Security-Policy',
         `frame-ancestors 'self' https://allowed.com ${EDITING_ALLOWED_ORIGINS.join(' ')}`
@@ -456,6 +478,10 @@ describe('EditingRenderMiddleware', () => {
 
       const middleware = new EditingRenderMiddleware();
       const handler = middleware.getHandler();
+
+      sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
 
       await handler(req, res);
 
@@ -470,7 +496,8 @@ describe('EditingRenderMiddleware', () => {
         version: query.sc_version,
       });
 
-      expect(res.redirect).to.have.been.calledOnce;
+      expect(res.status).to.be.calledOnceWith(200);
+      expect(res.send).to.have.been.calledOnceWith('<div>some html</div>');
       expect(res.setHeader).to.have.been.calledWith(
         'Content-Security-Policy',
         `frame-ancestors 'self' https://allowed.com ${EDITING_ALLOWED_ORIGINS.join(' ')}`
@@ -517,6 +544,10 @@ describe('EditingRenderMiddleware', () => {
       const middleware = new EditingRenderMiddleware();
       const handler = middleware.getHandler();
 
+      sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
       await handler(req, res);
 
       expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({
@@ -535,18 +566,219 @@ describe('EditingRenderMiddleware', () => {
         'GET, POST, OPTIONS, DELETE, PUT, PATCH'
       );
       expect(res.setHeader).to.have.been.calledWith('Set-Cookie', [
-        '__prerender_bypass=1122334455; Path=/; SameSite=None; Secure',
-        '__next_preview_data=6677889900; Path=/; SameSite=None; Secure',
         'sc_site=website; Path=/; HttpOnly; SameSite=None; Secure',
         'sc_preview=true; Path=/; HttpOnly; SameSite=None; Secure',
       ]);
 
-      expect(res.redirect).to.have.been.calledOnce;
-      expect(res.redirect).to.have.been.calledWith('/styleguide');
+      expect(res.status).to.be.calledOnceWith(200);
+      expect(res.send).to.have.been.calledOnceWith('<div>some html</div>');
       expect(res.setHeader).to.have.been.calledWith(
         'Content-Security-Policy',
         `frame-ancestors 'self' https://allowed.com ${EDITING_ALLOWED_ORIGINS.join(' ')}`
       );
+    });
+  });
+
+  describe('intrnal server request host resolution', () => {
+    it('should use host header for making the internal request if config setting or env is not provided and we are not in XMC env', async () => {
+      const req = mockRequest({ query });
+      const reqHost = 'some-other-host';
+      req.headers['host'] = reqHost;
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+
+      const handler = middleware.getHandler();
+
+      const fetcherGetStub = sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+      await handler(req, res);
+
+      const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
+      expect(fetchRequestUrl.includes(reqHost)).to.be.true;
+    });
+
+    it('should use http://localhost:3000 for making the internal request if config setting or env is not provided and we are in XMC', async () => {
+      process.env.SITECORE = 'yes';
+      const req = mockRequest({ query });
+      const expectedHost = 'http://localhost:3000';
+      const reqHost = 'some-other-host';
+      req.headers['host'] = reqHost;
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+
+      const handler = middleware.getHandler();
+
+      const fetcherGetStub = sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+      await handler(req, res);
+
+      const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
+      expect(fetchRequestUrl.includes(expectedHost)).to.be.true;
+      delete process.env.SITECORE_INTERNAL_EDITING_HOST_URL;
+    });
+
+    it('should use internal editing url from env variable if provided', async () => {
+      const reqHostEnv = 'http://custom-internal-host-env';
+      process.env.SITECORE_INTERNAL_EDITING_HOST_URL = reqHostEnv;
+
+      const req = mockRequest({ query });
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+
+      const handler = middleware.getHandler();
+
+      const fetcherGetStub = sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+      await handler(req, res);
+
+      const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
+      expect(fetchRequestUrl.includes(reqHostEnv)).to.be.true;
+      delete process.env.SITECORE_INTERNAL_EDITING_HOST_URL;
+    });
+
+    it('should use internal editing url from config if provided', async () => {
+      const reqHostConfig = 'http://custom-internal-host-config';
+      const reqHostEnv = 'http://custom-internal-host-env';
+      process.env.SITECORE_INTERNAL_EDITING_HOST_URL = reqHostEnv;
+
+      const req = mockRequest({ query });
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware({
+        sitecoreInternalEditingHostUrl: reqHostConfig,
+      });
+
+      const handler = middleware.getHandler();
+
+      const fetcherGetStub = sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+      await handler(req, res);
+
+      const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
+      expect(fetchRequestUrl.includes(reqHostConfig)).to.be.true;
+      delete process.env.SITECORE_INTERNAL_EDITING_HOST_URL;
+    });
+  });
+
+  describe('internal server request', () => {
+    it('should issue internal request propagating allowed query parameters', async () => {
+      const protectedQuery = {} as Query;
+      protectedQuery[QUERY_PARAM_VERCEL_PROTECTION_BYPASS] = 'bypass123';
+      protectedQuery[QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE] = 'true';
+      protectedQuery['someOtherParam'] = 'shouldNotBeIncluded';
+      const req = mockRequest({ query: { ...query, ...protectedQuery } });
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+
+      const handler = middleware.getHandler();
+
+      const fetcherGetStub = sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+      await handler(req, res);
+
+      const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
+      expect(fetchRequestUrl.includes(`${QUERY_PARAM_VERCEL_PROTECTION_BYPASS}=bypass123`)).to.be
+        .true;
+      expect(fetchRequestUrl.includes(`${QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE}=true`)).to.be.true;
+      expect(fetchRequestUrl.includes('someOtherParam=shouldNotBeIncluded')).to.be.false;
+    });
+
+    it('should issue intrnal request propagating allowed headers', async () => {
+      const req = mockRequest({
+        query,
+        headers: {
+          authorization: 'yes',
+          cookie: 'sc_another_cookie=12345',
+          otherHeader: 'shouldNotBeIncluded',
+        },
+      });
+
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+      const handler = middleware.getHandler();
+
+      const fetcherGetStub = sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+      await handler(req, res);
+
+      const fetchRequestHeaders = fetcherGetStub.getCall(0).args[1]?.headers;
+
+      expect(fetchRequestHeaders).to.not.be.undefined;
+      expect(fetchRequestHeaders).to.have.property(
+        'cookie',
+        'sc_another_cookie=12345;__prerender_bypass=1122334455; Path=/; SameSite=Lax;__next_preview_data=6677889900; Path=/; SameSite=Lax'
+      );
+      expect(fetchRequestHeaders).to.have.property('authorization', 'yes');
+      expect(fetchRequestHeaders).to.not.have.property('otherHeader');
+    });
+
+    it('should return 200 if internal request successful', async () => {
+      const req = mockRequest({ query });
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+      const handler = middleware.getHandler();
+
+      sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+      await handler(req, res);
+
+      expect(res.status).to.be.calledOnceWith(200);
+    });
+
+    it('should remove nextjs preview cookies before responding to browser', async () => {
+      const req = mockRequest({ query });
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+      const handler = middleware.getHandler();
+
+      sinon
+        .stub(middleware['dataFetcher'], 'get')
+        .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+      await handler(req, res);
+
+      expect(res.setHeader).to.have.been.calledWith('Set-Cookie', []);
+      expect(res.status).to.be.calledOnceWith(200);
+    });
+
+    it('should replace static props id in html before responding to browser', async () => {
+      const req = mockRequest({ query });
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+      const handler = middleware.getHandler();
+
+      sinon.stub(middleware['dataFetcher'], 'get').resolves({
+        status: 200,
+        statusText: 'success',
+        data: `<div>some html ${STATIC_PROPS_ID}</div>`,
+      });
+
+      await handler(req, res);
+
+      expect(res.status).to.be.calledOnceWith(200);
+      expect(res.send).to.be.calledOnceWith(`<div>some html ${SERVER_PROPS_ID}</div>`);
     });
   });
 });

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -620,7 +620,7 @@ describe('EditingRenderMiddleware', () => {
 
       const fetchRequestUrl = fetcherGetStub.getCall(0).args[0];
       expect(fetchRequestUrl.includes(expectedHost)).to.be.true;
-      delete process.env.SITECORE_INTERNAL_EDITING_HOST_URL;
+      delete process.env.SITECORE;
     });
 
     it('should use internal editing url from env variable if provided', async () => {

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -273,57 +273,72 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
     }
     requestUrl.searchParams.append('timestamp', Date.now().toString());
 
-    debug.editing('fetching page route for %s', query.route);
+    try {
+      debug.editing('fetching page route for %s', query.route);
 
-    const pageRes = await this.dataFetcher
-      .get<string>(requestUrl.toString(), {
-        credentials: 'include',
-        headers: propagatedHeaders,
-      })
-      .catch((err) => {
-        // We need to handle not found error provided by Vercel
-        // for `fallback: false` pages
-        if (err.response.status === 404) {
-          return err.response;
-        }
+      const pageRes = await this.dataFetcher
+        .get<string>(requestUrl.toString(), {
+          credentials: 'include',
+          headers: propagatedHeaders,
+        })
+        .catch((err) => {
+          // We need to handle not found error provided by Vercel
+          // for `fallback: false` pages
+          if (err.response.status === 404) {
+            return err.response;
+          }
 
-        throw err;
+          throw err;
+        });
+
+      let html = pageRes.data;
+      if (!html || html.length === 0) {
+        throw new Error(`Failed to render html for ${query.route}`);
+      }
+
+      // replace phkey attribute with key attribute so that newly added renderings
+      // show correct placeholders, so save and refresh won't be needed after adding each rendering
+      html = html.replace(new RegExp('phkey', 'g'), 'key');
+
+      // When SSG, Next will attempt to perform a router.replace on the client-side to inject the query string parms
+      // to the router state. See https://github.com/vercel/next.js/blob/v10.0.3/packages/next/client/index.tsx#L169.
+      // However, this doesn't really work since at this point we're in the editor and the location.search has nothing
+      // to do with the Next route/page we've rendered. Beyond the extraneous request, this can result in a 404 with
+      // certain route configurations (e.g. multiple catch-all routes).
+      // The following line will trick it into thinking we're SSR, thus avoiding any router.replace.
+      html = html.replace(STATIC_PROPS_ID, SERVER_PROPS_ID);
+
+      // remove preview cookies to not leak them to the browser
+      const setCookieHeader = res.getHeader('Set-Cookie');
+      if (setCookieHeader && Array.isArray(setCookieHeader)) {
+        // Filter out Next.js preview cookies
+        const filteredCookies = setCookieHeader.filter(
+          (cookie: string) =>
+            !/^__next_preview_data=/.test(cookie) && !/^__prerender_bypass=/.test(cookie)
+        );
+
+        res.setHeader('Set-Cookie', filteredCookies);
+      }
+
+      debug.editing('editing render middleware end in %dms: %o', Date.now() - startTimestamp, {
+        status: 200,
+        route,
       });
 
-    let html = pageRes.data;
-    if (!html || html.length === 0) {
-      throw new Error(`Failed to render html for ${query.route}`);
+      res.status(200).send(html);
+    } catch (err) {
+      const error = err as Record<string, unknown>;
+
+      console.error(error);
+
+      if (error.response) {
+        console.info(
+          // eslint-disable-next-line quotes
+          "Hint: for non-standard server or Next.js route configurations, you may need to override 'resolvePageUrl' or set the 'sitecoreInternalEditingHostUrl' (or SITECORE_INTERNAL_EDITING_HOST_URL env variable) available on the 'EditingRenderMiddleware' config."
+        );
+      }
+
+      res.status(500).send(`<html><body>${error}</body></html>`);
     }
-
-    // replace phkey attribute with key attribute so that newly added renderings
-    // show correct placeholders, so save and refresh won't be needed after adding each rendering
-    html = html.replace(new RegExp('phkey', 'g'), 'key');
-
-    // When SSG, Next will attempt to perform a router.replace on the client-side to inject the query string parms
-    // to the router state. See https://github.com/vercel/next.js/blob/v10.0.3/packages/next/client/index.tsx#L169.
-    // However, this doesn't really work since at this point we're in the editor and the location.search has nothing
-    // to do with the Next route/page we've rendered. Beyond the extraneous request, this can result in a 404 with
-    // certain route configurations (e.g. multiple catch-all routes).
-    // The following line will trick it into thinking we're SSR, thus avoiding any router.replace.
-    html = html.replace(STATIC_PROPS_ID, SERVER_PROPS_ID);
-
-    // remove preview cookies to not leak them to the browser
-    const setCookieHeader = res.getHeader('Set-Cookie');
-    if (setCookieHeader && Array.isArray(setCookieHeader)) {
-      // Filter out Next.js preview cookies
-      const filteredCookies = setCookieHeader.filter(
-        (cookie: string) =>
-          !/^__next_preview_data=/.test(cookie) && !/^__prerender_bypass=/.test(cookie)
-      );
-
-      res.setHeader('Set-Cookie', filteredCookies);
-    }
-
-    debug.editing('editing render middleware end in %dms: %o', Date.now() - startTimestamp, {
-      status: 200,
-      route,
-    });
-
-    res.status(200).send(html);
   };
 }

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -109,9 +109,13 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
       return internalHostUrl;
     }
 
+    // in xmc deployment we always use localhost:3000
+    if (process.env.SITECORE !== undefined) {
+      return 'http://localhost:3000';
+    }
+
     // to preserve auth headers, use https if we're in our 3 main hosting options
-    const useHttps =
-      (process.env.VERCEL || process.env.SITECORE || process.env.NETLIFY) !== undefined;
+    const useHttps = (process.env.VERCEL || process.env.NETLIFY) !== undefined;
     // use https for requests with auth but also support unsecured http rendering hosts
     return `${useHttps ? 'https' : 'http'}://${req.headers.host}`;
   };

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -230,38 +230,12 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
       );
     }
 
-    // Cookies with the SameSite=Lax policy set by Next.js setPreviewData function causes CORS issue
-    // when Next.js preview mode is activated, resulting the page to render in normal mode instead.
-    // By replacing it with "SameSite=None; Secure", we ensure cookies are correctly sent with
-    // cross-origin requests, allowing the page to be editable. This change should be reverted
-    // once vercel addresses this open issue: https://github.com/vercel/next.js/issues/49927
-    const setCookieHeader = res.getHeader('Set-Cookie');
+    // Set Preview mode identifier cookie, if the page is rendered in Sitecore Preview mode
+    if (mode === LayoutServicePageState.Preview) {
+      const previewSite = `${SITE_KEY}=${query.sc_site}; Path=/; HttpOnly; SameSite=None; Secure`;
+      const previewCookie = `${PREVIEW_KEY}=true; Path=/; HttpOnly; SameSite=None; Secure`;
 
-    if (setCookieHeader && Array.isArray(setCookieHeader)) {
-      const modifiedCookies = setCookieHeader.map((cookie) => {
-        const cookieIdentifiers: { [key: string]: RegExp } = {
-          __prerender_bypass: /^__prerender_bypass=/,
-          __next_preview_data: /^__next_preview_data=/,
-        };
-
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-        for (const [_, regex] of Object.entries(cookieIdentifiers)) {
-          if (cookie.match(regex)) {
-            return cookie.replace(/SameSite=Lax/, 'SameSite=None; Secure');
-          }
-        }
-        return cookie;
-      });
-
-      // Set Preview mode identifier cookie, if the page is rendered in Sitecore Preview mode
-      if (mode === LayoutServicePageState.Preview) {
-        const previewSite = `${SITE_KEY}=${query.sc_site}; Path=/; HttpOnly; SameSite=None; Secure`;
-        const previewCookie = `${PREVIEW_KEY}=true; Path=/; HttpOnly; SameSite=None; Secure`;
-
-        modifiedCookies.push(previewSite, previewCookie);
-      }
-
-      res.setHeader('Set-Cookie', modifiedCookies);
+      res.setHeader('Set-Cookie', [previewSite, previewCookie]);
     }
 
     // Restrict the page to be rendered only within the allowed origins
@@ -294,73 +268,57 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
     }
     requestUrl.searchParams.append('timestamp', Date.now().toString());
 
-    try {
-      debug.editing('fetching page route for %s', query.route);
+    debug.editing('fetching page route for %s', query.route);
 
-      const pageRes = await this.dataFetcher
-        .get<string>(requestUrl.toString(), {
-          credentials: 'include',
-          headers: propagatedHeaders,
-        })
-        .catch((err) => {
-          // We need to handle not found error provided by Vercel
-          // for `fallback: false` pages
-          if (err.response.status === 404) {
-            return err.response;
-          }
+    const pageRes = await this.dataFetcher
+      .get<string>(requestUrl.toString(), {
+        credentials: 'include',
+        headers: propagatedHeaders,
+      })
+      .catch((err) => {
+        // We need to handle not found error provided by Vercel
+        // for `fallback: false` pages
+        if (err.response.status === 404) {
+          return err.response;
+        }
 
-          throw err;
-        });
-
-      let html = pageRes.data;
-      if (!html || html.length === 0) {
-        throw new Error(`Failed to render html for ${query.route}`);
-      }
-
-      // replace phkey attribute with key attribute so that newly added renderings
-      // show correct placeholders, so save and refresh won't be needed after adding each rendering
-      html = html.replace(new RegExp('phkey', 'g'), 'key');
-
-      // When SSG, Next will attempt to perform a router.replace on the client-side to inject the query string parms
-      // to the router state. See https://github.com/vercel/next.js/blob/v10.0.3/packages/next/client/index.tsx#L169.
-      // However, this doesn't really work since at this point we're in the editor and the location.search has nothing
-      // to do with the Next route/page we've rendered. Beyond the extraneous request, this can result in a 404 with
-      // certain route configurations (e.g. multiple catch-all routes).
-      // The following line will trick it into thinking we're SSR, thus avoiding any router.replace.
-      html = html.replace(STATIC_PROPS_ID, SERVER_PROPS_ID);
-
-      // remove preview cookies to not leak them to the browser
-      const setCookieHeader = res.getHeader('Set-Cookie');
-      if (setCookieHeader && Array.isArray(setCookieHeader)) {
-        // Filter out Next.js preview cookies
-        const filteredCookies = setCookieHeader.filter(
-          (cookie: string) =>
-            !/^__next_preview_data=/.test(cookie) && !/^__prerender_bypass=/.test(cookie)
-        );
-
-        res.setHeader('Set-Cookie', filteredCookies);
-      }
-
-      debug.editing('editing render middleware end in %dms: %o', Date.now() - startTimestamp, {
-        status: 200,
-        route,
+        throw err;
       });
 
-      res.status(200).send(html);
-    } catch (err) {
-      debug.editing('error fetching page route %s: %o', requestUrl, err);
-      debug.editing('falling back to redirect method... ');
+    let html = pageRes.data;
+    if (!html || html.length === 0) {
+      throw new Error(`Failed to render html for ${query.route}`);
+    }
 
-      debug.editing(
-        'editing render middleware end in %dms: redirect %o',
-        Date.now() - startTimestamp,
-        {
-          status: 307,
-          route,
-        }
+    // replace phkey attribute with key attribute so that newly added renderings
+    // show correct placeholders, so save and refresh won't be needed after adding each rendering
+    html = html.replace(new RegExp('phkey', 'g'), 'key');
+
+    // When SSG, Next will attempt to perform a router.replace on the client-side to inject the query string parms
+    // to the router state. See https://github.com/vercel/next.js/blob/v10.0.3/packages/next/client/index.tsx#L169.
+    // However, this doesn't really work since at this point we're in the editor and the location.search has nothing
+    // to do with the Next route/page we've rendered. Beyond the extraneous request, this can result in a 404 with
+    // certain route configurations (e.g. multiple catch-all routes).
+    // The following line will trick it into thinking we're SSR, thus avoiding any router.replace.
+    html = html.replace(STATIC_PROPS_ID, SERVER_PROPS_ID);
+
+    // remove preview cookies to not leak them to the browser
+    const setCookieHeader = res.getHeader('Set-Cookie');
+    if (setCookieHeader && Array.isArray(setCookieHeader)) {
+      // Filter out Next.js preview cookies
+      const filteredCookies = setCookieHeader.filter(
+        (cookie: string) =>
+          !/^__next_preview_data=/.test(cookie) && !/^__prerender_bypass=/.test(cookie)
       );
 
-      res.redirect(route);
+      res.setHeader('Set-Cookie', filteredCookies);
     }
+
+    debug.editing('editing render middleware end in %dms: %o', Date.now() - startTimestamp, {
+      status: 200,
+      route,
+    });
+
+    res.status(200).send(html);
   };
 }

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -93,7 +93,7 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
   }
 
   /**
-   * Server URL resolution. Use config.sitecoreInternalEditingHostUrl if provided, else SITECORE_INTERNAL_EDITING_HOST_URL if provided, otherwise use host header
+   * Server URL resolution. Use config.sitecoreInternalEditingHostUrl if provided, else SITECORE_INTERNAL_EDITING_HOST_URL if provided, otherwise use 'http://localhost:3000' for XMC deployments, or host header in all other cases.
    * Note we use https protocol on Vercel due to serverless function architecture.
    * In all other scenarios, including localhost (with or without a proxy e.g. ngrok)
    * and within a nodejs container, http protocol should be used.
@@ -110,7 +110,7 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
     }
 
     // in xmc deployment we always use localhost:3000
-    if (process.env.SITECORE !== undefined) {
+    if (process.env.SITECORE) {
       return 'http://localhost:3000';
     }
 

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -93,7 +93,12 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
   }
 
   /**
-   * Server URL resolution. Use config.sitecoreInternalEditingHostUrl if provided, else SITECORE_INTERNAL_EDITING_HOST_URL if provided, otherwise use 'http://localhost:3000' for XMC deployments, or host header in all other cases.
+   * Server URL Resolution order (highest to lowest priority):
+   * 1. `config.sitecoreInternalEditingHostUrl` (explicitly set in config)
+   * 2. Environment variable `SITECORE_INTERNAL_EDITING_HOST_URL`
+   * 3. Fallbacks:
+   *    - For XM Cloud deployments → `'http://localhost:3000'`
+   *    - For all other cases → use the request `Host` header
    * Note we use https protocol on Vercel due to serverless function architecture.
    * In all other scenarios, including localhost (with or without a proxy e.g. ngrok)
    * and within a nodejs container, http protocol should be used.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is a follow up to https://github.com/Sitecore/content-sdk/pull/195 - Optimize editing render middleware and it:
- adds default fallback for server side request host to `http://localhost:3000` when we are in XMC environment
- removes the fallback to former approach with returning temporary redirect
- adds unit tests

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
