### PR TITLE
[Next.js] Support component-level data fetching in 404/500 pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Our versioning strategy is as follows:
 ## Unreleased
 
 ### 🎉 New Features & Improvements
+
 * Next.js App Router support:
   * Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
   * Base template ([#191](https://github.com/Sitecore/content-sdk/pull/191))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ Our versioning strategy is as follows:
 ## Unreleased
 
 ### 🎉 New Features & Improvements
-
 * Next.js App Router support:
   * Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
   * Base template ([#191](https://github.com/Sitecore/content-sdk/pull/191))
 * `[react]` Add `component:status` events for VariantGeneration ([#190](https://github.com/Sitecore/content-sdk/pull/190))
+* `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ Our versioning strategy is as follows:
   * Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
   * Base template ([#191](https://github.com/Sitecore/content-sdk/pull/191))
 * `[react]` Add `component:status` events for VariantGeneration ([#190](https://github.com/Sitecore/content-sdk/pull/190))
-* `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
 
 ## 1.1.0
 
 ### 🎉 New Features & Improvements
 
+* `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
 * Migration from ESlint 8 -> ESLint 9 and introduction of the new Flat Config file ([#176](https://github.com/Sitecore/content-sdk/pull/176))
 * Code generation for Design Library enablers:
   - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157))([#167](https://github.com/Sitecore/content-sdk/pull/167))([#170](https://github.com/Sitecore/content-sdk/pull/170))([#171](https://github.com/Sitecore/content-sdk/pull/171))([#175](https://github.com/Sitecore/content-sdk/pull/175))([#177](https://github.com/Sitecore/content-sdk/pull/177))([#187](https://github.com/Sitecore/content-sdk/pull/187))

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/Providers.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/Providers.tsx
@@ -1,0 +1,28 @@
+import {
+  ComponentPropsCollection,
+  ComponentPropsContext,
+  Page,
+  SitecoreProvider,
+} from '@sitecore-content-sdk/nextjs';
+import components from '.sitecore/component-map';
+import scConfig from 'sitecore.config';
+
+const Providers = ({
+  children,
+  componentProps,
+  page,
+}: {
+  children: React.ReactNode;
+  componentProps?: ComponentPropsCollection;
+  page: Page;
+}) => {
+  return (
+    <ComponentPropsContext value={componentProps || {}}>
+      <SitecoreProvider componentMap={components} api={scConfig.api} page={page}>
+        {children}
+      </SitecoreProvider>
+    </ComponentPropsContext>
+  );
+};
+
+export default Providers;

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/500.tsx
@@ -1,11 +1,12 @@
-﻿import Head from 'next/head';
-import { SitecoreProvider, SitecorePageProps, Page, ErrorPage } from '@sitecore-content-sdk/nextjs';
-import Layout from 'src/Layout';
+﻿import { JSX } from 'react';
 import { GetStaticProps } from 'next';
+import Head from 'next/head';
+import { SitecorePageProps, ErrorPage } from '@sitecore-content-sdk/nextjs';
+import Layout from 'src/Layout';
 import scConfig from 'sitecore.config';
 import client from 'lib/sitecore-client';
 import components from '.sitecore/component-map';
-import { JSX } from 'react';
+import Providers from 'src/Providers';
 
 /**
  * Rendered in case if we have 500 error
@@ -29,18 +30,20 @@ const Custom500 = (props: SitecorePageProps): JSX.Element => {
   }
 
   return (
-    <SitecoreProvider api={scConfig.api} componentMap={components} page={props.page}>
+    <Providers componentProps={props.componentProps} page={props.page}>
       <Layout page={props.page} />
-    </SitecoreProvider>
+    </Providers>
   );
 };
 
 export const getStaticProps: GetStaticProps = async (context) => {
-  let page: Page | null = null;
+  const props: SitecorePageProps = {
+    page: null,
+  };
 
   if (scConfig.generateStaticPaths) {
     try {
-      page = await client.getErrorPage(ErrorPage.InternalServerError, {
+      props.page = await client.getErrorPage(ErrorPage.InternalServerError, {
         site: scConfig.defaultSite,
         locale: context.locale || context.defaultLocale || scConfig.defaultLanguage,
       });
@@ -50,10 +53,12 @@ export const getStaticProps: GetStaticProps = async (context) => {
     }
   }
 
+  if (props.page) {
+    props.componentProps = await client.getComponentData(props.page.layout, context, components);
+  }
+
   return {
-    props: {
-      page,
-    },
+    props,
   };
 };
 

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -1,15 +1,12 @@
 ﻿import { useEffect, JSX } from 'react';
 <% if (prerender === 'SSG') { -%>
 import { GetStaticPaths, GetStaticProps } from 'next';
-import sites from '.sitecore/sites.json';
 <% } else if (prerender === 'SSR') { -%>
 import { GetServerSideProps } from 'next';
 <% } -%>
 import NotFound from 'src/NotFound';
 import Layout from 'src/Layout';
 import {
-  SitecoreProvider,
-  ComponentPropsContext,
   SitecorePageProps,
   <% if (prerender === 'SSG') { -%>
   StaticPath,
@@ -18,9 +15,11 @@ import {
 } from '@sitecore-content-sdk/nextjs';
 import { extractPath, handleEditorFastRefresh } from '@sitecore-content-sdk/nextjs/utils';
 import { isDesignLibraryPreviewData } from '@sitecore-content-sdk/nextjs/editing';
-import client from 'lib/sitecore-client';
+import sites from '.sitecore/sites.json';
 import components from '.sitecore/component-map';
 import scConfig from 'sitecore.config';
+import client from 'lib/sitecore-client';
+import Providers from 'src/Providers';
 
 const SitecorePage = ({ page, notFound, componentProps }: SitecorePageProps): JSX.Element => {
   useEffect(() => {
@@ -34,11 +33,9 @@ const SitecorePage = ({ page, notFound, componentProps }: SitecorePageProps): JS
   }
 
   return (
-    <ComponentPropsContext value={componentProps || {}}>
-      <SitecoreProvider componentMap={components} api={scConfig.api} page={page}>
-        <Layout page={page} />
-      </SitecoreProvider>
-    </ComponentPropsContext>
+    <Providers componentProps={componentProps} page={page}>
+      <Layout page={page} />
+    </Providers>
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Adds component-level data fetching to error and catch-all pages in the Next.js Pages Router template.
Establishes a consistent pattern for passing component props across all pages, including error routes.
Existing apps generated before this change can adopt the same pattern by adding `src/Providers.tsx` and wrapping pages with it.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
