### PR TITLE
[react] Custom properties are not applied to empty field in editing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[react]` Custom properties are not applied to empty field in editing mode ([#200](https://github.com/Sitecore/content-sdk/pull/200))
 * `[core]` Content styles fail to load due to incorrect contextId resolution ([#192](https://github.com/Sitecore/content-sdk/pull/192))
 * `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))
   - `SitecoreClient.getPreview` and `SitecoreClient.getDesignLibraryData` no longer request dictionary data. `Page` type is not affected.

--- a/packages/nextjs/src/components/Link.test.tsx
+++ b/packages/nextjs/src/components/Link.test.tsx
@@ -459,7 +459,7 @@ describe('<Link />', () => {
           `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
             testMetadata
           )}</code>`,
-          '<span>[No text in field]</span>',
+          '<span data-react-link="true">[No text in field]</span>',
           '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
         ].join('')
       );
@@ -482,7 +482,7 @@ describe('<Link />', () => {
           `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
             testMetadata
           )}</code>`,
-          '<span>[No text in field]</span>',
+          '<span data-react-link="true">[No text in field]</span>',
           '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
         ].join('')
       );

--- a/packages/react/src/components/Date.tsx
+++ b/packages/react/src/components/Date.tsx
@@ -6,7 +6,7 @@ import { EditableFieldProps } from './sharedTypes';
 import { FieldMetadata } from '@sitecore-content-sdk/core/layout';
 import { isFieldValueEmpty } from '@sitecore-content-sdk/core/layout';
 
-export interface DateFieldProps extends EditableFieldProps {
+export interface DateFieldProps extends EditableFieldProps<DateFieldProps> {
   /** The date field data. */
   [htmlAttributes: string]: unknown;
   field: FieldMetadata & {

--- a/packages/react/src/components/DefaultEmptyFieldEditingComponents.tsx
+++ b/packages/react/src/components/DefaultEmptyFieldEditingComponents.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 
-export const DefaultEmptyFieldEditingComponentText: React.FC = () => {
-  return <span>[No text in field]</span>;
+export const DefaultEmptyFieldEditingComponentText: React.FC<{
+  [key: string]: unknown;
+  tag?: string;
+}> = (props) => {
+  return React.createElement(props.tag || 'span', props, '[No text in field]');
 };
 
-export const DefaultEmptyFieldEditingComponentImage: React.FC = () => {
+export const DefaultEmptyFieldEditingComponentImage: React.FC<{
+  [key: string]: unknown;
+  className?: string;
+}> = (props) => {
   const inlineStyles = {
     minWidth: '48px',
     minHeight: '48px',
@@ -15,9 +21,10 @@ export const DefaultEmptyFieldEditingComponentImage: React.FC = () => {
 
   return (
     <img
+      {...props}
       alt=""
       src='data:image/svg+xml,%3Csvg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 240 240" style="enable-background:new 0 0 240 240;" xml:space="preserve"%3E%3Cstyle type="text/css"%3E .st0%7Bfill:none;%7D .st1%7Bfill:%23969696;%7D .st2%7Bfill:%23FFFFFF;%7D .st3%7Bfill:%23FFFFFF;stroke:%23FFFFFF;stroke-width:0.75;stroke-miterlimit:10;%7D%0A%3C/style%3E%3Cg%3E%3Crect class="st0" width="240" height="240"/%3E%3Cg%3E%3Cg%3E%3Crect x="20" y="20" class="st1" width="200" height="200"/%3E%3C/g%3E%3Cg%3E%3Ccircle class="st2" cx="174" cy="67" r="14"/%3E%3Cpath class="st2" d="M174,54c7.17,0,13,5.83,13,13s-5.83,13-13,13s-13-5.83-13-13S166.83,54,174,54 M174,52 c-8.28,0-15,6.72-15,15s6.72,15,15,15s15-6.72,15-15S182.28,52,174,52L174,52z"/%3E%3C/g%3E%3Cpolyline class="st3" points="29.5,179.25 81.32,122.25 95.41,137.75 137.23,91.75 209.5,179.75 "/%3E%3C/g%3E%3C/g%3E%3C/svg%3E'
-      className="scEmptyImage"
+      className={`scEmptyImage ${props.className || ''}`}
       style={inlineStyles}
     />
   );

--- a/packages/react/src/components/Image.test.tsx
+++ b/packages/react/src/components/Image.test.tsx
@@ -295,8 +295,8 @@ describe('<Image />', () => {
         metadata: testMetadata,
       };
 
-      const rendered = render(<Image field={field} />);
-      const defaultEmptyImagePlaceholder = render(<DefaultEmptyFieldEditingComponentImage />);
+      const rendered = render(<Image field={field} className="custom-class" />);
+      const defaultEmptyImagePlaceholder = render(<DefaultEmptyFieldEditingComponentImage className="custom-class" />);
       expect(rendered.container.innerHTML).to.equal(
         [
           `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
@@ -306,6 +306,8 @@ describe('<Image />', () => {
           '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
         ].join('')
       );
+      expect(rendered.container.innerHTML).to.contain('custom-class');
+      expect(rendered.container.innerHTML).to.contain('scEmptyImage');
     });
 
     it('should render custom empty field component when provided, when field value src is not present', () => {

--- a/packages/react/src/components/Image.tsx
+++ b/packages/react/src/components/Image.tsx
@@ -37,7 +37,7 @@ export interface ImageSizeParameters {
   sc?: number;
 }
 
-export interface ImageProps extends EditableFieldProps {
+export interface ImageProps extends EditableFieldProps<ImageProps> {
   [attributeName: string]: unknown;
   /** Image field data (consistent with other field types) */
   field?: (ImageField | ImageFieldValue) & FieldMetadata;

--- a/packages/react/src/components/Link.tsx
+++ b/packages/react/src/components/Link.tsx
@@ -23,7 +23,7 @@ export interface LinkField {
   value: LinkFieldValue;
 }
 
-export type LinkProps = EditableFieldProps &
+export type LinkProps = EditableFieldProps<LinkProps> &
   React.AnchorHTMLAttributes<HTMLAnchorElement> &
   RefAttributes<HTMLAnchorElement> & {
     /** The link field data. */

--- a/packages/react/src/components/RichText.tsx
+++ b/packages/react/src/components/RichText.tsx
@@ -9,7 +9,7 @@ export interface RichTextField extends FieldMetadata {
   value?: string;
 }
 
-export interface RichTextProps extends EditableFieldProps {
+export interface RichTextProps extends EditableFieldProps<RichTextProps> {
   [htmlAttributes: string]: unknown;
   /** The rich text field data. */
   field?: RichTextField;

--- a/packages/react/src/components/Text.tsx
+++ b/packages/react/src/components/Text.tsx
@@ -9,7 +9,7 @@ export interface TextField extends FieldMetadata {
   value?: string | number;
 }
 
-export interface TextProps extends EditableFieldProps {
+export interface TextProps extends EditableFieldProps<TextProps> {
   [htmlAttributes: string]: unknown;
   /** The text field data. */
   field?: TextField;

--- a/packages/react/src/components/sharedTypes/props.ts
+++ b/packages/react/src/components/sharedTypes/props.ts
@@ -1,7 +1,7 @@
 /**
  * Shared editing field props
  */
-export interface EditableFieldProps {
+export interface EditableFieldProps<EmptyFieldEditingComponentProps = unknown> {
   /**
    * Can be used to explicitly disable inline editing.
    * @default true
@@ -10,5 +10,5 @@ export interface EditableFieldProps {
   /**
    * Custom element to render in Pages in edit mode if field value is empty
    */
-  emptyFieldEditingComponent?: React.ComponentClass<unknown> | React.FC<unknown>;
+  emptyFieldEditingComponent?: React.ComponentClass<EmptyFieldEditingComponentProps> | React.FC<EmptyFieldEditingComponentProps>;
 }

--- a/packages/react/src/enhancers/withEmptyFieldEditingComponent.test.tsx
+++ b/packages/react/src/enhancers/withEmptyFieldEditingComponent.test.tsx
@@ -55,6 +55,7 @@ describe('withEmptyFieldEditingComponent', () => {
 
     it('Should render provided default empty value component component if field value is not provided', () => {
       const props = {
+        tag: 'h1',
         field: {
           value: '',
           metadata: testMetadata,
@@ -66,9 +67,10 @@ describe('withEmptyFieldEditingComponent', () => {
       });
 
       const rendered = render(<WrappedComponent {...props} />);
-      const expected = render(<DefaultEmptyFieldEditingComponentText />);
+      const expected = render(<DefaultEmptyFieldEditingComponentText tag='h1' />);
 
       expect(rendered.container.innerHTML).to.equal(expected.container.innerHTML);
+      expect(rendered.container.innerHTML).to.equal('<h1 tag="h1">[No text in field]</h1>');
     });
 
     it('Should render custom empty value component if provided via props if field value is not provided', () => {

--- a/packages/react/src/enhancers/withEmptyFieldEditingComponent.tsx
+++ b/packages/react/src/enhancers/withEmptyFieldEditingComponent.tsx
@@ -23,11 +23,11 @@ export interface WithEmptyFieldEditingComponentOptions {
 /*
  * represents the WithEmptyFieldEditingComponent HOC's props
  */
-interface WithEmptyFieldEditingComponentProps {
+interface WithEmptyFieldEditingComponentProps<Props> {
   // Partial<T> type is used here because _field.value_ could be required or optional for the different field types
   field?: (Partial<Field> | GenericFieldValue) & FieldMetadata;
   editable?: boolean;
-  emptyFieldEditingComponent?: React.ComponentClass | React.FC;
+  emptyFieldEditingComponent?: React.ComponentClass<Props> | React.FC<Props>;
 }
 
 /**
@@ -36,7 +36,7 @@ interface WithEmptyFieldEditingComponentProps {
  * @param {WithEmptyFieldEditingComponentProps} options the options of the HOC;
  */
 export function withEmptyFieldEditingComponent<
-  FieldComponentProps extends WithEmptyFieldEditingComponentProps,
+  FieldComponentProps extends WithEmptyFieldEditingComponentProps<FieldComponentProps>,
   RefElementType = HTMLElement
 >(
   FieldComponent: ComponentType<FieldComponentProps>,
@@ -44,10 +44,25 @@ export function withEmptyFieldEditingComponent<
 ) {
   const getEmptyFieldEditingComponent = (
     props: FieldComponentProps
-  ): React.ComponentClass | React.FC => {
+  ) => {
     const { editable = true } = props;
     if (props.field?.metadata && editable && isFieldValueEmpty(props.field)) {
-      return props.emptyFieldEditingComponent || options.defaultEmptyFieldEditingComponent;
+      const Component =
+        props.emptyFieldEditingComponent || options.defaultEmptyFieldEditingComponent;
+
+      let resolvedProps = props;
+
+      // If no custom empty field editing component is provided, we can omit unnecessary props
+      // to do not insert them to html
+      if (!props.emptyFieldEditingComponent) {
+        resolvedProps = {
+          ...props,
+          editable: undefined,
+          field: undefined,
+        };
+      }
+
+      return <Component {...resolvedProps} />;
     }
 
     return null;
@@ -55,27 +70,21 @@ export function withEmptyFieldEditingComponent<
 
   if (options.isForwardRef) {
     return forwardRef<RefElementType, FieldComponentProps>((props, ref) => {
-      const EmptyFieldEditingComponent = getEmptyFieldEditingComponent(
+      const emptyFieldEditingComponent = getEmptyFieldEditingComponent(
         props as FieldComponentProps
       );
+
       return (
-        <>
-          {(EmptyFieldEditingComponent && <EmptyFieldEditingComponent />) || (
-            <FieldComponent {...(props as FieldComponentProps)} ref={ref} />
-          )}
-        </>
+        emptyFieldEditingComponent || (
+          <FieldComponent {...(props as FieldComponentProps)} ref={ref} />
+        )
       );
     });
   }
 
   return (props: FieldComponentProps) => {
-    const EmptyFieldEditingComponent = getEmptyFieldEditingComponent(props);
-    return (
-      <>
-        {(EmptyFieldEditingComponent && <EmptyFieldEditingComponent />) || (
-          <FieldComponent {...props} />
-        )}
-      </>
-    );
+    const emptyFieldEditingComponent = getEmptyFieldEditingComponent(props);
+
+    return emptyFieldEditingComponent || <FieldComponent {...props} />;
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Previously, any custom properties passed to a Field component were not propagated to its corresponding empty field component. As a result, developers could not access these additional props when rendering custom empty states and the default empty component didn't apply these properties as well

This change ensures that all custom properties provided to the Field component are now also passed down to the empty field component.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
