### PR TITLE
[nextjs] Preserve default locale in external absolute urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,66 +14,63 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* Next.js App Router support:
-  * Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
-  * Base template ([#191](https://github.com/Sitecore/content-sdk/pull/191))
-* `[react]` Add `component:status` events for VariantGeneration ([#190](https://github.com/Sitecore/content-sdk/pull/190))
-
-### 🐛 Bug Fixes
-
-* `[nextjs]` Preserve default locale in external absolute urls ([#201](https://github.com/Sitecore/content-sdk/pull/201))
+- Next.js App Router support:
+  - Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
+  - Base template ([#191](https://github.com/Sitecore/content-sdk/pull/191))
+- `[react]` Add `component:status` events for VariantGeneration ([#190](https://github.com/Sitecore/content-sdk/pull/190))
 
 ## 1.1.0
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
-* Migration from ESlint 8 -> ESLint 9 and introduction of the new Flat Config file ([#176](https://github.com/Sitecore/content-sdk/pull/176))
-* Code generation for Design Library enablers:
+- `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
+- Migration from ESlint 8 -> ESLint 9 and introduction of the new Flat Config file ([#176](https://github.com/Sitecore/content-sdk/pull/176))
+- Code generation for Design Library enablers:
   - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157))([#167](https://github.com/Sitecore/content-sdk/pull/167))([#170](https://github.com/Sitecore/content-sdk/pull/170))([#171](https://github.com/Sitecore/content-sdk/pull/171))([#175](https://github.com/Sitecore/content-sdk/pull/175))([#177](https://github.com/Sitecore/content-sdk/pull/177))([#187](https://github.com/Sitecore/content-sdk/pull/187))
     - New `writeImportMap()`, `combineImportEntries()` methods and `defaultImportEntries` export available from `@sitecore-content-sdk/nextjs/codegen`
   - Dynamic component rendering ([#163](https://github.com/Sitecore/content-sdk/pull/163))
   - Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))
   - Ensure editing state is enabled in Design Library mode ([#181](https://github.com/Sitecore/content-sdk/pull/181))
-* `[core]` Ensure displayName paths are properly UTF-8 encoded. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
-* `[react]` Enhanced the Design Library cache buster format to hh-dd-mm-yyyy ([#188](https://github.com/Sitecore/content-sdk/pull/188))
-* `[nextjs]` Optimization for editing render middleware: issue an internal server request for fetching page data during editing instead of doing temporary redirect ([#195](https://github.com/Sitecore/content-sdk/pull/195)) ([#196](https://github.com/Sitecore/content-sdk/pull/196))
+- `[core]` Ensure displayName paths are properly UTF-8 encoded. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
+- `[react]` Enhanced the Design Library cache buster format to hh-dd-mm-yyyy ([#188](https://github.com/Sitecore/content-sdk/pull/188))
+- `[nextjs]` Optimization for editing render middleware: issue an internal server request for fetching page data during editing instead of doing temporary redirect ([#195](https://github.com/Sitecore/content-sdk/pull/195)) ([#196](https://github.com/Sitecore/content-sdk/pull/196))
   - added new environment variable `SITECORE_INTERNAL_EDITING_HOST_URL` - the internal host URL for the Next.js application, used for server-side requests for page rendering during editing
   - added a new setting in _sitecore.config_: _sitecoreInternalEditingHostUrl_. This setting allows you to define the internal host URL explicitly, overriding the corresponding environment variable.
   - if none of the above is set:
-     - in XM Cloud environment server request will be issued to `http://localhost:3000`
-     - in Vercel or Netlify scenarios, the host header of the incoming request will be used to make the internal request
+    - in XM Cloud environment server request will be issued to `http://localhost:3000`
+    - in Vercel or Netlify scenarios, the host header of the incoming request will be used to make the internal request
 
 ### 🐛 Bug Fixes
 
-* `[core]` Content styles fail to load due to incorrect contextId resolution ([#192](https://github.com/Sitecore/content-sdk/pull/192))
-* `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))
+- `[nextjs]` Preserve default locale in external absolute urls ([#201](https://github.com/Sitecore/content-sdk/pull/201))
+- `[core]` Content styles fail to load due to incorrect contextId resolution ([#192](https://github.com/Sitecore/content-sdk/pull/192))
+- `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))
   - `SitecoreClient.getPreview` and `SitecoreClient.getDesignLibraryData` no longer request dictionary data. `Page` type is not affected.
   - Updated `EditingService.fetchEditingData`:
     - Removed `siteName` parameter.
     - No longer requests and returns dictionary data.
-* `[cli]` Code extraction extends XM Cloud Rendering Host build by several minutes ([#173](https://github.com/Sitecore/content-sdk/pull/173))
-* `[core]` Fix redirect regex processing to prevent over-escaping of question marks in regex patterns ([#174](https://github.com/Sitecore/content-sdk/pull/174))
+- `[cli]` Code extraction extends XM Cloud Rendering Host build by several minutes ([#173](https://github.com/Sitecore/content-sdk/pull/173))
+- `[core]` Fix redirect regex processing to prevent over-escaping of question marks in regex patterns ([#174](https://github.com/Sitecore/content-sdk/pull/174))
 
 ## 1.0.1
 
 ### 🐛 Bug Fixes
 
-* `[core]` `[nextjs]` Restore proper local connection fallback 
-  * Added fallback to `middleware.ts` file to enable local API connections in the absence of `contextId`. ([#178](https://github.com/Sitecore/content-sdk/pull/178))([#180](https://github.com/Sitecore/content-sdk/pull/180))
+- `[core]` `[nextjs]` Restore proper local connection fallback
+  - Added fallback to `middleware.ts` file to enable local API connections in the absence of `contextId`. ([#178](https://github.com/Sitecore/content-sdk/pull/178))([#180](https://github.com/Sitecore/content-sdk/pull/180))
 
 ## 1.0.0
 
 ### 🎉 New Features & Improvements
 
-* Design Library Early Access enablers:
-  * `[core]` `[nextjs]` Integrated new _VariantGeneration_ mode ([#158](https://github.com/Sitecore/content-sdk/pull/158))
-  * `[nextjs]` Default static import-map ([#153](https://github.com/Sitecore/content-sdk/pull/153))
-  * `[cli]` Code Extraction ([#71](https://github.com/Sitecore/content-sdk/pull/71))([#113](https://github.com/Sitecore/content-sdk/pull/113))([#114](https://github.com/Sitecore/content-sdk/pull/114))([#154](https://github.com/Sitecore/content-sdk/pull/154))
+- Design Library Early Access enablers:
+  - `[core]` `[nextjs]` Integrated new _VariantGeneration_ mode ([#158](https://github.com/Sitecore/content-sdk/pull/158))
+  - `[nextjs]` Default static import-map ([#153](https://github.com/Sitecore/content-sdk/pull/153))
+  - `[cli]` Code Extraction ([#71](https://github.com/Sitecore/content-sdk/pull/71))([#113](https://github.com/Sitecore/content-sdk/pull/113))([#114](https://github.com/Sitecore/content-sdk/pull/114))([#154](https://github.com/Sitecore/content-sdk/pull/154))
 
 ### 🛠 Breaking Changes
 
-* Refactored `SitecoreProvider` and enhanced `SitecoreClient` ([#158](https://github.com/Sitecore/content-sdk/pull/158)):
+- Refactored `SitecoreProvider` and enhanced `SitecoreClient` ([#158](https://github.com/Sitecore/content-sdk/pull/158)):
 
   #### Reworked `SitecoreProvider` and Context
 
@@ -94,16 +91,19 @@ Our versioning strategy is as follows:
   #### Improvements to `SitecoreClient`
 
   - **Type cleanup and consistency**:
+
     - Removed `NextjsPage` interface.
     - All methods that generate page data now return a consistent `Page` object.
     - Properties `componentProps` and `notFound` are now part of the `SitecorePageProps` interface and are treated as optional.
     - `SitecorePageProps` now requires a standalone `page` field instead of merging all data into one props object.
 
   - **New `getErrorPage()` method**:
+
     - Replaces `getErrorPages()`, exposing only necessary data.
     - Introduces a new `ErrorPage` enum to select specific error types (e.g., `ErrorPage.NotFound`)
-  
+
   - **New `PageMode` Type**
+
     - The `Page` type now includes a `mode` field of type `PageMode`, providing runtime context (e.g. editing, design library, preview).
     - Replaces older properties like `pageState`, `pageEditing`, `componentType`.
 
@@ -121,87 +121,91 @@ Our versioning strategy is as follows:
   - The `DesignLibrary` component no longer accepts a `layoutData` prop.
   - It now accesses `page` directly from `SitecoreProvider`.
 
-* Refactor and simplify service names ([#133](https://github.com/Sitecore/content-sdk/pull/133)):
+- Refactor and simplify service names ([#133](https://github.com/Sitecore/content-sdk/pull/133)):
 
   You will be affected by the following changes **only** if:
+
   - You are referencing Content SDK services directly rather than using the `SitecoreClient` methods.
 
   If you're using the `SitecoreClient` to access services, **no changes** are required.
 
   Service class and config names have been refactored for clarity and consistency:
 
-  * Renamed:
-    * `RestComponentLayoutService` → `ComponentLayoutService`
-    * `RestComponentLayoutServiceConfig` → `ComponentLayoutServiceConfig`
-    * `GraphQLEditingService` → `EditingService`
-    * `GraphQLEditingServiceConfig` → `EditingServiceConfig`
-    * `GraphQLDictionaryService` → `DictionaryService`
-    * `GraphQLDictionaryServiceConfig` → `DictionaryServiceConfig`
-    * `GraphQLLayoutService` → `LayoutService`
-    * `GraphQLLayoutServiceConfig` → `LayoutServiceConfig`
-    * `GraphQLPersonalizeService` → `PersonalizeService`
-    * `GraphQLPersonalizeServiceConfig` → `PersonalizeServiceConfig`
-    * `GraphQLErrorPagesService` → `ErrorPagesService`
-    * `GraphQLErrorPagesServiceConfig` → `ErrorPagesServiceConfig`
-    * `GraphQLRedirectsService` → `RedirectsService`
-    * `GraphQLRedirectsServiceConfig` → `RedirectsServiceConfig`
-    * `GraphQLRobotsService` → `RobotsService`
-    * `GraphQLRobotsServiceConfig` → `RobotsServiceConfig`
-    * `GraphQLSiteInfoService` → `SiteInfoService`
-    * `GraphQLSiteInfoServiceConfig` → `SiteInfoServiceConfig`
-    * `GraphQLSitemapXmlService` → `SitemapXmlService`
-    * `GraphQLSitemapXmlServiceConfig` → `SitemapXmlServiceConfig`
-    * `GraphQLSitePathService` → `SitePathService`
-    * `GraphQLSitePathServiceConfig` → `SitePathServiceConfig`
-  * Removed `DictionaryService` interface
-* `[core]` `[nextjs]` `[templates/nextjs]` Refactor site resolution logic across packages ([#141](https://github.com/Sitecore/content-sdk/pull/141))([#155](https://github.com/Sitecore/content-sdk/pull/155))
-  * Removed `sites` parameter from `SitecoreClientInit` type
-  * Removed `SiteResolver` dependency and `resolveSite()` from `SitecoreClient`
-  * Removed support for passing a custom siteResolver to `SitecoreClient`
-  * Updated `SitecoreClient` to construct the `Page` using `siteName` instead of the full `SiteInfo`.
-  * Updated SitecoreClient's `getPagePaths()` to accept a `sites` parameter
-  * Modified the `getPagePaths` method in `SitecoreClient` to accept a `sites` parameter.
-  * Updated Next.js `SitemapMiddleware` and `RobotsMiddleware` to use their own instance of `SiteResolver` and accept a `sites` parameter via the constructor.
+  - Renamed:
+    - `RestComponentLayoutService` → `ComponentLayoutService`
+    - `RestComponentLayoutServiceConfig` → `ComponentLayoutServiceConfig`
+    - `GraphQLEditingService` → `EditingService`
+    - `GraphQLEditingServiceConfig` → `EditingServiceConfig`
+    - `GraphQLDictionaryService` → `DictionaryService`
+    - `GraphQLDictionaryServiceConfig` → `DictionaryServiceConfig`
+    - `GraphQLLayoutService` → `LayoutService`
+    - `GraphQLLayoutServiceConfig` → `LayoutServiceConfig`
+    - `GraphQLPersonalizeService` → `PersonalizeService`
+    - `GraphQLPersonalizeServiceConfig` → `PersonalizeServiceConfig`
+    - `GraphQLErrorPagesService` → `ErrorPagesService`
+    - `GraphQLErrorPagesServiceConfig` → `ErrorPagesServiceConfig`
+    - `GraphQLRedirectsService` → `RedirectsService`
+    - `GraphQLRedirectsServiceConfig` → `RedirectsServiceConfig`
+    - `GraphQLRobotsService` → `RobotsService`
+    - `GraphQLRobotsServiceConfig` → `RobotsServiceConfig`
+    - `GraphQLSiteInfoService` → `SiteInfoService`
+    - `GraphQLSiteInfoServiceConfig` → `SiteInfoServiceConfig`
+    - `GraphQLSitemapXmlService` → `SitemapXmlService`
+    - `GraphQLSitemapXmlServiceConfig` → `SitemapXmlServiceConfig`
+    - `GraphQLSitePathService` → `SitePathService`
+    - `GraphQLSitePathServiceConfig` → `SitePathServiceConfig`
+  - Removed `DictionaryService` interface
+
+- `[core]` `[nextjs]` `[templates/nextjs]` Refactor site resolution logic across packages ([#141](https://github.com/Sitecore/content-sdk/pull/141))([#155](https://github.com/Sitecore/content-sdk/pull/155))
+  - Removed `sites` parameter from `SitecoreClientInit` type
+  - Removed `SiteResolver` dependency and `resolveSite()` from `SitecoreClient`
+  - Removed support for passing a custom siteResolver to `SitecoreClient`
+  - Updated `SitecoreClient` to construct the `Page` using `siteName` instead of the full `SiteInfo`.
+  - Updated SitecoreClient's `getPagePaths()` to accept a `sites` parameter
+  - Modified the `getPagePaths` method in `SitecoreClient` to accept a `sites` parameter.
+  - Updated Next.js `SitemapMiddleware` and `RobotsMiddleware` to use their own instance of `SiteResolver` and accept a `sites` parameter via the constructor.
 
 ### 🐛 Bug Fixes
 
-* `[nextjs]` Ensure Redirect Middleware handles case-insensitive path matching to prevent missed redirects due to casing differences ([#159](https://github.com/Sitecore/jss/pull/159))
-* `[core]` `[nextjs]`Standardized way of handling contextId/clientContextId and related fallbacks ([#150](https://github.com/Sitecore/content-sdk/pull/150))
+- `[nextjs]` Ensure Redirect Middleware handles case-insensitive path matching to prevent missed redirects due to casing differences ([#159](https://github.com/Sitecore/jss/pull/159))
+- `[core]` `[nextjs]`Standardized way of handling contextId/clientContextId and related fallbacks ([#150](https://github.com/Sitecore/content-sdk/pull/150))
 
 ### 🧹 Chores
 
-* Add Github action workflow to generate package size and test coverage metrics report ([#151](https://github.com/Sitecore/content-sdk/pull/151))
+- Add Github action workflow to generate package size and test coverage metrics report ([#151](https://github.com/Sitecore/content-sdk/pull/151))
 
 ## 0.3.0
 
 ### 🎉 New Features & Improvements
 
-* `[create-content-sdk-app]`: Refactoring/Cleanup for scss files in SXA components ([#119](https://github.com/Sitecore/content-sdk/pull/119))([#122](https://github.com/Sitecore/content-sdk/pull/122))
-* `[core]` `[nextjs]` [DesignLibrary] Include metadata in the Design Library rendering mechanism ([#118](https://github.com/Sitecore/content-sdk/pull/118))
-* `[core]` `[nextjs]` `[cli]` Add automatic component map generation ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#128](https://github.com/Sitecore/content-sdk/pull/128) [#130](https://github.com/Sitecore/content-sdk/pull/130))
-* `[create-sitecore-jss]` Remove graphql introspection sample and scripts folder from next starter application ([#135](https://github.com/Sitecore/content-sdk/pull/135))
-* `[core]` [Content SDK] Update environment variable naming and associated config property ([#143](https://github.com/Sitecore/content-sdk/pull/143))
+- `[create-content-sdk-app]`: Refactoring/Cleanup for scss files in SXA components ([#119](https://github.com/Sitecore/content-sdk/pull/119))([#122](https://github.com/Sitecore/content-sdk/pull/122))
+- `[core]` `[nextjs]` [DesignLibrary] Include metadata in the Design Library rendering mechanism ([#118](https://github.com/Sitecore/content-sdk/pull/118))
+- `[core]` `[nextjs]` `[cli]` Add automatic component map generation ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#128](https://github.com/Sitecore/content-sdk/pull/128) [#130](https://github.com/Sitecore/content-sdk/pull/130))
+- `[create-sitecore-jss]` Remove graphql introspection sample and scripts folder from next starter application ([#135](https://github.com/Sitecore/content-sdk/pull/135))
+- `[core]` [Content SDK] Update environment variable naming and associated config property ([#143](https://github.com/Sitecore/content-sdk/pull/143))
 
 ### 🛠 Breaking Changes
 
-* `[create-content-sdk-app]` Renamed package from `@sitecore-content-sdk/create-app` to `create-content-sdk-app` (unscoped package)
+- `[create-content-sdk-app]` Renamed package from `@sitecore-content-sdk/create-app` to `create-content-sdk-app` (unscoped package)
   - Users can now run `npx create-content-sdk-app` instead of `npx @sitecore-content-sdk/create-app`
   - Follows the same pattern as other popular initializers like `create-react-app` and `create-next-app`
-* `[all]` Renamed all JSS references to Content SDK across the codebase: ([#131](https://github.com/Sitecore/content-sdk/pull/131))
+- `[all]` Renamed all JSS references to Content SDK across the codebase: ([#131](https://github.com/Sitecore/content-sdk/pull/131))
   - The create-sitecore-jss package has been renamed to create-content-sdk-app (unscoped package)
   - Component types and props renamed:
     - `ReactJssComponent` → `ReactContentSdkComponent`
     - `NextJssComponent` → `NextjsContentSdkComponent`
-* `[react]` `[nextjs]` Refactor `SitecoreContext` naming to `SitecoreProvider` ([95](https://github.com/Sitecore/content-sdk/pull/95)):
+- `[react]` `[nextjs]` Refactor `SitecoreContext` naming to `SitecoreProvider` ([95](https://github.com/Sitecore/content-sdk/pull/95)):
 
   We've revisited and improved the `SitecoreContext` naming for clarity and consistency. This affects component names, types, hook, and HOC.
-  
+
   #### Component Renames
 
   - Component:
+
     - `SitecoreContext` → `SitecoreProvider`
 
   - Properties:
+
     - `context` property renamed to `pageContext` to clarify that it holds **page-specific data** only
 
   - Interfaces:
@@ -213,57 +217,60 @@ Our versioning strategy is as follows:
   #### Hook and HOC Renames
 
   - Functions:
-    - `withSitecoreContext` → `withSitecore`  
-    - `useSitecoreContext` → `useSitecore`  
+
+    - `withSitecoreContext` → `withSitecore`
+    - `useSitecoreContext` → `useSitecore`
 
   - Properties:
+
     - `updateSitecoreContext` property -> `updateContext`
-    - `sitecoreContext`  property -> `pageContext`
+    - `sitecoreContext` property -> `pageContext`
 
   - Interfaces:
     - `WithSitecoreContextOptions` → `WithSitecoreOptions`
     - `WithSitecoreContextProps` → `WithSitecoreProps`
     - `WithSitecoreContextHocProps` → `WithSitecoreHocProps`
-* `[nextjs]` Component-level `getServerSideProps` and `getStaticProps` methods have been replaced by a single `getComponentServerProps` method for simplicity.
-    * In case a separate logic is needed depending on SSR/SSG context, an `isServerSidePropsContext` helper method from `@sitecore-content-sdk/nextjs/utils` can now be used.
-* `[nextjs]` [DesignLibrary] Script is requested from production even when a custom Edge URL is set ([#98](https://github.com/Sitecore/content-sdk/pull/98)):
-  * The `EditingScripts` component doesn't accept `sitecoreEdgeUrl` property anymore.
-  * The custom Edge URL is now accessed via the `api` property of the `SitecoreProvider` component.
-* `[nextjs]` `defineCliConfig` import has been moved to `@sitecore-content-sdk/nextjs/config-cli` submodule ([#128](https://github.com/Sitecore/content-sdk/pull/128)).
-* `[core][nextjs][cli]` Re-introduce component map generation logic ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#139](https://github.com/Sitecore/content-sdk/pull/139))
-* `[create-content-sdk-app]` Remove SXA components and style files from default `nextjs` template ([#139](https://github.com/Sitecore/content-sdk/pull/139))
-* `[core]` `[nextjs]` `[templates/nextjs]` Environment variables' naming has been updated ([#143](https://github.com/Sitecore/content-sdk/pull/143))
-  * `JSS_EDITING_SECRET` → `SITECORE_EDITING_SECRET`
-  * `NEXT_PUBLIC_SITECORE_SITE_NAME` → `NEXT_PUBLIC_DEFAULT_SITE_NAME`
-  * `DISABLE_SSG_FETCH` → `GENERATE_STATIC_PATHS`
-  * `disableStaticPaths` config property → `generateStaticPaths` (with inverted logic for clarity)
+
+- `[nextjs]` Component-level `getServerSideProps` and `getStaticProps` methods have been replaced by a single `getComponentServerProps` method for simplicity.
+  - In case a separate logic is needed depending on SSR/SSG context, an `isServerSidePropsContext` helper method from `@sitecore-content-sdk/nextjs/utils` can now be used.
+- `[nextjs]` [DesignLibrary] Script is requested from production even when a custom Edge URL is set ([#98](https://github.com/Sitecore/content-sdk/pull/98)):
+  - The `EditingScripts` component doesn't accept `sitecoreEdgeUrl` property anymore.
+  - The custom Edge URL is now accessed via the `api` property of the `SitecoreProvider` component.
+- `[nextjs]` `defineCliConfig` import has been moved to `@sitecore-content-sdk/nextjs/config-cli` submodule ([#128](https://github.com/Sitecore/content-sdk/pull/128)).
+- `[core][nextjs][cli]` Re-introduce component map generation logic ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#139](https://github.com/Sitecore/content-sdk/pull/139))
+- `[create-content-sdk-app]` Remove SXA components and style files from default `nextjs` template ([#139](https://github.com/Sitecore/content-sdk/pull/139))
+- `[core]` `[nextjs]` `[templates/nextjs]` Environment variables' naming has been updated ([#143](https://github.com/Sitecore/content-sdk/pull/143))
+  - `JSS_EDITING_SECRET` → `SITECORE_EDITING_SECRET`
+  - `NEXT_PUBLIC_SITECORE_SITE_NAME` → `NEXT_PUBLIC_DEFAULT_SITE_NAME`
+  - `DISABLE_SSG_FETCH` → `GENERATE_STATIC_PATHS`
+  - `disableStaticPaths` config property → `generateStaticPaths` (with inverted logic for clarity)
 
 ### 🐛 Bug Fixes
 
-* `[core]` Fix for enabling debug logs previously not appearing during build execution ([#137](https://github.com/Sitecore/content-sdk/pull/137))
-* `[core]` Fix for making clientContextId optional for client-side execution to avoid runtime errors ([#121](https://github.com/Sitecore/content-sdk/pull/121))
-* `[core]` `[sitecore.config]` Fallback values are not respected when framework specific value is empty & validate resolved config instead of base ([#97](https://github.com/Sitecore/content-sdk/pull/97))
-* `[nextjs]` Improve device detection and prevent false prefetch handling in Personalize middleware and also ensure personalized responses are not served from prefetch cache and proper personalization was applied during client side navigation. ([#129](https://github.com/Sitecore/content-sdk/pull/129))
-* `[react]` Suspense in ErrorBoundary component is not rendered when it is wrapping a BYOCWrapper to prevent client side hydration errors ([#132](https://github.com/Sitecore/content-sdk/pull/132))
-* `[nextjs]` Fix component-level data fetching method is exposed in client bundle ([#134](https://github.com/Sitecore/content-sdk/pull/134))
-* `[react]` Add an optional `disableSuspense` flag to the Placeholder component to prevent error boundaries from rendering Suspense which helps contain errors for components. This can help avoid hydration issues in connected mode. ([#96](https://github.com/Sitecore/content-sdk/pull/96))
+- `[core]` Fix for enabling debug logs previously not appearing during build execution ([#137](https://github.com/Sitecore/content-sdk/pull/137))
+- `[core]` Fix for making clientContextId optional for client-side execution to avoid runtime errors ([#121](https://github.com/Sitecore/content-sdk/pull/121))
+- `[core]` `[sitecore.config]` Fallback values are not respected when framework specific value is empty & validate resolved config instead of base ([#97](https://github.com/Sitecore/content-sdk/pull/97))
+- `[nextjs]` Improve device detection and prevent false prefetch handling in Personalize middleware and also ensure personalized responses are not served from prefetch cache and proper personalization was applied during client side navigation. ([#129](https://github.com/Sitecore/content-sdk/pull/129))
+- `[react]` Suspense in ErrorBoundary component is not rendered when it is wrapping a BYOCWrapper to prevent client side hydration errors ([#132](https://github.com/Sitecore/content-sdk/pull/132))
+- `[nextjs]` Fix component-level data fetching method is exposed in client bundle ([#134](https://github.com/Sitecore/content-sdk/pull/134))
+- `[react]` Add an optional `disableSuspense` flag to the Placeholder component to prevent error boundaries from rendering Suspense which helps contain errors for components. This can help avoid hydration issues in connected mode. ([#96](https://github.com/Sitecore/content-sdk/pull/96))
 
 ### 🧹 Chores
 
-* `[react]` Update feaas dependencies ([#149](https://github.com/Sitecore/content-sdk/pull/149))
+- `[react]` Update feaas dependencies ([#149](https://github.com/Sitecore/content-sdk/pull/149))
 
 ## 0.2.1
 
 ### 🎉 New Features & Improvements
 
-* `[core]` [DesignLibrary] Call partial layout rendering endpoint via Envoy and ContextID ([#111](https://github.com/Sitecore/content-sdk/pull/111))
+- `[core]` [DesignLibrary] Call partial layout rendering endpoint via Envoy and ContextID ([#111](https://github.com/Sitecore/content-sdk/pull/111))
 
 ## 0.2.0
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
-  - Introduced `.env.container.example`  
+- `[nextjs]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
+  - Introduced `.env.container.example`
     - Intended for local development against a Sitecore container instance.
   - Introduced `.env.remote.example`
     - Intended for working with a remote Sitecore instance.
@@ -272,37 +279,37 @@ Our versioning strategy is as follows:
   - Removed `GRAPH_QL_SERVICE_RETRIES` environment variable
     This is not environment-specific and should be defined in the configuration instead.
   - Removed `DISABLE_SSG_FETCH` environment variable
-    - In XM Cloud, this is set to `true` by default as the application runs as an editing host.  
+    - In XM Cloud, this is set to `true` by default as the application runs as an editing host.
     - It can still be configured via the `DISABLE_SSG_FETCH` environment variable or the `disableStaticPaths` config property if needed.
     - By default, it is set to `false` in the configuration.
-* `[core]` `[nextjs]` Introduced `getRobots` method in `SitecoreClient` and a new `RobotsMiddleware` for Next.js API routes ([#83](https://github.com/Sitecore/content-sdk/pull/83))
+- `[core]` `[nextjs]` Introduced `getRobots` method in `SitecoreClient` and a new `RobotsMiddleware` for Next.js API routes ([#83](https://github.com/Sitecore/content-sdk/pull/83))
   - The `getRobots(siteName, fetchOptions?)` method centralizes logic for fetching `robots.txt` content.
   - A new `RobotsMiddleware` class encapsulates HTTP-level logic for generating `robots.txt` responses in Next.js apps.
   - These additions follow the same extensible architecture as existing features enabling custom behavior via service overrides and improving consistency across endpoints.
-* `[cli]` Introduce "project" subcommands ([#73](https://github.com/Sitecore/content-sdk/pull/73))
-* `[nextjs]` Enhance customizability for Sitecore Client and SDK Middlwares ([#87](https://github.com/Sitecore/content-sdk/pull/87))
-* `[core]` `[nextjs]` `[create-content-sdk-app]` Passing configuration object to `defineConfig` in _sitecore.config_ is now optional. Introduced _sitecore.config.ts.example_ ([#90](https://github.com/Sitecore/content-sdk/pull/90)) ([#93](https://github.com/Sitecore/content-sdk/pull/93))
-* `[nextjs]` Starter kit components clean up ([#107](https://github.com/Sitecore/content-sdk/pull/107)):
+- `[cli]` Introduce "project" subcommands ([#73](https://github.com/Sitecore/content-sdk/pull/73))
+- `[nextjs]` Enhance customizability for Sitecore Client and SDK Middlwares ([#87](https://github.com/Sitecore/content-sdk/pull/87))
+- `[core]` `[nextjs]` `[create-content-sdk-app]` Passing configuration object to `defineConfig` in _sitecore.config_ is now optional. Introduced _sitecore.config.ts.example_ ([#90](https://github.com/Sitecore/content-sdk/pull/90)) ([#93](https://github.com/Sitecore/content-sdk/pull/93))
+- `[nextjs]` Starter kit components clean up ([#107](https://github.com/Sitecore/content-sdk/pull/107)):
   - Reduced code duplication
   - Streamlined the implementation to improve consistency
   - Removed outdated logic related to editing support
 
 ### 🛠 Breaking Changes
 
-* `[core]` SXA Form can't fire CloudSDK events due to initialization error ([#63](https://github.com/Sitecore/content-sdk/pull/63)):
-  * Form utilities have been moved from `@sitecore-content-sdk/core/form` to the root of `@sitecore-content-sdk/core`. Update your imports to reflect this change if you are referencing these utilities.
-* `[nextjs]` Update React to version 19 and Next JS to version 15 ([#76](https://github.com/Sitecore/content-sdk/pull/76))
+- `[core]` SXA Form can't fire CloudSDK events due to initialization error ([#63](https://github.com/Sitecore/content-sdk/pull/63)):
+  - Form utilities have been moved from `@sitecore-content-sdk/core/form` to the root of `@sitecore-content-sdk/core`. Update your imports to reflect this change if you are referencing these utilities.
+- `[nextjs]` Update React to version 19 and Next JS to version 15 ([#76](https://github.com/Sitecore/content-sdk/pull/76))
 
 ### 🐛 Bug Fixes
 
-* `[nextjs]` Fix for case sensitive redirects (make all redirects case-insensitive) ([#70](https://github.com/Sitecore/content-sdk/pull/70))
-* `[core]` Fix for lookbehind regex. (not supported on ios 16) ([#67](https://github.com/Sitecore/content-sdk/pull/67))
-* `[nextjs]` Render "unoptimized" Next Image in component rendering mode ([#66](https://github.com/Sitecore/content-sdk/pull/66))
-* `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))
-* `[cli]` Process env variables in both cli global and local mode by default. ([#61](https://github.com/Sitecore/content-sdk/pull/61))
-* `[react]` `[nextjs]` Do not render EditingScripts component in DesignLibrary component. Fix 'dataSourceId' query parameter name in editing render middleware. ([#64](https://github.com/Sitecore/content-sdk/pull/64))
+- `[nextjs]` Fix for case sensitive redirects (make all redirects case-insensitive) ([#70](https://github.com/Sitecore/content-sdk/pull/70))
+- `[core]` Fix for lookbehind regex. (not supported on ios 16) ([#67](https://github.com/Sitecore/content-sdk/pull/67))
+- `[nextjs]` Render "unoptimized" Next Image in component rendering mode ([#66](https://github.com/Sitecore/content-sdk/pull/66))
+- `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))
+- `[cli]` Process env variables in both cli global and local mode by default. ([#61](https://github.com/Sitecore/content-sdk/pull/61))
+- `[react]` `[nextjs]` Do not render EditingScripts component in DesignLibrary component. Fix 'dataSourceId' query parameter name in editing render middleware. ([#64](https://github.com/Sitecore/content-sdk/pull/64))
 
 ### 🧹 Chores
 
-* `[template/nextjs]` Clean package.json scripts ([#75](https://github.com/Sitecore/content-sdk/pull/75))
-* Upgrade 3rd party dependencies ([#88](https://github.com/Sitecore/content-sdk/pull/88)) ([#92](https://github.com/Sitecore/content-sdk/pull/92))
+- `[template/nextjs]` Clean package.json scripts ([#75](https://github.com/Sitecore/content-sdk/pull/75))
+- Upgrade 3rd party dependencies ([#88](https://github.com/Sitecore/content-sdk/pull/88)) ([#92](https://github.com/Sitecore/content-sdk/pull/92))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,64 +14,64 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-- Next.js App Router support:
-  - Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
-  - Base template ([#191](https://github.com/Sitecore/content-sdk/pull/191))
-- `[react]` Add `component:status` events for VariantGeneration ([#190](https://github.com/Sitecore/content-sdk/pull/190))
+* Next.js App Router support:
+  * Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
+  * Base template ([#191](https://github.com/Sitecore/content-sdk/pull/191))
+* `[react]` Add `component:status` events for VariantGeneration ([#190](https://github.com/Sitecore/content-sdk/pull/190))
 
 ## 1.1.0
 
 ### 🎉 New Features & Improvements
 
-- `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
-- Migration from ESlint 8 -> ESLint 9 and introduction of the new Flat Config file ([#176](https://github.com/Sitecore/content-sdk/pull/176))
-- Code generation for Design Library enablers:
+* `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
+* Migration from ESlint 8 -> ESLint 9 and introduction of the new Flat Config file ([#176](https://github.com/Sitecore/content-sdk/pull/176))
+* Code generation for Design Library enablers:
   - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157))([#167](https://github.com/Sitecore/content-sdk/pull/167))([#170](https://github.com/Sitecore/content-sdk/pull/170))([#171](https://github.com/Sitecore/content-sdk/pull/171))([#175](https://github.com/Sitecore/content-sdk/pull/175))([#177](https://github.com/Sitecore/content-sdk/pull/177))([#187](https://github.com/Sitecore/content-sdk/pull/187))
     - New `writeImportMap()`, `combineImportEntries()` methods and `defaultImportEntries` export available from `@sitecore-content-sdk/nextjs/codegen`
   - Dynamic component rendering ([#163](https://github.com/Sitecore/content-sdk/pull/163))
   - Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))
   - Ensure editing state is enabled in Design Library mode ([#181](https://github.com/Sitecore/content-sdk/pull/181))
-- `[core]` Ensure displayName paths are properly UTF-8 encoded. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
-- `[react]` Enhanced the Design Library cache buster format to hh-dd-mm-yyyy ([#188](https://github.com/Sitecore/content-sdk/pull/188))
-- `[nextjs]` Optimization for editing render middleware: issue an internal server request for fetching page data during editing instead of doing temporary redirect ([#195](https://github.com/Sitecore/content-sdk/pull/195)) ([#196](https://github.com/Sitecore/content-sdk/pull/196))
+* `[core]` Ensure displayName paths are properly UTF-8 encoded. ([#179](https://github.com/Sitecore/content-sdk/pull/179))
+* `[react]` Enhanced the Design Library cache buster format to hh-dd-mm-yyyy ([#188](https://github.com/Sitecore/content-sdk/pull/188))
+* `[nextjs]` Optimization for editing render middleware: issue an internal server request for fetching page data during editing instead of doing temporary redirect ([#195](https://github.com/Sitecore/content-sdk/pull/195)) ([#196](https://github.com/Sitecore/content-sdk/pull/196))
   - added new environment variable `SITECORE_INTERNAL_EDITING_HOST_URL` - the internal host URL for the Next.js application, used for server-side requests for page rendering during editing
   - added a new setting in _sitecore.config_: _sitecoreInternalEditingHostUrl_. This setting allows you to define the internal host URL explicitly, overriding the corresponding environment variable.
   - if none of the above is set:
-    - in XM Cloud environment server request will be issued to `http://localhost:3000`
-    - in Vercel or Netlify scenarios, the host header of the incoming request will be used to make the internal request
+     - in XM Cloud environment server request will be issued to `http://localhost:3000`
+     - in Vercel or Netlify scenarios, the host header of the incoming request will be used to make the internal request
 
 ### 🐛 Bug Fixes
 
-- `[nextjs]` Preserve default locale in external absolute urls ([#201](https://github.com/Sitecore/content-sdk/pull/201))
-- `[react]` Custom properties are not applied to empty field in editing mode ([#200](https://github.com/Sitecore/content-sdk/pull/200))
-- `[core]` Content styles fail to load due to incorrect contextId resolution ([#192](https://github.com/Sitecore/content-sdk/pull/192))
-- `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))
+* `[nextjs]` Preserve default locale in external absolute urls ([#201](https://github.com/Sitecore/content-sdk/pull/201))
+* `[react]` Custom properties are not applied to empty field in editing mode ([#200](https://github.com/Sitecore/content-sdk/pull/200))
+* `[core]` Content styles fail to load due to incorrect contextId resolution ([#192](https://github.com/Sitecore/content-sdk/pull/192))
+* `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))
   - `SitecoreClient.getPreview` and `SitecoreClient.getDesignLibraryData` no longer request dictionary data. `Page` type is not affected.
   - Updated `EditingService.fetchEditingData`:
     - Removed `siteName` parameter.
     - No longer requests and returns dictionary data.
-- `[cli]` Code extraction extends XM Cloud Rendering Host build by several minutes ([#173](https://github.com/Sitecore/content-sdk/pull/173))
-- `[core]` Fix redirect regex processing to prevent over-escaping of question marks in regex patterns ([#174](https://github.com/Sitecore/content-sdk/pull/174))
+* `[cli]` Code extraction extends XM Cloud Rendering Host build by several minutes ([#173](https://github.com/Sitecore/content-sdk/pull/173))
+* `[core]` Fix redirect regex processing to prevent over-escaping of question marks in regex patterns ([#174](https://github.com/Sitecore/content-sdk/pull/174))
 
 ## 1.0.1
 
 ### 🐛 Bug Fixes
 
-- `[core]` `[nextjs]` Restore proper local connection fallback
-  - Added fallback to `middleware.ts` file to enable local API connections in the absence of `contextId`. ([#178](https://github.com/Sitecore/content-sdk/pull/178))([#180](https://github.com/Sitecore/content-sdk/pull/180))
+* `[core]` `[nextjs]` Restore proper local connection fallback 
+  * Added fallback to `middleware.ts` file to enable local API connections in the absence of `contextId`. ([#178](https://github.com/Sitecore/content-sdk/pull/178))([#180](https://github.com/Sitecore/content-sdk/pull/180))
 
 ## 1.0.0
 
 ### 🎉 New Features & Improvements
 
-- Design Library Early Access enablers:
-  - `[core]` `[nextjs]` Integrated new _VariantGeneration_ mode ([#158](https://github.com/Sitecore/content-sdk/pull/158))
-  - `[nextjs]` Default static import-map ([#153](https://github.com/Sitecore/content-sdk/pull/153))
-  - `[cli]` Code Extraction ([#71](https://github.com/Sitecore/content-sdk/pull/71))([#113](https://github.com/Sitecore/content-sdk/pull/113))([#114](https://github.com/Sitecore/content-sdk/pull/114))([#154](https://github.com/Sitecore/content-sdk/pull/154))
+* Design Library Early Access enablers:
+  * `[core]` `[nextjs]` Integrated new _VariantGeneration_ mode ([#158](https://github.com/Sitecore/content-sdk/pull/158))
+  * `[nextjs]` Default static import-map ([#153](https://github.com/Sitecore/content-sdk/pull/153))
+  * `[cli]` Code Extraction ([#71](https://github.com/Sitecore/content-sdk/pull/71))([#113](https://github.com/Sitecore/content-sdk/pull/113))([#114](https://github.com/Sitecore/content-sdk/pull/114))([#154](https://github.com/Sitecore/content-sdk/pull/154))
 
 ### 🛠 Breaking Changes
 
-- Refactored `SitecoreProvider` and enhanced `SitecoreClient` ([#158](https://github.com/Sitecore/content-sdk/pull/158)):
+* Refactored `SitecoreProvider` and enhanced `SitecoreClient` ([#158](https://github.com/Sitecore/content-sdk/pull/158)):
 
   #### Reworked `SitecoreProvider` and Context
 
@@ -92,19 +92,16 @@ Our versioning strategy is as follows:
   #### Improvements to `SitecoreClient`
 
   - **Type cleanup and consistency**:
-
     - Removed `NextjsPage` interface.
     - All methods that generate page data now return a consistent `Page` object.
     - Properties `componentProps` and `notFound` are now part of the `SitecorePageProps` interface and are treated as optional.
     - `SitecorePageProps` now requires a standalone `page` field instead of merging all data into one props object.
 
   - **New `getErrorPage()` method**:
-
     - Replaces `getErrorPages()`, exposing only necessary data.
     - Introduces a new `ErrorPage` enum to select specific error types (e.g., `ErrorPage.NotFound`)
-
+  
   - **New `PageMode` Type**
-
     - The `Page` type now includes a `mode` field of type `PageMode`, providing runtime context (e.g. editing, design library, preview).
     - Replaces older properties like `pageState`, `pageEditing`, `componentType`.
 
@@ -122,91 +119,87 @@ Our versioning strategy is as follows:
   - The `DesignLibrary` component no longer accepts a `layoutData` prop.
   - It now accesses `page` directly from `SitecoreProvider`.
 
-- Refactor and simplify service names ([#133](https://github.com/Sitecore/content-sdk/pull/133)):
+* Refactor and simplify service names ([#133](https://github.com/Sitecore/content-sdk/pull/133)):
 
   You will be affected by the following changes **only** if:
-
   - You are referencing Content SDK services directly rather than using the `SitecoreClient` methods.
 
   If you're using the `SitecoreClient` to access services, **no changes** are required.
 
   Service class and config names have been refactored for clarity and consistency:
 
-  - Renamed:
-    - `RestComponentLayoutService` → `ComponentLayoutService`
-    - `RestComponentLayoutServiceConfig` → `ComponentLayoutServiceConfig`
-    - `GraphQLEditingService` → `EditingService`
-    - `GraphQLEditingServiceConfig` → `EditingServiceConfig`
-    - `GraphQLDictionaryService` → `DictionaryService`
-    - `GraphQLDictionaryServiceConfig` → `DictionaryServiceConfig`
-    - `GraphQLLayoutService` → `LayoutService`
-    - `GraphQLLayoutServiceConfig` → `LayoutServiceConfig`
-    - `GraphQLPersonalizeService` → `PersonalizeService`
-    - `GraphQLPersonalizeServiceConfig` → `PersonalizeServiceConfig`
-    - `GraphQLErrorPagesService` → `ErrorPagesService`
-    - `GraphQLErrorPagesServiceConfig` → `ErrorPagesServiceConfig`
-    - `GraphQLRedirectsService` → `RedirectsService`
-    - `GraphQLRedirectsServiceConfig` → `RedirectsServiceConfig`
-    - `GraphQLRobotsService` → `RobotsService`
-    - `GraphQLRobotsServiceConfig` → `RobotsServiceConfig`
-    - `GraphQLSiteInfoService` → `SiteInfoService`
-    - `GraphQLSiteInfoServiceConfig` → `SiteInfoServiceConfig`
-    - `GraphQLSitemapXmlService` → `SitemapXmlService`
-    - `GraphQLSitemapXmlServiceConfig` → `SitemapXmlServiceConfig`
-    - `GraphQLSitePathService` → `SitePathService`
-    - `GraphQLSitePathServiceConfig` → `SitePathServiceConfig`
-  - Removed `DictionaryService` interface
-
-- `[core]` `[nextjs]` `[templates/nextjs]` Refactor site resolution logic across packages ([#141](https://github.com/Sitecore/content-sdk/pull/141))([#155](https://github.com/Sitecore/content-sdk/pull/155))
-  - Removed `sites` parameter from `SitecoreClientInit` type
-  - Removed `SiteResolver` dependency and `resolveSite()` from `SitecoreClient`
-  - Removed support for passing a custom siteResolver to `SitecoreClient`
-  - Updated `SitecoreClient` to construct the `Page` using `siteName` instead of the full `SiteInfo`.
-  - Updated SitecoreClient's `getPagePaths()` to accept a `sites` parameter
-  - Modified the `getPagePaths` method in `SitecoreClient` to accept a `sites` parameter.
-  - Updated Next.js `SitemapMiddleware` and `RobotsMiddleware` to use their own instance of `SiteResolver` and accept a `sites` parameter via the constructor.
+  * Renamed:
+    * `RestComponentLayoutService` → `ComponentLayoutService`
+    * `RestComponentLayoutServiceConfig` → `ComponentLayoutServiceConfig`
+    * `GraphQLEditingService` → `EditingService`
+    * `GraphQLEditingServiceConfig` → `EditingServiceConfig`
+    * `GraphQLDictionaryService` → `DictionaryService`
+    * `GraphQLDictionaryServiceConfig` → `DictionaryServiceConfig`
+    * `GraphQLLayoutService` → `LayoutService`
+    * `GraphQLLayoutServiceConfig` → `LayoutServiceConfig`
+    * `GraphQLPersonalizeService` → `PersonalizeService`
+    * `GraphQLPersonalizeServiceConfig` → `PersonalizeServiceConfig`
+    * `GraphQLErrorPagesService` → `ErrorPagesService`
+    * `GraphQLErrorPagesServiceConfig` → `ErrorPagesServiceConfig`
+    * `GraphQLRedirectsService` → `RedirectsService`
+    * `GraphQLRedirectsServiceConfig` → `RedirectsServiceConfig`
+    * `GraphQLRobotsService` → `RobotsService`
+    * `GraphQLRobotsServiceConfig` → `RobotsServiceConfig`
+    * `GraphQLSiteInfoService` → `SiteInfoService`
+    * `GraphQLSiteInfoServiceConfig` → `SiteInfoServiceConfig`
+    * `GraphQLSitemapXmlService` → `SitemapXmlService`
+    * `GraphQLSitemapXmlServiceConfig` → `SitemapXmlServiceConfig`
+    * `GraphQLSitePathService` → `SitePathService`
+    * `GraphQLSitePathServiceConfig` → `SitePathServiceConfig`
+  * Removed `DictionaryService` interface
+* `[core]` `[nextjs]` `[templates/nextjs]` Refactor site resolution logic across packages ([#141](https://github.com/Sitecore/content-sdk/pull/141))([#155](https://github.com/Sitecore/content-sdk/pull/155))
+  * Removed `sites` parameter from `SitecoreClientInit` type
+  * Removed `SiteResolver` dependency and `resolveSite()` from `SitecoreClient`
+  * Removed support for passing a custom siteResolver to `SitecoreClient`
+  * Updated `SitecoreClient` to construct the `Page` using `siteName` instead of the full `SiteInfo`.
+  * Updated SitecoreClient's `getPagePaths()` to accept a `sites` parameter
+  * Modified the `getPagePaths` method in `SitecoreClient` to accept a `sites` parameter.
+  * Updated Next.js `SitemapMiddleware` and `RobotsMiddleware` to use their own instance of `SiteResolver` and accept a `sites` parameter via the constructor.
 
 ### 🐛 Bug Fixes
 
-- `[nextjs]` Ensure Redirect Middleware handles case-insensitive path matching to prevent missed redirects due to casing differences ([#159](https://github.com/Sitecore/jss/pull/159))
-- `[core]` `[nextjs]`Standardized way of handling contextId/clientContextId and related fallbacks ([#150](https://github.com/Sitecore/content-sdk/pull/150))
+* `[nextjs]` Ensure Redirect Middleware handles case-insensitive path matching to prevent missed redirects due to casing differences ([#159](https://github.com/Sitecore/jss/pull/159))
+* `[core]` `[nextjs]`Standardized way of handling contextId/clientContextId and related fallbacks ([#150](https://github.com/Sitecore/content-sdk/pull/150))
 
 ### 🧹 Chores
 
-- Add Github action workflow to generate package size and test coverage metrics report ([#151](https://github.com/Sitecore/content-sdk/pull/151))
+* Add Github action workflow to generate package size and test coverage metrics report ([#151](https://github.com/Sitecore/content-sdk/pull/151))
 
 ## 0.3.0
 
 ### 🎉 New Features & Improvements
 
-- `[create-content-sdk-app]`: Refactoring/Cleanup for scss files in SXA components ([#119](https://github.com/Sitecore/content-sdk/pull/119))([#122](https://github.com/Sitecore/content-sdk/pull/122))
-- `[core]` `[nextjs]` [DesignLibrary] Include metadata in the Design Library rendering mechanism ([#118](https://github.com/Sitecore/content-sdk/pull/118))
-- `[core]` `[nextjs]` `[cli]` Add automatic component map generation ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#128](https://github.com/Sitecore/content-sdk/pull/128) [#130](https://github.com/Sitecore/content-sdk/pull/130))
-- `[create-sitecore-jss]` Remove graphql introspection sample and scripts folder from next starter application ([#135](https://github.com/Sitecore/content-sdk/pull/135))
-- `[core]` [Content SDK] Update environment variable naming and associated config property ([#143](https://github.com/Sitecore/content-sdk/pull/143))
+* `[create-content-sdk-app]`: Refactoring/Cleanup for scss files in SXA components ([#119](https://github.com/Sitecore/content-sdk/pull/119))([#122](https://github.com/Sitecore/content-sdk/pull/122))
+* `[core]` `[nextjs]` [DesignLibrary] Include metadata in the Design Library rendering mechanism ([#118](https://github.com/Sitecore/content-sdk/pull/118))
+* `[core]` `[nextjs]` `[cli]` Add automatic component map generation ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#128](https://github.com/Sitecore/content-sdk/pull/128) [#130](https://github.com/Sitecore/content-sdk/pull/130))
+* `[create-sitecore-jss]` Remove graphql introspection sample and scripts folder from next starter application ([#135](https://github.com/Sitecore/content-sdk/pull/135))
+* `[core]` [Content SDK] Update environment variable naming and associated config property ([#143](https://github.com/Sitecore/content-sdk/pull/143))
 
 ### 🛠 Breaking Changes
 
-- `[create-content-sdk-app]` Renamed package from `@sitecore-content-sdk/create-app` to `create-content-sdk-app` (unscoped package)
+* `[create-content-sdk-app]` Renamed package from `@sitecore-content-sdk/create-app` to `create-content-sdk-app` (unscoped package)
   - Users can now run `npx create-content-sdk-app` instead of `npx @sitecore-content-sdk/create-app`
   - Follows the same pattern as other popular initializers like `create-react-app` and `create-next-app`
-- `[all]` Renamed all JSS references to Content SDK across the codebase: ([#131](https://github.com/Sitecore/content-sdk/pull/131))
+* `[all]` Renamed all JSS references to Content SDK across the codebase: ([#131](https://github.com/Sitecore/content-sdk/pull/131))
   - The create-sitecore-jss package has been renamed to create-content-sdk-app (unscoped package)
   - Component types and props renamed:
     - `ReactJssComponent` → `ReactContentSdkComponent`
     - `NextJssComponent` → `NextjsContentSdkComponent`
-- `[react]` `[nextjs]` Refactor `SitecoreContext` naming to `SitecoreProvider` ([95](https://github.com/Sitecore/content-sdk/pull/95)):
+* `[react]` `[nextjs]` Refactor `SitecoreContext` naming to `SitecoreProvider` ([95](https://github.com/Sitecore/content-sdk/pull/95)):
 
   We've revisited and improved the `SitecoreContext` naming for clarity and consistency. This affects component names, types, hook, and HOC.
-
+  
   #### Component Renames
 
   - Component:
-
     - `SitecoreContext` → `SitecoreProvider`
 
   - Properties:
-
     - `context` property renamed to `pageContext` to clarify that it holds **page-specific data** only
 
   - Interfaces:
@@ -218,60 +211,57 @@ Our versioning strategy is as follows:
   #### Hook and HOC Renames
 
   - Functions:
-
-    - `withSitecoreContext` → `withSitecore`
-    - `useSitecoreContext` → `useSitecore`
+    - `withSitecoreContext` → `withSitecore`  
+    - `useSitecoreContext` → `useSitecore`  
 
   - Properties:
-
     - `updateSitecoreContext` property -> `updateContext`
-    - `sitecoreContext` property -> `pageContext`
+    - `sitecoreContext`  property -> `pageContext`
 
   - Interfaces:
     - `WithSitecoreContextOptions` → `WithSitecoreOptions`
     - `WithSitecoreContextProps` → `WithSitecoreProps`
     - `WithSitecoreContextHocProps` → `WithSitecoreHocProps`
-
-- `[nextjs]` Component-level `getServerSideProps` and `getStaticProps` methods have been replaced by a single `getComponentServerProps` method for simplicity.
-  - In case a separate logic is needed depending on SSR/SSG context, an `isServerSidePropsContext` helper method from `@sitecore-content-sdk/nextjs/utils` can now be used.
-- `[nextjs]` [DesignLibrary] Script is requested from production even when a custom Edge URL is set ([#98](https://github.com/Sitecore/content-sdk/pull/98)):
-  - The `EditingScripts` component doesn't accept `sitecoreEdgeUrl` property anymore.
-  - The custom Edge URL is now accessed via the `api` property of the `SitecoreProvider` component.
-- `[nextjs]` `defineCliConfig` import has been moved to `@sitecore-content-sdk/nextjs/config-cli` submodule ([#128](https://github.com/Sitecore/content-sdk/pull/128)).
-- `[core][nextjs][cli]` Re-introduce component map generation logic ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#139](https://github.com/Sitecore/content-sdk/pull/139))
-- `[create-content-sdk-app]` Remove SXA components and style files from default `nextjs` template ([#139](https://github.com/Sitecore/content-sdk/pull/139))
-- `[core]` `[nextjs]` `[templates/nextjs]` Environment variables' naming has been updated ([#143](https://github.com/Sitecore/content-sdk/pull/143))
-  - `JSS_EDITING_SECRET` → `SITECORE_EDITING_SECRET`
-  - `NEXT_PUBLIC_SITECORE_SITE_NAME` → `NEXT_PUBLIC_DEFAULT_SITE_NAME`
-  - `DISABLE_SSG_FETCH` → `GENERATE_STATIC_PATHS`
-  - `disableStaticPaths` config property → `generateStaticPaths` (with inverted logic for clarity)
+* `[nextjs]` Component-level `getServerSideProps` and `getStaticProps` methods have been replaced by a single `getComponentServerProps` method for simplicity.
+    * In case a separate logic is needed depending on SSR/SSG context, an `isServerSidePropsContext` helper method from `@sitecore-content-sdk/nextjs/utils` can now be used.
+* `[nextjs]` [DesignLibrary] Script is requested from production even when a custom Edge URL is set ([#98](https://github.com/Sitecore/content-sdk/pull/98)):
+  * The `EditingScripts` component doesn't accept `sitecoreEdgeUrl` property anymore.
+  * The custom Edge URL is now accessed via the `api` property of the `SitecoreProvider` component.
+* `[nextjs]` `defineCliConfig` import has been moved to `@sitecore-content-sdk/nextjs/config-cli` submodule ([#128](https://github.com/Sitecore/content-sdk/pull/128)).
+* `[core][nextjs][cli]` Re-introduce component map generation logic ([#124](https://github.com/Sitecore/content-sdk/pull/124) [#139](https://github.com/Sitecore/content-sdk/pull/139))
+* `[create-content-sdk-app]` Remove SXA components and style files from default `nextjs` template ([#139](https://github.com/Sitecore/content-sdk/pull/139))
+* `[core]` `[nextjs]` `[templates/nextjs]` Environment variables' naming has been updated ([#143](https://github.com/Sitecore/content-sdk/pull/143))
+  * `JSS_EDITING_SECRET` → `SITECORE_EDITING_SECRET`
+  * `NEXT_PUBLIC_SITECORE_SITE_NAME` → `NEXT_PUBLIC_DEFAULT_SITE_NAME`
+  * `DISABLE_SSG_FETCH` → `GENERATE_STATIC_PATHS`
+  * `disableStaticPaths` config property → `generateStaticPaths` (with inverted logic for clarity)
 
 ### 🐛 Bug Fixes
 
-- `[core]` Fix for enabling debug logs previously not appearing during build execution ([#137](https://github.com/Sitecore/content-sdk/pull/137))
-- `[core]` Fix for making clientContextId optional for client-side execution to avoid runtime errors ([#121](https://github.com/Sitecore/content-sdk/pull/121))
-- `[core]` `[sitecore.config]` Fallback values are not respected when framework specific value is empty & validate resolved config instead of base ([#97](https://github.com/Sitecore/content-sdk/pull/97))
-- `[nextjs]` Improve device detection and prevent false prefetch handling in Personalize middleware and also ensure personalized responses are not served from prefetch cache and proper personalization was applied during client side navigation. ([#129](https://github.com/Sitecore/content-sdk/pull/129))
-- `[react]` Suspense in ErrorBoundary component is not rendered when it is wrapping a BYOCWrapper to prevent client side hydration errors ([#132](https://github.com/Sitecore/content-sdk/pull/132))
-- `[nextjs]` Fix component-level data fetching method is exposed in client bundle ([#134](https://github.com/Sitecore/content-sdk/pull/134))
-- `[react]` Add an optional `disableSuspense` flag to the Placeholder component to prevent error boundaries from rendering Suspense which helps contain errors for components. This can help avoid hydration issues in connected mode. ([#96](https://github.com/Sitecore/content-sdk/pull/96))
+* `[core]` Fix for enabling debug logs previously not appearing during build execution ([#137](https://github.com/Sitecore/content-sdk/pull/137))
+* `[core]` Fix for making clientContextId optional for client-side execution to avoid runtime errors ([#121](https://github.com/Sitecore/content-sdk/pull/121))
+* `[core]` `[sitecore.config]` Fallback values are not respected when framework specific value is empty & validate resolved config instead of base ([#97](https://github.com/Sitecore/content-sdk/pull/97))
+* `[nextjs]` Improve device detection and prevent false prefetch handling in Personalize middleware and also ensure personalized responses are not served from prefetch cache and proper personalization was applied during client side navigation. ([#129](https://github.com/Sitecore/content-sdk/pull/129))
+* `[react]` Suspense in ErrorBoundary component is not rendered when it is wrapping a BYOCWrapper to prevent client side hydration errors ([#132](https://github.com/Sitecore/content-sdk/pull/132))
+* `[nextjs]` Fix component-level data fetching method is exposed in client bundle ([#134](https://github.com/Sitecore/content-sdk/pull/134))
+* `[react]` Add an optional `disableSuspense` flag to the Placeholder component to prevent error boundaries from rendering Suspense which helps contain errors for components. This can help avoid hydration issues in connected mode. ([#96](https://github.com/Sitecore/content-sdk/pull/96))
 
 ### 🧹 Chores
 
-- `[react]` Update feaas dependencies ([#149](https://github.com/Sitecore/content-sdk/pull/149))
+* `[react]` Update feaas dependencies ([#149](https://github.com/Sitecore/content-sdk/pull/149))
 
 ## 0.2.1
 
 ### 🎉 New Features & Improvements
 
-- `[core]` [DesignLibrary] Call partial layout rendering endpoint via Envoy and ContextID ([#111](https://github.com/Sitecore/content-sdk/pull/111))
+* `[core]` [DesignLibrary] Call partial layout rendering endpoint via Envoy and ContextID ([#111](https://github.com/Sitecore/content-sdk/pull/111))
 
 ## 0.2.0
 
 ### 🎉 New Features & Improvements
 
-- `[nextjs]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
-  - Introduced `.env.container.example`
+* `[nextjs]` Rework and simplify .env ([#89](https://github.com/Sitecore/content-sdk/pull/89)):
+  - Introduced `.env.container.example`  
     - Intended for local development against a Sitecore container instance.
   - Introduced `.env.remote.example`
     - Intended for working with a remote Sitecore instance.
@@ -280,37 +270,37 @@ Our versioning strategy is as follows:
   - Removed `GRAPH_QL_SERVICE_RETRIES` environment variable
     This is not environment-specific and should be defined in the configuration instead.
   - Removed `DISABLE_SSG_FETCH` environment variable
-    - In XM Cloud, this is set to `true` by default as the application runs as an editing host.
+    - In XM Cloud, this is set to `true` by default as the application runs as an editing host.  
     - It can still be configured via the `DISABLE_SSG_FETCH` environment variable or the `disableStaticPaths` config property if needed.
     - By default, it is set to `false` in the configuration.
-- `[core]` `[nextjs]` Introduced `getRobots` method in `SitecoreClient` and a new `RobotsMiddleware` for Next.js API routes ([#83](https://github.com/Sitecore/content-sdk/pull/83))
+* `[core]` `[nextjs]` Introduced `getRobots` method in `SitecoreClient` and a new `RobotsMiddleware` for Next.js API routes ([#83](https://github.com/Sitecore/content-sdk/pull/83))
   - The `getRobots(siteName, fetchOptions?)` method centralizes logic for fetching `robots.txt` content.
   - A new `RobotsMiddleware` class encapsulates HTTP-level logic for generating `robots.txt` responses in Next.js apps.
   - These additions follow the same extensible architecture as existing features enabling custom behavior via service overrides and improving consistency across endpoints.
-- `[cli]` Introduce "project" subcommands ([#73](https://github.com/Sitecore/content-sdk/pull/73))
-- `[nextjs]` Enhance customizability for Sitecore Client and SDK Middlwares ([#87](https://github.com/Sitecore/content-sdk/pull/87))
-- `[core]` `[nextjs]` `[create-content-sdk-app]` Passing configuration object to `defineConfig` in _sitecore.config_ is now optional. Introduced _sitecore.config.ts.example_ ([#90](https://github.com/Sitecore/content-sdk/pull/90)) ([#93](https://github.com/Sitecore/content-sdk/pull/93))
-- `[nextjs]` Starter kit components clean up ([#107](https://github.com/Sitecore/content-sdk/pull/107)):
+* `[cli]` Introduce "project" subcommands ([#73](https://github.com/Sitecore/content-sdk/pull/73))
+* `[nextjs]` Enhance customizability for Sitecore Client and SDK Middlwares ([#87](https://github.com/Sitecore/content-sdk/pull/87))
+* `[core]` `[nextjs]` `[create-content-sdk-app]` Passing configuration object to `defineConfig` in _sitecore.config_ is now optional. Introduced _sitecore.config.ts.example_ ([#90](https://github.com/Sitecore/content-sdk/pull/90)) ([#93](https://github.com/Sitecore/content-sdk/pull/93))
+* `[nextjs]` Starter kit components clean up ([#107](https://github.com/Sitecore/content-sdk/pull/107)):
   - Reduced code duplication
   - Streamlined the implementation to improve consistency
   - Removed outdated logic related to editing support
 
 ### 🛠 Breaking Changes
 
-- `[core]` SXA Form can't fire CloudSDK events due to initialization error ([#63](https://github.com/Sitecore/content-sdk/pull/63)):
-  - Form utilities have been moved from `@sitecore-content-sdk/core/form` to the root of `@sitecore-content-sdk/core`. Update your imports to reflect this change if you are referencing these utilities.
-- `[nextjs]` Update React to version 19 and Next JS to version 15 ([#76](https://github.com/Sitecore/content-sdk/pull/76))
+* `[core]` SXA Form can't fire CloudSDK events due to initialization error ([#63](https://github.com/Sitecore/content-sdk/pull/63)):
+  * Form utilities have been moved from `@sitecore-content-sdk/core/form` to the root of `@sitecore-content-sdk/core`. Update your imports to reflect this change if you are referencing these utilities.
+* `[nextjs]` Update React to version 19 and Next JS to version 15 ([#76](https://github.com/Sitecore/content-sdk/pull/76))
 
 ### 🐛 Bug Fixes
 
-- `[nextjs]` Fix for case sensitive redirects (make all redirects case-insensitive) ([#70](https://github.com/Sitecore/content-sdk/pull/70))
-- `[core]` Fix for lookbehind regex. (not supported on ios 16) ([#67](https://github.com/Sitecore/content-sdk/pull/67))
-- `[nextjs]` Render "unoptimized" Next Image in component rendering mode ([#66](https://github.com/Sitecore/content-sdk/pull/66))
-- `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))
-- `[cli]` Process env variables in both cli global and local mode by default. ([#61](https://github.com/Sitecore/content-sdk/pull/61))
-- `[react]` `[nextjs]` Do not render EditingScripts component in DesignLibrary component. Fix 'dataSourceId' query parameter name in editing render middleware. ([#64](https://github.com/Sitecore/content-sdk/pull/64))
+* `[nextjs]` Fix for case sensitive redirects (make all redirects case-insensitive) ([#70](https://github.com/Sitecore/content-sdk/pull/70))
+* `[core]` Fix for lookbehind regex. (not supported on ios 16) ([#67](https://github.com/Sitecore/content-sdk/pull/67))
+* `[nextjs]` Render "unoptimized" Next Image in component rendering mode ([#66](https://github.com/Sitecore/content-sdk/pull/66))
+* `[react]` Extend `withDatasourceCheck` logic to handle empty datasource in DesignLibrary mode ([#62](https://github.com/Sitecore/content-sdk/pull/62))
+* `[cli]` Process env variables in both cli global and local mode by default. ([#61](https://github.com/Sitecore/content-sdk/pull/61))
+* `[react]` `[nextjs]` Do not render EditingScripts component in DesignLibrary component. Fix 'dataSourceId' query parameter name in editing render middleware. ([#64](https://github.com/Sitecore/content-sdk/pull/64))
 
 ### 🧹 Chores
 
-- `[template/nextjs]` Clean package.json scripts ([#75](https://github.com/Sitecore/content-sdk/pull/75))
-- Upgrade 3rd party dependencies ([#88](https://github.com/Sitecore/content-sdk/pull/88)) ([#92](https://github.com/Sitecore/content-sdk/pull/92))
+* `[template/nextjs]` Clean package.json scripts ([#75](https://github.com/Sitecore/content-sdk/pull/75))
+* Upgrade 3rd party dependencies ([#88](https://github.com/Sitecore/content-sdk/pull/88)) ([#92](https://github.com/Sitecore/content-sdk/pull/92))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Our versioning strategy is as follows:
   * Base template ([#191](https://github.com/Sitecore/content-sdk/pull/191))
 * `[react]` Add `component:status` events for VariantGeneration ([#190](https://github.com/Sitecore/content-sdk/pull/190))
 
+### 🐛 Bug Fixes
+
+* `[nextjs]` Preserve default locale in external absolute urls ([#201](https://github.com/Sitecore/content-sdk/pull/201))
+
 ## 1.1.0
 
 ### 🎉 New Features & Improvements

--- a/packages/nextjs/src/components/Link.test.tsx
+++ b/packages/nextjs/src/components/Link.test.tsx
@@ -448,21 +448,27 @@ describe('<Link />', () => {
         metadata: testMetadata,
       };
 
-      const rendered = render(
+      const { container } = render(
         <Page>
           <Link field={field} />
         </Page>
       );
 
-      expect(rendered.container.innerHTML).to.equal(
-        [
-          `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
-            testMetadata
-          )}</code>`,
-          '<span data-react-link="true">[No text in field]</span>',
-          '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
-        ].join('')
-      );
+      // metadata wrappers exist
+      const codes = container.querySelectorAll('code.scpm');
+      expect(codes.length).to.equal(2);
+      expect(codes[0].getAttribute('type')).to.equal('text/sitecore');
+      expect(codes[0].getAttribute('chrometype')).to.equal('field');
+      expect(codes[0].getAttribute('kind')).to.equal('open');
+      expect(codes[1].getAttribute('kind')).to.equal('close');
+
+      // placeholder span
+      const span = container.querySelector('span');
+      expect(span).to.not.equal(null);
+      expect(span?.textContent).to.equal('[No text in field]');
+
+      // no anchor rendered
+      expect(container.querySelector('a')).to.equal(null);
     });
 
     it('should render default empty field component when field href is not present', () => {
@@ -471,21 +477,27 @@ describe('<Link />', () => {
         metadata: testMetadata,
       };
 
-      const rendered = render(
+      const { container } = render(
         <Page>
           <Link field={field} />
         </Page>
       );
 
-      expect(rendered.container.innerHTML).to.equal(
-        [
-          `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
-            testMetadata
-          )}</code>`,
-          '<span data-react-link="true">[No text in field]</span>',
-          '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
-        ].join('')
-      );
+      // metadata wrappers exist
+      const codes = container.querySelectorAll('code.scpm');
+      expect(codes.length).to.equal(2);
+      expect(codes[0].getAttribute('type')).to.equal('text/sitecore');
+      expect(codes[0].getAttribute('chrometype')).to.equal('field');
+      expect(codes[0].getAttribute('kind')).to.equal('open');
+      expect(codes[1].getAttribute('kind')).to.equal('close');
+
+      // placeholder span
+      const span = container.querySelector('span');
+      expect(span).to.not.equal(null);
+      expect(span?.textContent).to.equal('[No text in field]');
+
+      // no anchor rendered
+      expect(container.querySelector('a')).to.equal(null);
     });
 
     it('should render custom empty field component when provided, when field value href is not present', () => {

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -1715,9 +1715,11 @@ describe('RedirectsMiddleware', () => {
       });
 
       it('should not strip default locale from external absolute URLs', async () => {
+        const externalUrl = 'https://example.com/en/this-is-en';
         const cloneUrl = () => Object.assign({}, req.nextUrl);
+
         const url = {
-          href: 'https://example.com/en/this-is-en',
+          href: externalUrl,
           pathname: '/en/this-is-en',
           origin: 'https://example.com',
           locale: 'en',
@@ -1731,8 +1733,8 @@ describe('RedirectsMiddleware', () => {
             nextUrl: {
               pathname: '/ra',
               href: 'http://localhost:3000/ra',
-              locale: 'en-HK',
               origin: 'http://localhost:3000',
+              locale: 'en',
               clone: cloneUrl,
             },
           },
@@ -1741,30 +1743,18 @@ describe('RedirectsMiddleware', () => {
 
         setupRedirectStub(302);
 
-        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+        const { finalRes } = await runTestWithRedirect(
           {
             pattern: '/ra',
-            target: 'https://example.com/en/this-is-en',
+            target: externalUrl,
             redirectType: REDIRECT_TYPE_302,
             isQueryStringPreserved: false,
-            locale: 'en-HK',
+            locale: 'en',
           },
           req,
           res
         );
-
-        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {},
-          redirected: undefined,
-          status: 302,
-          url,
-        });
-
-        expect(siteResolver.getByHost).to.be.calledWith(hostname);
-        // eslint-disable-next-line no-unused-expressions
-        expect(fetchRedirects.called).to.be.true;
-        expect(finalRes.status).to.equal(302);
-        expect(finalRes.url).to.equal('https://example.com/en/this-is-en');
+        expect(finalRes.url).to.equal(externalUrl);
       });
     });
 

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -30,7 +30,41 @@ describe('RedirectsMiddleware', () => {
     expect(debugSpy.args.find((log) => log[0] === message)).to.deep.equal([message, ...params]);
   const validateEndMessageDebugLog = (message, params) => {
     const logParams = debugSpy.args.find((log) => log[0] === message) as Array<unknown>;
-    expect(logParams[2]).to.deep.equal(params);
+
+    const normalizeUrl = (u: any) => {
+      if (typeof u === 'string') return u;
+      if (u && typeof u === 'object') return typeof u.href === 'string' ? u.href : String(u);
+      return u;
+    };
+
+    const normalizeHeaders = (h: any) => {
+      if (!h) return h;
+      // Convert Headers -> plain object so deep-equal is stable
+      if (typeof Headers !== 'undefined' && h instanceof Headers) {
+        return Object.fromEntries(h.entries());
+      }
+      // In case something stringified to "[object Headers]"
+      if (h === '[object Headers]') return {};
+      return h;
+    };
+
+    const actual = { ...(logParams[2] as any) };
+    const expected = { ...(params as any) };
+
+    if ('url' in actual) actual.url = normalizeUrl(actual.url);
+    if ('url' in expected) expected.url = normalizeUrl(expected.url);
+
+    if ('headers' in actual) actual.headers = normalizeHeaders(actual.headers);
+    if ('headers' in expected) expected.headers = normalizeHeaders(expected.headers);
+
+    expect(actual).to.deep.equal(expected);
+  };
+
+  // Helper: stable comparison for NextResponse-like objects
+  const getHref = (r: any) => (typeof r?.url === 'string' ? r.url : r?.url?.href);
+  const expectNextResponseLike = (actual: any, expected: any) => {
+    expect(actual.status).to.equal(expected.status);
+    expect(getHref(actual)).to.equal(getHref(expected));
   };
 
   const referrer = 'http://localhost:3000';
@@ -1395,8 +1429,7 @@ describe('RedirectsMiddleware', () => {
 
         expect(siteResolver.getByHost).to.be.calledWith('localhost');
         expect(fetchRedirects).to.be.calledWith(siteName);
-        expect(finalRes).to.deep.equal(res);
-        expect(finalRes.status).to.equal(res.status);
+        expectNextResponseLike(finalRes, res);
       });
 
       it('custom fallback hostname is used', async () => {
@@ -1448,8 +1481,7 @@ describe('RedirectsMiddleware', () => {
 
         expect(siteResolver.getByHost).to.be.calledWith('foobar');
         expect(fetchRedirects).to.be.calledWith(siteName);
-        expect(finalRes).to.deep.equal(res);
-        expect(finalRes.status).to.equal(res.status);
+        expectNextResponseLike(finalRes, res);
       });
 
       it('should redirect, when next.config uses params trailingSlash is true', async () => {
@@ -1497,8 +1529,7 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
-        expect(finalRes.status).to.equal(res.status);
+        expectNextResponseLike(finalRes, res);
       });
 
       it('should redirect when the isQueryStringPreserved parameter is true and the target URL contains query string parameters', async () => {
@@ -1755,8 +1786,12 @@ describe('RedirectsMiddleware', () => {
           res
         );
 
-        const urlObj = finalRes.url as unknown as { href: string };
-        expect(urlObj.href).to.equal(externalUrl);
+        const urlVal =
+          typeof (finalRes as any).url === 'string'
+            ? (finalRes as any).url
+            : (finalRes as any).url?.href;
+
+        expect(urlVal).to.equal(externalUrl);
       });
     });
 

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -1714,7 +1714,7 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
-      it('should not strip default locale from external absolute URLs', async () => {
+      it('should not strip locale from external absolute URLs', async () => {
         const externalUrl = 'https://example.com/en/this-is-en';
         const cloneUrl = () => Object.assign({}, req.nextUrl);
 

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -60,13 +60,6 @@ describe('RedirectsMiddleware', () => {
     expect(actual).to.deep.equal(expected);
   };
 
-  // Helper: stable comparison for NextResponse-like objects
-  const getHref = (r: any) => (typeof r?.url === 'string' ? r.url : r?.url?.href);
-  const expectNextResponseLike = (actual: any, expected: any) => {
-    expect(actual.status).to.equal(expected.status);
-    expect(getHref(actual)).to.equal(getHref(expected));
-  };
-
   const referrer = 'http://localhost:3000';
   const hostname = 'foo.net';
   const siteName = 'nextjs-app';
@@ -582,7 +575,7 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
+        // less brittle than deep equal on different url shapes
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -624,8 +617,9 @@ describe('RedirectsMiddleware', () => {
           res
         );
 
+        // rewrite path -> expect our custom rewrite header
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {},
+          headers: { 'x-sc-rewrite': 'http://localhost:3000/found' },
           redirected: undefined,
           status: 200,
           url,
@@ -634,7 +628,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -677,7 +670,7 @@ describe('RedirectsMiddleware', () => {
         );
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {},
+          headers: { 'x-sc-rewrite': 'http://localhost:3000/found?abc=def' },
           redirected: undefined,
           status: 200,
           url,
@@ -686,7 +679,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -737,7 +729,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -829,7 +820,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -881,7 +871,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -934,7 +923,6 @@ describe('RedirectsMiddleware', () => {
         );
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -985,7 +973,6 @@ describe('RedirectsMiddleware', () => {
         );
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1038,7 +1025,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1089,7 +1075,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1141,7 +1126,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1429,7 +1413,7 @@ describe('RedirectsMiddleware', () => {
 
         expect(siteResolver.getByHost).to.be.calledWith('localhost');
         expect(fetchRedirects).to.be.calledWith(siteName);
-        expectNextResponseLike(finalRes, res);
+        expect(finalRes.status).to.equal(res.status);
       });
 
       it('custom fallback hostname is used', async () => {
@@ -1481,7 +1465,7 @@ describe('RedirectsMiddleware', () => {
 
         expect(siteResolver.getByHost).to.be.calledWith('foobar');
         expect(fetchRedirects).to.be.calledWith(siteName);
-        expectNextResponseLike(finalRes, res);
+        expect(finalRes.status).to.equal(res.status);
       });
 
       it('should redirect, when next.config uses params trailingSlash is true', async () => {
@@ -1529,7 +1513,7 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expectNextResponseLike(finalRes, res);
+        expect(finalRes.status).to.equal(res.status);
       });
 
       it('should redirect when the isQueryStringPreserved parameter is true and the target URL contains query string parameters', async () => {
@@ -1579,7 +1563,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1689,7 +1672,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1741,7 +1723,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1844,7 +1825,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1895,7 +1875,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1955,7 +1934,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -1754,7 +1754,9 @@ describe('RedirectsMiddleware', () => {
           req,
           res
         );
-        expect(finalRes.url).to.equal(externalUrl);
+
+        const urlObj = finalRes.url as unknown as { href: string };
+        expect(urlObj.href).to.equal(externalUrl);
       });
     });
 

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -1713,6 +1713,59 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
+
+      it('should not strip default locale from external absolute URLs', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'https://example.com/en/this-is-en',
+          pathname: '/en/this-is-en',
+          origin: 'https://example.com',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/ra',
+              href: 'http://localhost:3000/ra',
+              locale: 'en-HK',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 302,
+        });
+
+        setupRedirectStub(302);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: '/ra',
+            target: 'https://example.com/en/this-is-en',
+            redirectType: REDIRECT_TYPE_302,
+            isQueryStringPreserved: false,
+            locale: 'en-HK',
+          },
+          req,
+          res
+        );
+
+        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+          headers: {},
+          redirected: undefined,
+          status: 302,
+          url,
+        });
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(302);
+        expect(finalRes.url).to.equal('https://example.com/en/this-is-en');
+      });
     });
 
     describe('should redirect to normalized path when nextjs specific "path" query string parameter is provided', () => {

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -393,14 +393,7 @@ describe('RedirectsMiddleware', () => {
           headers: {},
           redirected: undefined,
           status: 301,
-          url: {
-            href: 'http://localhost:3000/custom-target',
-            pathname: '/custom-target',
-            origin: 'http://localhost:3000',
-            locale: 'en',
-            search: '',
-            clone: cloneUrl,
-          },
+          url,
         });
 
         expect(customRedirectsService.fetchRedirects).to.be.calledOnce;
@@ -1323,6 +1316,8 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByName).to.be.calledWith(site);
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.cookies.get('sc_site')?.value).to.equal(site);
+        // pass-through: ensure the same response instance is returned
+        expect(finalRes).to.deep.equal(res);
       });
 
       it('should preserve site name from response data when provided, if handler is disabled / skipped', async () => {
@@ -1363,6 +1358,8 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByName).to.not.be.called;
         expect(fetchRedirects.called).to.be.false;
         expect(finalRes.cookies.get('sc_site')?.value).to.equal(site);
+        // pass-through: ensure the same response instance is returned
+        expect(finalRes).to.deep.equal(res);
       });
 
       it('default fallback hostname is used', async () => {
@@ -1767,12 +1764,7 @@ describe('RedirectsMiddleware', () => {
           res
         );
 
-        const urlVal =
-          typeof (finalRes as any).url === 'string'
-            ? (finalRes as any).url
-            : (finalRes as any).url?.href;
-
-        expect(urlVal).to.equal(externalUrl);
+        expect(finalRes.url).to.equal(externalUrl);
       });
     });
 

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -343,7 +343,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
    * @param {string} type One of `REDIRECT_TYPE_301`, `REDIRECT_TYPE_302`, or `REDIRECT_TYPE_SERVER_TRANSFER`.
    * @param {NextRequest} req The incoming request.
    * @param {NextResponse} res The current response (used for header cleanup / carry-over).
-   * @param {boolean} [isExternal=false] Whether `target` is an external absolute URL.
+   * @param {boolean} isExternal Set to `true` when `target` is an external absolute URL (e.g. `https://…`).
    *   Passed through to `rewrite` so it can skip locale/basePath stripping for externals.
    * @returns {NextResponse} The redirect/rewrite response, or `res` if the type is not recognized.
    */
@@ -374,7 +374,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
 
   /**
    * Helper function to create a redirect response and remove the x-middleware-next header.
-   * @param {NextURL} url The URL to redirect to.
+   * @param {NextURL | string} url The URL to redirect to.
    * @param {Response} res The response object.
    * @param {number} status The HTTP status code of the redirect.
    * @param {string} statusText The status text of the redirect.

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -139,30 +139,19 @@ export class RedirectsMiddleware extends MiddlewareBase {
 
         // Redirect logic for external (absolute) URLS. To avoid locale stripping: use plain string for external URLs to prevent Next.js rewriting.
         if (REGEXP_ABSOLUTE_URL.test(existsRedirect.target)) {
-          switch (existsRedirect.redirectType) {
-            case REDIRECT_TYPE_301:
-              return this.createRedirectResponse(
-                existsRedirect.target,
-                res,
-                301,
-                'Moved Permanently'
-              );
-            case REDIRECT_TYPE_302:
-              return this.createRedirectResponse(existsRedirect.target, res, 302, 'Found');
-            case REDIRECT_TYPE_SERVER_TRANSFER:
-              return this.rewrite(existsRedirect.target, req, res, true);
-            default:
-              return res;
-          }
+          return this.dispatchRedirect(
+            existsRedirect.target,
+            existsRedirect.redirectType,
+            req,
+            res,
+            true
+          );
         } else {
           const isUrl = isRegexOrUrl(existsRedirect.pattern) === 'url';
           const targetParts = existsRedirect.target.split('/');
           const urlFirstPart = targetParts[1];
 
-          if (
-            !REGEXP_ABSOLUTE_URL.test(existsRedirect.target) &&
-            this.locales.includes(urlFirstPart)
-          ) {
+          if (this.locales.includes(urlFirstPart)) {
             req.nextUrl.locale = urlFirstPart;
             existsRedirect.target = existsRedirect.target.replace(`/${urlFirstPart}`, '');
           }
@@ -197,19 +186,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
         }
 
         /** return Response redirect with http code of redirect type */
-        switch (existsRedirect.redirectType) {
-          case REDIRECT_TYPE_301: {
-            return this.createRedirectResponse(url, res, 301, 'Moved Permanently');
-          }
-          case REDIRECT_TYPE_302: {
-            return this.createRedirectResponse(url, res, 302, 'Found');
-          }
-          case REDIRECT_TYPE_SERVER_TRANSFER: {
-            return this.rewrite(url.href, req, res, true);
-          }
-          default:
-            return res;
-        }
+        return this.dispatchRedirect(url, existsRedirect.redirectType, req, res, false);
       };
 
       const response = await createResponse();
@@ -358,6 +335,41 @@ export class RedirectsMiddleware extends MiddlewareBase {
     url.href = newUrl.href;
 
     return url;
+  }
+
+  /**
+   * Helper function to dispatch a redirect or rewrite based on the redirect type.
+   * @param {NextURL | string} target The final target to redirect/rewrite to.
+   * @param {string} type One of `REDIRECT_TYPE_301`, `REDIRECT_TYPE_302`, or `REDIRECT_TYPE_SERVER_TRANSFER`.
+   * @param {NextRequest} req The incoming request.
+   * @param {NextResponse} res The current response (used for header cleanup / carry-over).
+   * @param {boolean} [isExternal=false] Whether `target` is an external absolute URL.
+   *   Passed through to `rewrite` so it can skip locale/basePath stripping for externals.
+   * @returns {NextResponse} The redirect/rewrite response, or `res` if the type is not recognized.
+   */
+  protected dispatchRedirect(
+    target: NextURL | string,
+    type: string,
+    req: NextRequest,
+    res: NextResponse,
+    isExternal = false
+  ): NextResponse {
+    switch (type) {
+      case REDIRECT_TYPE_301:
+        return this.createRedirectResponse(target, res, 301, 'Moved Permanently');
+      case REDIRECT_TYPE_302:
+        return this.createRedirectResponse(target, res, 302, 'Found');
+      case REDIRECT_TYPE_SERVER_TRANSFER:
+        // rewrite expects a string; unwrap NextURL if needed
+        return this.rewrite(
+          typeof target === 'string' ? target : target.href,
+          req,
+          res,
+          isExternal
+        );
+      default:
+        return res;
+    }
   }
 
   /**

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -144,7 +144,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
           const targetParts = existsRedirect.target.split('/');
           const urlFirstPart = targetParts[1];
 
-          if (this.locales.includes(urlFirstPart)) {
+          if ( !REGEXP_ABSOLUTE_URL.test(existsRedirect.target) && this.locales.includes(urlFirstPart) ) {
             req.nextUrl.locale = urlFirstPart;
             existsRedirect.target = existsRedirect.target.replace(`/${urlFirstPart}`, '');
           }

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -137,14 +137,32 @@ export class RedirectsMiddleware extends MiddlewareBase {
 
         const url = this.normalizeUrl(req.nextUrl.clone());
 
+        // Redirect logic for external (absolute) URLS. To avoid locale stripping: use plain string for external URLs to prevent Next.js rewriting.
         if (REGEXP_ABSOLUTE_URL.test(existsRedirect.target)) {
-          url.href = existsRedirect.target;
+          switch (existsRedirect.redirectType) {
+            case REDIRECT_TYPE_301:
+              return this.createRedirectResponse(
+                existsRedirect.target,
+                res,
+                301,
+                'Moved Permanently'
+              );
+            case REDIRECT_TYPE_302:
+              return this.createRedirectResponse(existsRedirect.target, res, 302, 'Found');
+            case REDIRECT_TYPE_SERVER_TRANSFER:
+              return this.rewrite(existsRedirect.target, req, res, true);
+            default:
+              return res;
+          }
         } else {
           const isUrl = isRegexOrUrl(existsRedirect.pattern) === 'url';
           const targetParts = existsRedirect.target.split('/');
           const urlFirstPart = targetParts[1];
 
-          if ( !REGEXP_ABSOLUTE_URL.test(existsRedirect.target) && this.locales.includes(urlFirstPart) ) {
+          if (
+            !REGEXP_ABSOLUTE_URL.test(existsRedirect.target) &&
+            this.locales.includes(urlFirstPart)
+          ) {
             req.nextUrl.locale = urlFirstPart;
             existsRedirect.target = existsRedirect.target.replace(`/${urlFirstPart}`, '');
           }
@@ -351,7 +369,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
    * @returns {NextResponse<unknown>} The redirect response.
    */
   protected createRedirectResponse(
-    url: NextURL,
+    url: NextURL | string,
     res: Response | undefined,
     status: number,
     statusText: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fixes an issue where the default locale was stripped from external absolute URLs in redirects.

Example:
Before: `/en-hk/ra` → `https://example.com/this-is-en`
After: `/en-hk/ra` → `https://example.com/en/this-is-en`

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
