### PR TITLE
[nextjs] Preserve default locale in external absolute urls (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[nextjs]` Preserve default locale in external absolute urls ([#201](https://github.com/Sitecore/content-sdk/pull/201))
 * `[react]` Custom properties are not applied to empty field in editing mode ([#200](https://github.com/Sitecore/content-sdk/pull/200))
 * `[core]` Content styles fail to load due to incorrect contextId resolution ([#192](https://github.com/Sitecore/content-sdk/pull/192))
 * `[core]` Duplicate dictionary requests in editing, preview, and design library modes ([#161](https://github.com/Sitecore/content-sdk/pull/161))

--- a/packages/nextjs/src/components/Link.test.tsx
+++ b/packages/nextjs/src/components/Link.test.tsx
@@ -448,21 +448,27 @@ describe('<Link />', () => {
         metadata: testMetadata,
       };
 
-      const rendered = render(
+      const { container } = render(
         <Page>
           <Link field={field} />
         </Page>
       );
 
-      expect(rendered.container.innerHTML).to.equal(
-        [
-          `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
-            testMetadata
-          )}</code>`,
-          '<span data-react-link="true">[No text in field]</span>',
-          '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
-        ].join('')
-      );
+      // metadata wrappers exist
+      const codes = container.querySelectorAll('code.scpm');
+      expect(codes.length).to.equal(2);
+      expect(codes[0].getAttribute('type')).to.equal('text/sitecore');
+      expect(codes[0].getAttribute('chrometype')).to.equal('field');
+      expect(codes[0].getAttribute('kind')).to.equal('open');
+      expect(codes[1].getAttribute('kind')).to.equal('close');
+
+      // placeholder span
+      const span = container.querySelector('span');
+      expect(span).to.not.equal(null);
+      expect(span?.textContent).to.equal('[No text in field]');
+
+      // no anchor rendered
+      expect(container.querySelector('a')).to.equal(null);
     });
 
     it('should render default empty field component when field href is not present', () => {
@@ -471,21 +477,27 @@ describe('<Link />', () => {
         metadata: testMetadata,
       };
 
-      const rendered = render(
+      const { container } = render(
         <Page>
           <Link field={field} />
         </Page>
       );
 
-      expect(rendered.container.innerHTML).to.equal(
-        [
-          `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
-            testMetadata
-          )}</code>`,
-          '<span data-react-link="true">[No text in field]</span>',
-          '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
-        ].join('')
-      );
+      // metadata wrappers exist
+      const codes = container.querySelectorAll('code.scpm');
+      expect(codes.length).to.equal(2);
+      expect(codes[0].getAttribute('type')).to.equal('text/sitecore');
+      expect(codes[0].getAttribute('chrometype')).to.equal('field');
+      expect(codes[0].getAttribute('kind')).to.equal('open');
+      expect(codes[1].getAttribute('kind')).to.equal('close');
+
+      // placeholder span
+      const span = container.querySelector('span');
+      expect(span).to.not.equal(null);
+      expect(span?.textContent).to.equal('[No text in field]');
+
+      // no anchor rendered
+      expect(container.querySelector('a')).to.equal(null);
     });
 
     it('should render custom empty field component when provided, when field value href is not present', () => {

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -30,7 +30,34 @@ describe('RedirectsMiddleware', () => {
     expect(debugSpy.args.find((log) => log[0] === message)).to.deep.equal([message, ...params]);
   const validateEndMessageDebugLog = (message, params) => {
     const logParams = debugSpy.args.find((log) => log[0] === message) as Array<unknown>;
-    expect(logParams[2]).to.deep.equal(params);
+
+    const normalizeUrl = (u: any) => {
+      if (typeof u === 'string') return u;
+      if (u && typeof u === 'object') return typeof u.href === 'string' ? u.href : String(u);
+      return u;
+    };
+
+    const normalizeHeaders = (h: any) => {
+      if (!h) return h;
+      // Convert Headers -> plain object so deep-equal is stable
+      if (typeof Headers !== 'undefined' && h instanceof Headers) {
+        return Object.fromEntries(h.entries());
+      }
+      // In case something stringified to "[object Headers]"
+      if (h === '[object Headers]') return {};
+      return h;
+    };
+
+    const actual = { ...(logParams[2] as any) };
+    const expected = { ...(params as any) };
+
+    if ('url' in actual) actual.url = normalizeUrl(actual.url);
+    if ('url' in expected) expected.url = normalizeUrl(expected.url);
+
+    if ('headers' in actual) actual.headers = normalizeHeaders(actual.headers);
+    if ('headers' in expected) expected.headers = normalizeHeaders(expected.headers);
+
+    expect(actual).to.deep.equal(expected);
   };
 
   const referrer = 'http://localhost:3000';
@@ -366,14 +393,7 @@ describe('RedirectsMiddleware', () => {
           headers: {},
           redirected: undefined,
           status: 301,
-          url: {
-            href: 'http://localhost:3000/custom-target',
-            pathname: '/custom-target',
-            origin: 'http://localhost:3000',
-            locale: 'en',
-            search: '',
-            clone: cloneUrl,
-          },
+          url,
         });
 
         expect(customRedirectsService.fetchRedirects).to.be.calledOnce;
@@ -548,7 +568,7 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
+        // less brittle than deep equal on different url shapes
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -590,8 +610,9 @@ describe('RedirectsMiddleware', () => {
           res
         );
 
+        // rewrite path -> expect our custom rewrite header
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {},
+          headers: { 'x-sc-rewrite': 'http://localhost:3000/found' },
           redirected: undefined,
           status: 200,
           url,
@@ -600,7 +621,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -643,7 +663,7 @@ describe('RedirectsMiddleware', () => {
         );
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {},
+          headers: { 'x-sc-rewrite': 'http://localhost:3000/found?abc=def' },
           redirected: undefined,
           status: 200,
           url,
@@ -652,7 +672,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -703,7 +722,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -795,7 +813,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -847,7 +864,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -900,7 +916,6 @@ describe('RedirectsMiddleware', () => {
         );
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -951,7 +966,6 @@ describe('RedirectsMiddleware', () => {
         );
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1004,7 +1018,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1055,7 +1068,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1107,7 +1119,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1305,6 +1316,8 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByName).to.be.calledWith(site);
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.cookies.get('sc_site')?.value).to.equal(site);
+        // pass-through: ensure the same response instance is returned
+        expect(finalRes).to.deep.equal(res);
       });
 
       it('should preserve site name from response data when provided, if handler is disabled / skipped', async () => {
@@ -1345,6 +1358,8 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByName).to.not.be.called;
         expect(fetchRedirects.called).to.be.false;
         expect(finalRes.cookies.get('sc_site')?.value).to.equal(site);
+        // pass-through: ensure the same response instance is returned
+        expect(finalRes).to.deep.equal(res);
       });
 
       it('default fallback hostname is used', async () => {
@@ -1395,7 +1410,6 @@ describe('RedirectsMiddleware', () => {
 
         expect(siteResolver.getByHost).to.be.calledWith('localhost');
         expect(fetchRedirects).to.be.calledWith(siteName);
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1448,7 +1462,6 @@ describe('RedirectsMiddleware', () => {
 
         expect(siteResolver.getByHost).to.be.calledWith('foobar');
         expect(fetchRedirects).to.be.calledWith(siteName);
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1497,7 +1510,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1548,7 +1560,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1658,7 +1669,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1710,8 +1720,51 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
+      });
+
+      it('should not strip locale from external absolute URLs', async () => {
+        const externalUrl = 'https://example.com/en/this-is-en';
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+
+        const url = {
+          href: externalUrl,
+          pathname: '/en/this-is-en',
+          origin: 'https://example.com',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/ra',
+              href: 'http://localhost:3000/ra',
+              origin: 'http://localhost:3000',
+              locale: 'en',
+              clone: cloneUrl,
+            },
+          },
+          status: 302,
+        });
+
+        setupRedirectStub(302);
+
+        const { finalRes } = await runTestWithRedirect(
+          {
+            pattern: '/ra',
+            target: externalUrl,
+            redirectType: REDIRECT_TYPE_302,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(finalRes.url).to.equal(externalUrl);
       });
     });
 
@@ -1764,7 +1817,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1815,7 +1867,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 
@@ -1875,7 +1926,6 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
       });
 

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -137,8 +137,15 @@ export class RedirectsMiddleware extends MiddlewareBase {
 
         const url = this.normalizeUrl(req.nextUrl.clone());
 
+        // Redirect logic for external (absolute) URLS. To avoid locale stripping: use plain string for external URLs to prevent Next.js rewriting.
         if (REGEXP_ABSOLUTE_URL.test(existsRedirect.target)) {
-          url.href = existsRedirect.target;
+          return this.dispatchRedirect(
+            existsRedirect.target,
+            existsRedirect.redirectType,
+            req,
+            res,
+            true
+          );
         } else {
           const isUrl = isRegexOrUrl(existsRedirect.pattern) === 'url';
           const targetParts = existsRedirect.target.split('/');
@@ -179,19 +186,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
         }
 
         /** return Response redirect with http code of redirect type */
-        switch (existsRedirect.redirectType) {
-          case REDIRECT_TYPE_301: {
-            return this.createRedirectResponse(url, res, 301, 'Moved Permanently');
-          }
-          case REDIRECT_TYPE_302: {
-            return this.createRedirectResponse(url, res, 302, 'Found');
-          }
-          case REDIRECT_TYPE_SERVER_TRANSFER: {
-            return this.rewrite(url.href, req, res, true);
-          }
-          default:
-            return res;
-        }
+        return this.dispatchRedirect(url, existsRedirect.redirectType, req, res, false);
       };
 
       const response = await createResponse();
@@ -343,15 +338,50 @@ export class RedirectsMiddleware extends MiddlewareBase {
   }
 
   /**
+   * Helper function to dispatch a redirect or rewrite based on the redirect type.
+   * @param {NextURL | string} target The final target to redirect/rewrite to.
+   * @param {string} type One of `REDIRECT_TYPE_301`, `REDIRECT_TYPE_302`, or `REDIRECT_TYPE_SERVER_TRANSFER`.
+   * @param {NextRequest} req The incoming request.
+   * @param {NextResponse} res The current response (used for header cleanup / carry-over).
+   * @param {boolean} isExternal Set to `true` when `target` is an external absolute URL (e.g. `https://…`).
+   *   Passed through to `rewrite` so it can skip locale/basePath stripping for externals.
+   * @returns {NextResponse} The redirect/rewrite response, or `res` if the type is not recognized.
+   */
+  protected dispatchRedirect(
+    target: NextURL | string,
+    type: string,
+    req: NextRequest,
+    res: NextResponse,
+    isExternal = false
+  ): NextResponse {
+    switch (type) {
+      case REDIRECT_TYPE_301:
+        return this.createRedirectResponse(target, res, 301, 'Moved Permanently');
+      case REDIRECT_TYPE_302:
+        return this.createRedirectResponse(target, res, 302, 'Found');
+      case REDIRECT_TYPE_SERVER_TRANSFER:
+        // rewrite expects a string; unwrap NextURL if needed
+        return this.rewrite(
+          typeof target === 'string' ? target : target.href,
+          req,
+          res,
+          isExternal
+        );
+      default:
+        return res;
+    }
+  }
+
+  /**
    * Helper function to create a redirect response and remove the x-middleware-next header.
-   * @param {NextURL} url The URL to redirect to.
+   * @param {NextURL | string} url The URL to redirect to.
    * @param {Response} res The response object.
    * @param {number} status The HTTP status code of the redirect.
    * @param {string} statusText The status text of the redirect.
    * @returns {NextResponse<unknown>} The redirect response.
    */
   protected createRedirectResponse(
-    url: NextURL,
+    url: NextURL | string,
     res: Response | undefined,
     status: number,
     statusText: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR cherry-picks the redirects fix for locale omission in absolute URLs  from `dev` into the `release/1.x.x` branch to include the upcoming release line

Related PR: https://github.com/Sitecore/content-sdk/pull/201

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
