### PR TITLE
[Chore] Enhance Jira Issue Creation Logic by Skipping the Creation for Admin and Maintainer PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Our versioning strategy is as follows:
 * `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
 * `[react]` `[core]` Unite capabilities of library | library-metadata with library-variant-generation modes. `isVariantGeneration` is honored only when `isDesignLibrary`(library | library-metadata) is true and `generation=variant` query string is passed to the editing render endpoint. ([#208](https://github.com/Sitecore/content-sdk/pull/208))
 
+### 🧹 Chores
+*  Enhance Jira issue creation logic by skipping the creation for admin and maintainer PRs ([#211](https://github.com/Sitecore/content-sdk/pull/211))
+
 ## 1.1.0
 
 ### 🎉 New Features & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ Our versioning strategy is as follows:
 * `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
 * `[react]` `[core]` Unite capabilities of library | library-metadata with library-variant-generation modes. `isVariantGeneration` is honored only when `isDesignLibrary`(library | library-metadata) is true and `generation=variant` query string is passed to the editing render endpoint. ([#208](https://github.com/Sitecore/content-sdk/pull/208))
 
-### 🧹 Chores
-*  Enhance Jira issue creation logic by skipping the creation for admin and maintainer PRs ([#211](https://github.com/Sitecore/content-sdk/pull/211))
-
 ## 1.1.0
 
 ### 🎉 New Features & Improvements

--- a/scripts/create-jira-issue.js
+++ b/scripts/create-jira-issue.js
@@ -71,8 +71,6 @@ const JIRA_ISSUE_TYPE = Object.freeze([
     process.exit(1);
   }
 
-  console.log('userInfoRes:', JSON.stringify(userInfoRes, null, 2));
-
   // don't create Jira issue if PR is created by admin or maintainer
   if (
     github.event.pull_request &&

--- a/scripts/create-jira-issue.js
+++ b/scripts/create-jira-issue.js
@@ -71,6 +71,8 @@ const JIRA_ISSUE_TYPE = Object.freeze([
     process.exit(1);
   }
 
+  console.log('userInfoRes:', JSON.stringify(userInfoRes, null, 2));
+
   // don't create Jira issue if PR is created by admin
   if (github.event.pull_request && userInfoRes.permission === 'admin') {
     console.log('Skipped Jira issue creation. The Pull Request was created by admin user.');

--- a/scripts/create-jira-issue.js
+++ b/scripts/create-jira-issue.js
@@ -72,15 +72,12 @@ const JIRA_ISSUE_TYPE = Object.freeze([
   }
 
   // don't create Jira issue if PR is created by admin or maintainer
-  if (
-    github.event.pull_request &&
-    userInfoRes.user &&
-    (userInfoRes.user.permissions?.admin === true ||
-      userInfoRes.user.permissions?.maintain === true)
-  ) {
-    console.log(
-      'Skipped Jira issue creation. The Pull Request was created by admin or maintainer user.'
-    );
+if (
+  github.event.pull_request &&
+  (userInfoRes.user?.permissions?.admin || userInfoRes.user?.permissions?.maintain)
+) {
+  console.log('Skipping Jira issue creation: PR author is admin/maintainer.');
+}
     return;
   }
 

--- a/scripts/create-jira-issue.js
+++ b/scripts/create-jira-issue.js
@@ -73,9 +73,16 @@ const JIRA_ISSUE_TYPE = Object.freeze([
 
   console.log('userInfoRes:', JSON.stringify(userInfoRes, null, 2));
 
-  // don't create Jira issue if PR is created by admin
-  if (github.event.pull_request && userInfoRes.permission === 'admin') {
-    console.log('Skipped Jira issue creation. The Pull Request was created by admin user.');
+  // don't create Jira issue if PR is created by admin or maintainer
+  if (
+    github.event.pull_request &&
+    userInfoRes.user &&
+    (userInfoRes.user.permissions?.admin === true ||
+      userInfoRes.user.permissions?.maintain === true)
+  ) {
+    console.log(
+      'Skipped Jira issue creation. The Pull Request was created by admin or maintainer user.'
+    );
     return;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR updates the Jira issue creation script to prevent automatic Jira issue creation for pull requests submitted by users with admin or maintainer permissions. The check now inspects the userInfoRes.user.permissions object and skips Jira issue creation if either admin or maintain is set to true. This helps avoid unnecessary Jira tickets for privileged users.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
