### PR TITLE
[nextjs] Normalize import-map keys from absolute paths to relative paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Our versioning strategy is as follows:
 * `[nextjs]` Support component-level data fetching in 404/500 pages ([#199](https://github.com/Sitecore/content-sdk/pull/199))
 * Migration from ESlint 8 -> ESLint 9 and introduction of the new Flat Config file ([#176](https://github.com/Sitecore/content-sdk/pull/176))
 * Code generation for Design Library enablers:
-  - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157))([#167](https://github.com/Sitecore/content-sdk/pull/167))([#170](https://github.com/Sitecore/content-sdk/pull/170))([#171](https://github.com/Sitecore/content-sdk/pull/171))([#175](https://github.com/Sitecore/content-sdk/pull/175))([#177](https://github.com/Sitecore/content-sdk/pull/177))([#187](https://github.com/Sitecore/content-sdk/pull/187))
+  - `[core]` `[nextjs]` Add import-map generation ([#157](https://github.com/Sitecore/content-sdk/pull/157))([#167](https://github.com/Sitecore/content-sdk/pull/167))([#170](https://github.com/Sitecore/content-sdk/pull/170))([#171](https://github.com/Sitecore/content-sdk/pull/171))([#175](https://github.com/Sitecore/content-sdk/pull/175))([#177](https://github.com/Sitecore/content-sdk/pull/177))([#187](https://github.com/Sitecore/content-sdk/pull/187)) ([#221](https://github.com/Sitecore/content-sdk/pull/221))
     - New `writeImportMap()`, `combineImportEntries()` methods and `defaultImportEntries` export available from `@sitecore-content-sdk/nextjs/codegen`
   - Dynamic component rendering ([#163](https://github.com/Sitecore/content-sdk/pull/163))
   - Updated API endpoint to new Edge Platform format ([#162](https://github.com/Sitecore/content-sdk/pull/162))

--- a/packages/nextjs/src/tools/codegen/import-map.test.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.test.ts
@@ -14,7 +14,7 @@ import sinon from 'sinon';
 import path from 'path';
 import fs from 'fs';
 
-describe.only('Import Map Generation', () => {
+describe('Import Map Generation', () => {
   describe('getImportMap', () => {
     const sandbox = sinon.createSandbox();
     let cwdStub: sinon.SinonStub;

--- a/packages/nextjs/src/tools/codegen/import-map.test.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.test.ts
@@ -14,7 +14,7 @@ import sinon from 'sinon';
 import path from 'path';
 import fs from 'fs';
 
-describe('Import Map Generation', () => {
+describe.only('Import Map Generation', () => {
   describe('getImportMap', () => {
     const sandbox = sinon.createSandbox();
     let cwdStub: sinon.SinonStub;
@@ -39,7 +39,7 @@ describe('Import Map Generation', () => {
     beforeEach(() => {
       const appFolder = path.resolve(process.cwd(), './src/tools/codegen/test-data/import-map');
       cwdStub = sandbox.stub(process, 'cwd').returns(appFolder);
-      testExportsModulePath = path.resolve(process.cwd(), 'test-exports').replace(/\\/g, '/');
+      testExportsModulePath = 'test-exports';
     });
 
     afterEach(() => {
@@ -68,12 +68,10 @@ describe('Import Map Generation', () => {
 
     it('should return map with named imports when tsconfig paths is used (ts-path-alias.ts)', () => {
       const result = getImportMap(['single-file-imports/ts-path-alias.ts']);
-      testExportsModulePath = path
-        .resolve(process.cwd(), 'ts-path-alias/test-path-exports')
-        .replace(/\\/g, '/');
+
       const expected = [
         {
-          module: testExportsModulePath,
+          module: '@pathed/test-path-exports',
           namedImports: [{ name: 'pathedVariable', value: 'pathedVariable' }],
           defaultImport: null,
           namespaceImport: null,
@@ -199,18 +197,18 @@ describe('Import Map Generation', () => {
     });
 
     it('should return map from multi-file imports with duplicate mixed exports', () => {
+      const reactSpecifier = 'react';
+      const fakeReactSpecifier = 'fake-react';
+      const testExports2Specifier = 'test-exports-2';
+      const testExportsSpecifier = 'test-exports';
+
       cwdStub.restore();
-      const testFakeReactImportModule = path
-        .resolve(process.cwd(), './src/tools/codegen/test-data/import-map/fake-react')
-        .replace(/\\/g, '/');
-      const testDuplicateImportModulePath = path
-        .resolve(process.cwd(), './src/tools/codegen/test-data/import-map/test-exports-2')
-        .replace(/\\/g, '/');
       const multiFileFolder = path.resolve(
         process.cwd(),
         './src/tools/codegen/test-data/import-map'
       );
       cwdStub = sandbox.stub(process, 'cwd').returns(multiFileFolder);
+
       const result = getImportMap([
         'multi-file-imports/A.tsx',
         'multi-file-imports/B.tsx',
@@ -218,42 +216,44 @@ describe('Import Map Generation', () => {
         'multi-file-imports/D.tsx',
         'multi-file-imports/E.tsx',
       ]);
+
       const expected = [
         {
-          module: 'react',
+          module: reactSpecifier,
           defaultImport: 'React',
           namedImports: [{ name: 'useEffect', value: 'useEffect' }],
-          namespaceImport: getImportValueAlias('React', 'react', 'namespace'),
+          namespaceImport: getImportValueAlias('React', reactSpecifier, 'namespace'),
         },
         {
-          module: testDuplicateImportModulePath,
+          module: testExports2Specifier,
           namedImports: [{ name: 'testClassInstance', value: 'testClassInstance' }],
           defaultImport: null,
           namespaceImport: null,
         },
         {
-          module: testFakeReactImportModule,
-          defaultImport: getImportValueAlias('React', testFakeReactImportModule, 'default'),
-          namespaceImport: getImportValueAlias('React', testFakeReactImportModule, 'namespace'),
+          module: fakeReactSpecifier,
+          defaultImport: getImportValueAlias('React', fakeReactSpecifier, 'default'),
+          namespaceImport: getImportValueAlias('React', fakeReactSpecifier, 'namespace'),
           namedImports: [
             {
               name: 'useEffect',
-              value: getImportValueAlias('useEffect', testFakeReactImportModule, 'named'),
+              value: getImportValueAlias('useEffect', fakeReactSpecifier, 'named'),
             },
           ],
         },
         {
-          module: testExportsModulePath,
+          module: testExportsSpecifier,
           namedImports: [
             {
               name: 'testClassInstance',
-              value: getImportValueAlias('testClassInstance', testExportsModulePath, 'named'),
+              value: getImportValueAlias('testClassInstance', testExportsSpecifier, 'named'),
             },
           ],
           defaultImport: 'testExportsDefault',
           namespaceImport: null,
         },
       ];
+
       expect(convertToTestable(result)).to.deep.equal(expected);
     });
   });

--- a/packages/nextjs/src/tools/codegen/import-map.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.ts
@@ -5,7 +5,7 @@ import { debug } from '@sitecore-content-sdk/core';
 import { getComponentList } from '@sitecore-content-sdk/core/tools';
 import { SitecoreConfig } from '@sitecore-content-sdk/core/config';
 import crypto from 'crypto';
-import { isBare, stripExtension, toAppSpecifier, toPosix } from './utils';
+import { isNodeModuleImport, stripExtension, getRelativeImportPath, toPosixPath } from './utils';
 
 let _getComponentList = getComponentList;
 const aliasImport = /^([a-zA-Z0-9]+) as .+$/;
@@ -204,22 +204,22 @@ export const getImportMap = (paths: string[]) => {
 
         let importModuleName: string;
 
-        // if import path points to a file in local app - process import path to the file (i.e. ./myComponent)
-        // if it points to node_modules or a file in monorepo - parse import path as dependency module name (i.e. React)
         if (
           resolvedImportPath.includes('node_modules') ||
           resolvedImportPath.endsWith('.d.ts') ||
-          !toPosix(resolvedImportPath).startsWith(toPosix(appPath) + '/')
+          !toPosixPath(resolvedImportPath).startsWith(toPosixPath(appPath) + '/')
         ) {
+          // if import path points to a file in local app - process import path to the file (i.e. ./myComponent)
+          // if it points to node_modules or a file in monorepo - parse import path as dependency module name (i.e. React)
           // external dependency → keep as-is
-          importModuleName = isBare(moduleName)
+          importModuleName = isNodeModuleImport(moduleName)
             ? stripExtension(moduleName)
-            : toAppSpecifier(resolvedImportPath, appPath);
+            : getRelativeImportPath(resolvedImportPath, appPath);
         } else {
           // local file
-          importModuleName = isBare(moduleName)
+          importModuleName = isNodeModuleImport(moduleName)
             ? stripExtension(moduleName)
-            : toAppSpecifier(resolvedImportPath, appPath);
+            : getRelativeImportPath(resolvedImportPath, appPath);
         }
 
         // Set module import info in the map. If module import exists - add entries to existing entry

--- a/packages/nextjs/src/tools/codegen/import-map.ts
+++ b/packages/nextjs/src/tools/codegen/import-map.ts
@@ -5,6 +5,7 @@ import { debug } from '@sitecore-content-sdk/core';
 import { getComponentList } from '@sitecore-content-sdk/core/tools';
 import { SitecoreConfig } from '@sitecore-content-sdk/core/config';
 import crypto from 'crypto';
+import { isBare, stripExtension, toAppSpecifier, toPosix } from './utils';
 
 let _getComponentList = getComponentList;
 const aliasImport = /^([a-zA-Z0-9]+) as .+$/;
@@ -179,6 +180,11 @@ export const getImportMap = (paths: string[]) => {
     ts.forEachChild(jsCodeSource, (childNode) => {
       if (ts.isImportDeclaration(childNode) && childNode.importClause) {
         const imports = getImportedValues(childNode);
+
+        if (!imports) {
+          return;
+        }
+
         // import path is extracted
         const moduleName = childNode.moduleSpecifier.getText().replace(/['"]/g, '');
         const resolvedModule = ts.nodeModuleNameResolver(
@@ -187,75 +193,92 @@ export const getImportMap = (paths: string[]) => {
           cliCompilerOptions,
           tsHost
         );
+
         // get import path and check if its import target exists
         const resolvedImportPath = resolvedModule?.resolvedModule?.resolvedFileName;
-        if (resolvedImportPath && imports) {
-          // if import path points to a file in local app - process import path to the file (i.e. ./myComponent)
-          // if it points to node_modules or a file in monorepo - parse import path as dependency module name (i.e. React)
-          const importModuleName =
-            resolvedImportPath.indexOf('node_modules') > -1 || resolvedImportPath.endsWith('.d.ts')
-              ? moduleName
-              : resolvedImportPath.replace(/\.[a-zA-Z]{2,4}$/, ''); // remove file extension
-          // Set module import info in the map. If module import exists - add entries to existing entry
-          // Otherwise, add new entry
-          if (!importMap.has(importModuleName)) {
-            importMap.set(importModuleName, {
-              namedExports: new Map(),
-              defaultExport: null,
-              namespaceExport: null,
-            });
-          }
 
-          const moduleEntry = importMap.get(importModuleName);
-
-          imports.named.forEach((importEntry) => {
-            const sameModuleNamedAlready = moduleEntry!.namedExports.has(importEntry);
-
-            if (sameModuleNamedAlready) {
-              return;
-            }
-
-            const nameTaken = importsList.includes(importEntry);
-
-            const importValue = nameTaken
-              ? getImportValueAlias(importEntry, importModuleName, 'named')
-              : importEntry;
-
-            moduleEntry!.namedExports.set(importEntry, importValue);
-            importsList.push(importEntry);
-          });
-          if (imports.namespace) {
-            const sameModuleNamedAlready = moduleEntry!.namespaceExport;
-
-            if (sameModuleNamedAlready) {
-              return;
-            }
-
-            const nameTaken = importsList.includes(imports.namespace);
-            const importValue = nameTaken
-              ? getImportValueAlias(imports.namespace, importModuleName, 'namespace')
-              : imports.namespace;
-
-            moduleEntry!.namespaceExport = importValue;
-            importsList.push(importValue);
-          }
-          if (imports.default) {
-            const sameModuleNamedAlready = moduleEntry!.defaultExport;
-
-            if (sameModuleNamedAlready) {
-              return;
-            }
-
-            const nameTaken = importsList.includes(imports.default);
-            const importValue = nameTaken
-              ? getImportValueAlias(imports.default, importModuleName, 'default')
-              : imports.default;
-
-            moduleEntry!.defaultExport = importValue;
-            importsList.push(importValue);
-          }
-        } else {
+        if (!resolvedImportPath) {
           console.warn('[Codegen] Could not resolve a file for import %s', moduleName);
+          return;
+        }
+
+        let importModuleName: string;
+
+        // if import path points to a file in local app - process import path to the file (i.e. ./myComponent)
+        // if it points to node_modules or a file in monorepo - parse import path as dependency module name (i.e. React)
+        if (
+          resolvedImportPath.includes('node_modules') ||
+          resolvedImportPath.endsWith('.d.ts') ||
+          !toPosix(resolvedImportPath).startsWith(toPosix(appPath) + '/')
+        ) {
+          // external dependency → keep as-is
+          importModuleName = isBare(moduleName)
+            ? stripExtension(moduleName)
+            : toAppSpecifier(resolvedImportPath, appPath);
+        } else {
+          // local file
+          importModuleName = isBare(moduleName)
+            ? stripExtension(moduleName)
+            : toAppSpecifier(resolvedImportPath, appPath);
+        }
+
+        // Set module import info in the map. If module import exists - add entries to existing entry
+        // Otherwise, add new entry
+        if (!importMap.has(importModuleName)) {
+          importMap.set(importModuleName, {
+            namedExports: new Map(),
+            defaultExport: null,
+            namespaceExport: null,
+          });
+        }
+
+        const moduleEntry = importMap.get(importModuleName);
+
+        imports.named.forEach((importEntry) => {
+          const sameModuleNamedAlready = moduleEntry!.namedExports.has(importEntry);
+
+          if (sameModuleNamedAlready) {
+            return;
+          }
+
+          const nameTaken = importsList.includes(importEntry);
+
+          const importValue = nameTaken
+            ? getImportValueAlias(importEntry, importModuleName, 'named')
+            : importEntry;
+
+          moduleEntry!.namedExports.set(importEntry, importValue);
+          importsList.push(importEntry);
+        });
+        if (imports.namespace) {
+          const sameModuleNamedAlready = moduleEntry!.namespaceExport;
+
+          if (sameModuleNamedAlready) {
+            return;
+          }
+
+          const nameTaken = importsList.includes(imports.namespace);
+          const importValue = nameTaken
+            ? getImportValueAlias(imports.namespace, importModuleName, 'namespace')
+            : imports.namespace;
+
+          moduleEntry!.namespaceExport = importValue;
+          importsList.push(importValue);
+        }
+        if (imports.default) {
+          const sameModuleNamedAlready = moduleEntry!.defaultExport;
+
+          if (sameModuleNamedAlready) {
+            return;
+          }
+
+          const nameTaken = importsList.includes(imports.default);
+          const importValue = nameTaken
+            ? getImportValueAlias(imports.default, importModuleName, 'default')
+            : imports.default;
+
+          moduleEntry!.defaultExport = importValue;
+          importsList.push(importValue);
         }
       }
     });
@@ -367,9 +390,9 @@ export const nextJsMapTemplate = (indexedImportMap: Map<string, ModuleExports>) 
 // Below are built-in Content SDK imports neccessary for the import map
 import { combineImportEntries, defaultImportEntries } from '@sitecore-content-sdk/nextjs/codegen';
 // end of built-in imports
-  
+
 ${importStatements.join('\n')}
-    
+
 const importMap = [
 ${finalImportMap
   .map((entry) =>

--- a/packages/nextjs/src/tools/codegen/utils.test.ts
+++ b/packages/nextjs/src/tools/codegen/utils.test.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import nock from 'nock';
 import fs from 'fs';
 import * as codegenUtils from './utils';
+import { toPosixPath, stripExtension, getRelativeImportPath, isNodeModuleImport } from './utils';
 
 describe('codegen-utils', () => {
   const sandbox = sinon.createSandbox();
@@ -331,6 +332,70 @@ describe('codegen-utils', () => {
 
     it('should return false when not in a recognized build context', () => {
       expect(codegenUtils.validateDeployContext()).to.be.false;
+    });
+  });
+
+  describe('Path & Import Utils', () => {
+    describe('toPosixPath', () => {
+      it('converts backslashes to forward slashes', () => {
+        expect(toPosixPath('C:\\repo\\app\\src\\index.ts')).to.equal('C:/repo/app/src/index.ts');
+        expect(toPosixPath('some\\nested\\dir')).to.equal('some/nested/dir');
+      });
+      it('leaves forward slashes unchanged', () => {
+        expect(toPosixPath('C:/repo/app/src/index.ts')).to.equal('C:/repo/app/src/index.ts');
+        expect(toPosixPath('some/nested/dir')).to.equal('some/nested/dir');
+      });
+    });
+
+    describe('stripExtension', () => {
+      it('removes supported script extensions', () => {
+        expect(stripExtension('file.ts')).to.equal('file');
+        expect(stripExtension('file.tsx')).to.equal('file');
+        expect(stripExtension('file.js')).to.equal('file');
+        expect(stripExtension('file.jsx')).to.equal('file');
+        expect(stripExtension('file.mjs')).to.equal('file');
+        expect(stripExtension('file.cjs')).to.equal('file');
+      });
+
+      it('leaves other extensions unchanged', () => {
+        expect(stripExtension('file.json')).to.equal('file.json');
+        expect(stripExtension('styles.css')).to.equal('styles.css');
+        expect(stripExtension('archive.tar.gz')).to.equal('archive.tar.gz');
+      });
+
+      it('only strips the final extension', () => {
+        expect(stripExtension('lib/utils/index.tsx')).to.equal('lib/utils/index');
+      });
+    });
+
+    describe('getRelativeImportPath', () => {
+      it('returns POSIX, extensionless path relative to app root', () => {
+        const appRoot = path.resolve('/repo/app');
+        const absFile = path.resolve(appRoot, 'src', 'components', 'Button.tsx');
+        const rel = getRelativeImportPath(absFile, appRoot);
+        expect(rel).to.equal('src/components/Button');
+      });
+
+      it('normalizes separators regardless of OS', () => {
+        const appRoot = path.resolve('/repo/app');
+        const absFile = path.resolve(appRoot, 'lib', 'utils', 'index.mjs');
+        const rel = getRelativeImportPath(absFile, appRoot);
+        expect(rel).to.equal('lib/utils/index');
+      });
+    });
+
+    describe('isNodeModuleImport', () => {
+      it('returns true for package names and alias-like specifiers', () => {
+        ['react', '@scope/pkg', 'components/Button', '#internal', 'somePkg'].forEach((s) =>
+          expect(isNodeModuleImport(s), s).to.equal(true)
+        );
+      });
+
+      it('returns false for relative and absolute specifiers', () => {
+        ['./x', '../x', '/abs/path'].forEach((s) =>
+          expect(isNodeModuleImport(s), s).to.equal(false)
+        );
+      });
     });
   });
 });

--- a/packages/nextjs/src/tools/codegen/utils.ts
+++ b/packages/nextjs/src/tools/codegen/utils.ts
@@ -246,16 +246,15 @@ export const sendCode = async ({
 };
 
 // Normalize path separators to POSIX-style "/" for cross-platform consistency.
-export const toPosix = (p: string) => p.replace(/\\/g, '/');
+export const toPosixPath = (p: string) => p.replace(/\\/g, '/');
 export const stripExtension = (p: string) => p.replace(/\.(tsx?|jsx?|mjs|cjs)$/, '');
 
-// Convert an absolute file path into an app-relative module specifier (POSIX), optionally stripping a leading "src/".
-export const toAppSpecifier = (absFile: string, appPath: string) => {
-  let rel = toPosix(path.relative(appPath, absFile));
-  if (rel.startsWith('src/')) rel = rel.slice(4);
+// Convert an absolute file path into an relative module specifier (POSIX)
+export const getRelativeImportPath = (absFile: string, appPath: string) => {
+  let rel = toPosixPath(path.relative(appPath, absFile));
   return stripExtension(rel);
 };
 
 // Determine if a specifier is bare/aliased (i.e., not relative "./" or "../" and not absolute "/").
-export const isBare = (name: string) =>
+export const isNodeModuleImport = (name: string) =>
   !name.startsWith('./') && !name.startsWith('../') && !name.startsWith('/');

--- a/packages/nextjs/src/tools/codegen/utils.ts
+++ b/packages/nextjs/src/tools/codegen/utils.ts
@@ -244,3 +244,18 @@ export const sendCode = async ({
   }
   return file.path;
 };
+
+// Normalize path separators to POSIX-style "/" for cross-platform consistency.
+export const toPosix = (p: string) => p.replace(/\\/g, '/');
+export const stripExtension = (p: string) => p.replace(/\.(tsx?|jsx?|mjs|cjs)$/, '');
+
+// Convert an absolute file path into an app-relative module specifier (POSIX), optionally stripping a leading "src/".
+export const toAppSpecifier = (absFile: string, appPath: string) => {
+  let rel = toPosix(path.relative(appPath, absFile));
+  if (rel.startsWith('src/')) rel = rel.slice(4);
+  return stripExtension(rel);
+};
+
+// Determine if a specifier is bare/aliased (i.e., not relative "./" or "../" and not absolute "/").
+export const isBare = (name: string) =>
+  !name.startsWith('./') && !name.startsWith('../') && !name.startsWith('/');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR fixes a path mismatch where the import-map stored absolute build paths (e.g. /workspace/tmp/builds/...) that don’t exist causing “Missing module …” at runtime.
We now:
 - Keep external deps as-is (e.g. react).
 - For local files:
    • keep bare/aliased specifiers (e.g. components/…), stripping extension.
    • convert relative imports to app-relative specifiers via `toAppSpecifier`, normalizing slashes.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
