### PR TITLE
[core][nextjs] Implementation of separate component map for app router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Our versioning strategy is as follows:
   - Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
   - Editing and preview support ([#198](https://github.com/Sitecore/content-sdk/pull/198))
   - Internationalization support ([#202](https://github.com/Sitecore/content-sdk/pull/202)) ([#214](https://github.com/Sitecore/content-sdk/pull/214))
+  - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))
 
 ## 1.1.0
 

--- a/packages/core/src/tools/generate-map.ts
+++ b/packages/core/src/tools/generate-map.ts
@@ -1,4 +1,4 @@
-import { ComponentFile, ComponentImport } from './templating';
+import { ComponentFile, ComponentImport, RouterType } from './templating';
 
 export type GenerateMapFunction = (args: GenerateMapArgs) => void;
 
@@ -17,4 +17,5 @@ export type GenerateMapArgs = {
   componentImports?: ComponentImport[];
   exclude?: string[];
   mapTemplate?: (components: ComponentFile[], componentImports?: ComponentImport[]) => string;
+  routerType?: RouterType;
 };

--- a/packages/core/src/tools/generate-map.ts
+++ b/packages/core/src/tools/generate-map.ts
@@ -1,4 +1,4 @@
-import { ComponentFile, ComponentImport, RouterType } from './templating';
+import { ComponentFile, ComponentImport, ComponentFileWithType } from './templating';
 
 export type GenerateMapFunction = (args: GenerateMapArgs) => void;
 
@@ -9,13 +9,16 @@ export type GenerateMapFunction = (args: GenerateMapArgs) => void;
  * @property {string} [destination='src/.sitecore'] - Destination folder path for the generated map.
  * @property {ComponentImport[]} [componentImports] - Optional array of package definitions for component imports to include in the map.
  * @property {string[]} [exclude] - Optional array of glob paths to exclude from the map.
- * @property {Function} [mapTemplate] - Optional custom template function to generate the component map content.
+ * @property {Function} [mapTemplate] - Optional custom template function to generate the main component map content.
+ * @property {Function} [clientMapTemplate] - Optional custom template function to generate the client component map content (only used when clientComponentMap is true).
+ * @property {boolean} [clientComponentMap] - Optional flag to generate separate client and server component maps. When true, generates both component-map.ts (all components) and component-map.client.ts (client + universal only). When false or undefined, generates single component-map.ts (traditional behavior).
  */
 export type GenerateMapArgs = {
   paths: string[];
   destination?: string;
   componentImports?: ComponentImport[];
   exclude?: string[];
-  mapTemplate?: (components: ComponentFile[], componentImports?: ComponentImport[]) => string;
-  routerType?: RouterType;
+  mapTemplate?: (components: ComponentFile[] | ComponentFileWithType[], componentImports?: ComponentImport[]) => string;
+  clientMapTemplate?: (components: ComponentFileWithType[], componentImports?: ComponentImport[]) => string;
+  clientComponentMap?: boolean;
 };

--- a/packages/core/src/tools/templating/components.test.ts
+++ b/packages/core/src/tools/templating/components.test.ts
@@ -1,9 +1,17 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { getComponentList } from './components';
-import { ComponentFile } from '../../../tools';
+import {
+  getComponentList,
+  detectComponentType,
+  getComponentListWithTypes,
+  filterComponentsByType,
+  detectRouterType,
+} from './components';
+import { ComponentFile, ComponentFileWithType } from './components';
+import * as componentsModule from './components';
 import path from 'path';
+import fs from 'fs';
 
 describe('components', () => {
   const sandbox = sinon.createSandbox();
@@ -235,6 +243,240 @@ describe('components', () => {
       expect(result).to.deep.equal(expected);
 
       globSyncStub.restore();
+    });
+  });
+
+  describe('detectComponentType', () => {
+    let readFileSyncStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      readFileSyncStub = sandbox.stub(fs, 'readFileSync');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should detect client component from use client directive at top', () => {
+      readFileSyncStub.returns(`'use client';
+export default function ClientComponent() {
+  return <button>Client</button>;
+}`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('client');
+    });
+
+    it('should detect client component with comments before directive', () => {
+      readFileSyncStub.returns(`/**
+ * This is a client component
+ */
+'use client';
+export default function CommentedClient() {
+  return <button>Client</button>;
+}`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('client');
+    });
+
+    it('should NOT detect use client after imports', () => {
+      readFileSyncStub.returns(`import React from 'react';
+'use client';
+export default function InvalidClient() {
+  return <div>Should be universal</div>;
+}`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('universal');
+    });
+
+    it('should NOT detect use client in string literals', () => {
+      readFileSyncStub.returns(`export default function FakeClient() {
+  const directive = 'use client';
+  return <div>Contains: {directive}</div>;
+}`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('universal');
+    });
+
+    it('should detect server component from explicit export', () => {
+      readFileSyncStub.returns(`export default function ServerComponent() {
+  return <div>Server</div>;
+}
+export const componentType: 'server' = 'server';`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('server');
+    });
+
+    it('should detect client component from explicit export', () => {
+      readFileSyncStub.returns(`export default function ClientComponent() {
+  return <div>Client</div>;
+}
+export const componentType: 'client' = 'client';`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('client');
+    });
+
+    it('should detect universal component from explicit export', () => {
+      readFileSyncStub.returns(`export default function UniversalComponent() {
+  return <div>Universal</div>;
+}
+export const componentType: 'universal' = 'universal';`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('universal');
+    });
+
+    it('should detect server component from server-only imports', () => {
+      readFileSyncStub.returns(`import { headers } from 'next/headers';
+export default function HeadersComponent() {
+  return <div>Has server imports</div>;
+}`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('server');
+    });
+
+    it('should prioritize explicit export over use client directive', () => {
+      readFileSyncStub.returns(`'use client';
+export default function OverrideComponent() {
+  return <div>Override</div>;
+}
+export const componentType: 'server' = 'server';`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('server');
+    });
+
+    it('should default to universal for plain components', () => {
+      readFileSyncStub.returns(`export default function PlainComponent() {
+  return <div>Plain component</div>;
+}`);
+
+      const result = detectComponentType('test.tsx');
+      expect(result).to.equal('universal');
+    });
+
+    it('should handle file read errors gracefully', () => {
+      readFileSyncStub.throws(new Error('File not found'));
+
+      const result = detectComponentType('nonexistent.tsx');
+      expect(result).to.equal('universal');
+    });
+  });
+
+  describe('detectRouterType', () => {
+    let existsSyncStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      existsSyncStub = sandbox.stub(fs, 'existsSync');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should detect App Router when src/app exists', () => {
+      existsSyncStub.callsFake((pathStr: string) => pathStr.includes('src/app'));
+
+      const result = detectRouterType();
+      expect(result).to.equal('app');
+    });
+
+    it('should detect App Router when app exists', () => {
+      existsSyncStub.callsFake(
+        (pathStr: string) => pathStr.includes('/app') && !pathStr.includes('src')
+      );
+
+      const result = detectRouterType();
+      expect(result).to.equal('app');
+    });
+
+    it('should detect Pages Router when src/pages exists', () => {
+      existsSyncStub.callsFake((pathStr: string) => pathStr.includes('src/pages'));
+
+      const result = detectRouterType();
+      expect(result).to.equal('pages');
+    });
+
+    it('should default to Pages Router when neither exists', () => {
+      existsSyncStub.returns(false);
+
+      const result = detectRouterType();
+      expect(result).to.equal('pages');
+    });
+  });
+
+  describe('filterComponentsByType', () => {
+    const mockComponents: ComponentFileWithType[] = [
+      {
+        filePath: 'client.tsx',
+        importPath: './client',
+        moduleName: 'ClientComp',
+        componentName: 'ClientComp',
+        componentType: 'client',
+      },
+      {
+        filePath: 'server.tsx',
+        importPath: './server',
+        moduleName: 'ServerComp',
+        componentName: 'ServerComp',
+        componentType: 'server',
+      },
+      {
+        filePath: 'universal.tsx',
+        importPath: './universal',
+        moduleName: 'UniversalComp',
+        componentName: 'UniversalComp',
+        componentType: 'universal',
+      },
+    ];
+
+    it('should filter components by single type', () => {
+      const result = filterComponentsByType(mockComponents, ['client']);
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].componentType).to.equal('client');
+    });
+
+    it('should filter components by multiple types', () => {
+      const result = filterComponentsByType(mockComponents, ['client', 'universal']);
+      expect(result).to.have.lengthOf(2);
+      expect(result.map((c) => c.componentType)).to.include.members(['client', 'universal']);
+    });
+
+    it('should return empty array when no matches', () => {
+      const result = filterComponentsByType(mockComponents, ['nonexistent' as any]);
+      expect(result).to.be.empty;
+    });
+
+    it('should return all components when all types specified', () => {
+      const result = filterComponentsByType(mockComponents, ['client', 'server', 'universal']);
+      expect(result).to.have.lengthOf(3);
+    });
+  });
+
+  describe('getComponentListWithTypes', () => {
+    it('should combine component list with type detection', () => {
+      // Use actual test data files that exist in the project
+      const result = getComponentListWithTypes(['src/test-data/components/*.tsx']);
+
+      // Verify that the result includes components with detected types
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.greaterThan(0);
+
+      // Each component should have the required properties including componentType
+      result.forEach((component) => {
+        expect(component).to.have.property('filePath');
+        expect(component).to.have.property('importPath');
+        expect(component).to.have.property('moduleName');
+        expect(component).to.have.property('componentName');
+        expect(component).to.have.property('componentType');
+        expect(['client', 'server', 'universal']).to.include(component.componentType);
+      });
     });
   });
 });

--- a/packages/core/src/tools/templating/components.test.ts
+++ b/packages/core/src/tools/templating/components.test.ts
@@ -9,7 +9,6 @@ import {
   detectRouterType,
 } from './components';
 import { ComponentFile, ComponentFileWithType } from './components';
-import * as componentsModule from './components';
 import path from 'path';
 import fs from 'fs';
 

--- a/packages/core/src/tools/templating/components.ts
+++ b/packages/core/src/tools/templating/components.ts
@@ -171,7 +171,7 @@ export function detectComponentType(filePath: string): ComponentType {
       // Check for explicit componentType export (improved detection)
       if (ts.isVariableStatement(node)) {
         const hasExportModifier = node.modifiers?.some(
-          (modifier: ts.Modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+          (modifier: ts.ModifierLike) => modifier.kind === ts.SyntaxKind.ExportKeyword
         );
 
         if (hasExportModifier) {

--- a/packages/core/src/tools/templating/components.ts
+++ b/packages/core/src/tools/templating/components.ts
@@ -1,8 +1,12 @@
 import * as glob from 'glob';
+import * as fs from 'fs';
 
 const componentNamePattern = /^[\/]*(.+[\/\\])*(.+)\.[jt]sx?$/;
 
 const componentPathPattern = /^([\/]*.+[\/\\].+)\..+$/;
+
+export type ComponentType = 'server' | 'client' | 'universal';
+export type RouterType = 'app' | 'pages';
 
 /**
  * Describes a file that represents a component definition
@@ -17,6 +21,11 @@ export interface ComponentFile {
   importPath: string;
   moduleName: string;
   componentName: string;
+  componentType?: ComponentType;
+}
+
+export interface ComponentFileWithType extends ComponentFile {
+  componentType: ComponentType;
 }
 
 /**
@@ -71,4 +80,67 @@ export function getComponentList(paths: string[], exclude?: string[]): Component
   }, []);
 
   return components;
+}
+
+export function detectRouterType(projectRoot: string = process.cwd()): RouterType {
+  const appDirExists =
+    fs.existsSync(`${projectRoot}/src/app`) || fs.existsSync(`${projectRoot}/app`);
+  const pagesDirExists =
+    fs.existsSync(`${projectRoot}/src/pages`) || fs.existsSync(`${projectRoot}/pages`);
+
+  if (appDirExists) {
+    return 'app';
+  }
+
+  if (pagesDirExists) {
+    return 'pages';
+  }
+
+  return 'pages';
+}
+
+export function detectComponentType(filePath: string): ComponentType {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // Check for 'use client' directive
+    if (content.includes("'use client'") || content.includes('"use client"')) {
+      return 'client';
+    }
+
+    // Check for explicit componentType export
+    const componentTypeMatch = content.match(
+      /export\s+const\s+componentType\s*[:=]\s*['"`](\w+)['"`]/
+    );
+    if (componentTypeMatch) {
+      const type = componentTypeMatch[1] as ComponentType;
+      if (type === 'server' || type === 'client' || type === 'universal') {
+        return type;
+      }
+    }
+
+    // Default to universal if no explicit indicators
+    return 'universal';
+  } catch {
+    return 'universal';
+  }
+}
+
+export function getComponentListWithTypes(
+  paths: string[],
+  exclude?: string[]
+): ComponentFileWithType[] {
+  const components = getComponentList(paths, exclude);
+
+  return components.map((component) => ({
+    ...component,
+    componentType: detectComponentType(component.filePath),
+  }));
+}
+
+export function filterComponentsByType(
+  components: ComponentFileWithType[],
+  allowedTypes: ComponentType[]
+): ComponentFileWithType[] {
+  return components.filter((component) => allowedTypes.includes(component.componentType));
 }

--- a/packages/core/src/tools/templating/components.ts
+++ b/packages/core/src/tools/templating/components.ts
@@ -1,5 +1,6 @@
 import * as glob from 'glob';
-import * as fs from 'fs';
+import fs from 'fs';
+import * as ts from 'typescript';
 
 const componentNamePattern = /^[\/]*(.+[\/\\])*(.+)\.[jt]sx?$/;
 
@@ -65,8 +66,8 @@ export function getComponentList(paths: string[], exclude?: string[]): Component
     return result.concat(
       ...glob
         .sync(globPath, { ignore: exclude, nodir: true })
-        .filter((path) => path.match(componentNamePattern))
-        .map((filePath) => {
+        .filter((path: string) => path.match(componentNamePattern))
+        .map((filePath: string) => {
           const name = filePath.match(componentNamePattern)![2];
           console.debug(`Registering Content SDK component ${name}`);
           return {
@@ -103,25 +104,137 @@ export function detectComponentType(filePath: string): ComponentType {
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
 
-    // Check for 'use client' directive
-    if (content.includes("'use client'") || content.includes('"use client"')) {
+    // Parse using TypeScript AST (following patterns from import-map.ts and utils.ts)
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      content,
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    let hasUseClientDirective = false;
+    let explicitComponentType: ComponentType | null = null;
+    let hasServerOnlyImports = false;
+
+    // Track position to ensure directives come before imports/other statements
+    let foundFirstNonDirectiveStatement = false;
+
+    // Helper function to check if a node is a valid directive
+    const isValidDirective = (node: ts.Node): boolean => {
+      return (
+        ts.isExpressionStatement(node) &&
+        ts.isStringLiteral(node.expression) &&
+        !foundFirstNonDirectiveStatement
+      );
+    };
+
+    // More comprehensive AST traversal (following patterns from import-map.ts and utils.ts)
+    const traverseNode = (node: ts.Node) => {
+      // Check for 'use client'/'use server' directives (must be at top, before imports)
+      if (isValidDirective(node) && ts.isStringLiteral((node as ts.ExpressionStatement).expression)) {
+        const directiveText = ((node as ts.ExpressionStatement).expression as ts.StringLiteral).text;
+        if (directiveText === 'use client') {
+          hasUseClientDirective = true;
+          return; // Don't mark as non-directive statement
+        }
+        if (directiveText === 'use server') {
+          explicitComponentType = 'server';
+          return; // Don't mark as non-directive statement
+        }
+      }
+
+      // Mark that we've seen a non-directive statement (imports, declarations, etc.)
+      if (ts.isImportDeclaration(node) || ts.isVariableStatement(node) || ts.isFunctionDeclaration(node) || ts.isExportDeclaration(node) || ts.isExportAssignment(node)) {
+        foundFirstNonDirectiveStatement = true;
+      }
+
+      // Check for import declarations with server-only modules
+      if (ts.isImportDeclaration(node)) {
+        const moduleSpecifier = node.moduleSpecifier;
+        if (ts.isStringLiteral(moduleSpecifier)) {
+          const importPath = moduleSpecifier.text;
+          // Expand server-only module detection
+          if (
+            importPath === 'next/headers' ||
+            importPath === 'server-only' ||
+            importPath === 'next/cache' ||
+            importPath === 'next/cookies' ||
+            importPath.startsWith('node:') ||
+            importPath === 'fs' ||
+            importPath === 'path'
+          ) {
+            hasServerOnlyImports = true;
+          }
+        }
+      }
+
+      // Check for explicit componentType export (improved detection)
+      if (ts.isVariableStatement(node)) {
+        const hasExportModifier = node.modifiers?.some(
+          (modifier: ts.Modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+        );
+
+        if (hasExportModifier) {
+          node.declarationList.declarations.forEach((declaration: ts.VariableDeclaration) => {
+            if (
+              ts.isIdentifier(declaration.name) &&
+              declaration.name.text === 'componentType' &&
+              declaration.initializer
+            ) {
+              // Handle string literal
+              if (ts.isStringLiteral(declaration.initializer)) {
+                const typeValue = declaration.initializer.text as ComponentType;
+                if (typeValue === 'server' || typeValue === 'client' || typeValue === 'universal') {
+                  explicitComponentType = typeValue;
+                }
+              }
+              // Handle template literal (e.g., `client`)
+              else if (ts.isNoSubstitutionTemplateLiteral(declaration.initializer)) {
+                const typeValue = declaration.initializer.text as ComponentType;
+                if (typeValue === 'server' || typeValue === 'client' || typeValue === 'universal') {
+                  explicitComponentType = typeValue;
+                }
+              }
+            }
+          });
+        }
+      }
+
+      // Check for named export of componentType (export const componentType = ...)
+      if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+        node.exportClause.elements.forEach((exportSpecifier: ts.ExportSpecifier) => {
+          if (exportSpecifier.name.text === 'componentType') {
+            // This would need additional logic to resolve the actual value, but for now
+            // we'll rely on the variable declaration detection above
+          }
+        });
+      }
+
+      // Recursively traverse child nodes (following import-map.ts pattern)
+      ts.forEachChild(node, traverseNode);
+    };
+
+    // Start traversal from the source file (following utils.ts pattern)
+    ts.forEachChild(sourceFile, traverseNode);
+
+    // Priority: explicit componentType export > use client/server directives > server-only imports > universal default
+    if (explicitComponentType) {
+      return explicitComponentType;
+    }
+
+    if (hasUseClientDirective) {
       return 'client';
     }
 
-    // Check for explicit componentType export
-    const componentTypeMatch = content.match(
-      /export\s+const\s+componentType\s*[:=]\s*['"`](\w+)['"`]/
-    );
-    if (componentTypeMatch) {
-      const type = componentTypeMatch[1] as ComponentType;
-      if (type === 'server' || type === 'client' || type === 'universal') {
-        return type;
-      }
+    if (hasServerOnlyImports) {
+      return 'server';
     }
 
-    // Default to universal if no explicit indicators
+    // Default to universal for components that can work in both environments
     return 'universal';
-  } catch {
+
+  } catch (error) {
+    console.warn(`Failed to parse component file ${filePath}, defaulting to universal:`, error);
     return 'universal';
   }
 }

--- a/packages/core/src/tools/templating/index.ts
+++ b/packages/core/src/tools/templating/index.ts
@@ -1,3 +1,14 @@
-export { ComponentFile, ComponentImport, getComponentList } from './components';
+export { 
+  ComponentFile, 
+  ComponentImport, 
+  ComponentFileWithType,
+  ComponentType,
+  RouterType,
+  getComponentList,
+  detectRouterType,
+  detectComponentType,
+  getComponentListWithTypes,
+  filterComponentsByType
+} from './components';
 export { PluginDefinition, generatePlugins, ModuleType } from './plugins';
 export { matchPath } from './utils';

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Providers.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Providers.tsx
@@ -6,7 +6,7 @@ import {
   Page,
   SitecoreProvider,
 } from '@sitecore-content-sdk/nextjs';
-import components from '.sitecore/component-map';
+import components from '.sitecore/component-map.client';
 import scConfig from 'sitecore.config';
 
 export default function Providers({

--- a/packages/nextjs/src/tools/generate-map.ts
+++ b/packages/nextjs/src/tools/generate-map.ts
@@ -4,9 +4,13 @@ import {
   GenerateMapFunction,
   getComponentList,
   ComponentImport,
+  detectRouterType,
+  getComponentListWithTypes,
+  filterComponentsByType,
+  ComponentFileWithType,
 } from '@sitecore-content-sdk/core/tools';
-import path from 'path';
-import fs from 'fs';
+import * as path from 'path';
+import * as fs from 'fs';
 
 /**
  * Generate and write componentMap.ts file based on provided params.
@@ -18,21 +22,117 @@ export const generateMap: GenerateMapFunction = ({
   exclude,
   componentImports,
   mapTemplate = nextjsMapTemplate,
+  routerType,
 }: GenerateMapArgs) => {
-  const components = getComponentList(paths, exclude);
+  const detectedRouterType = routerType || detectRouterType();
+  const shouldGenerateClientMap = detectedRouterType === 'app';
 
-  const componentMapContent = mapTemplate(components, componentImports);
+  if (shouldGenerateClientMap) {
+    const componentsWithTypes = getComponentListWithTypes(paths, exclude);
 
-  const componentMapFile = path.join(process.cwd(), destination, 'component-map.ts');
+    // Generate regular component map (all components with type information)
+    const regularMapContent = nextjsMapTemplateWithTypes(componentsWithTypes, componentImports);
+    const regularMapFile = path.join(process.cwd(), destination, 'component-map.ts');
 
-  try {
-    fs.writeFileSync(componentMapFile, componentMapContent, {
-      encoding: 'utf8',
-    });
-  } catch (error) {
-    console.error(`Component Map generation failed. Error writing to file ${destination}:`, error);
-    throw error;
+    try {
+      fs.writeFileSync(regularMapFile, regularMapContent, { encoding: 'utf8' });
+    } catch (error) {
+      console.error(
+        `Component Map generation failed. Error writing to file ${destination}:`,
+        error
+      );
+      throw error;
+    }
+
+    // Generate client component map (client + universal components only)
+    const clientComponents = filterComponentsByType(componentsWithTypes, ['client', 'universal']);
+    const clientMapContent = nextjsClientMapTemplate(clientComponents, componentImports);
+    const clientMapFile = path.join(process.cwd(), destination, 'component-map.client.ts');
+
+    try {
+      fs.writeFileSync(clientMapFile, clientMapContent, { encoding: 'utf8' });
+    } catch (error) {
+      console.error(
+        `Client Component Map generation failed. Error writing to file ${destination}:`,
+        error
+      );
+      throw error;
+    }
+  } else {
+    // Pages Router - generate single component map
+    const components = getComponentList(paths, exclude);
+    const componentMapContent = mapTemplate(components, componentImports);
+    const componentMapFile = path.join(process.cwd(), destination, 'component-map.ts');
+
+    try {
+      fs.writeFileSync(componentMapFile, componentMapContent, { encoding: 'utf8' });
+    } catch (error) {
+      console.error(
+        `Component Map generation failed. Error writing to file ${destination}:`,
+        error
+      );
+      throw error;
+    }
   }
+};
+
+const nextjsMapTemplateWithTypes = (
+  components: ComponentFileWithType[],
+  componentImports?: ComponentImport[]
+): string => {
+  const wildcardImports: string[] = [];
+  const namedImports: string[] = [];
+  const componentMapEntries: string[] = [];
+
+  components.forEach((component) => {
+    wildcardImports.push(`import * as ${component.moduleName} from '${component.importPath}';`);
+    // Add fallback componentType if not exported by the component
+    wildcardImports.push(
+      `${component.moduleName}.componentType = ${component.moduleName}.componentType || '${component.componentType}';`
+    );
+    componentMapEntries.push(`['${component.moduleName}', ${component.moduleName}]`);
+  });
+
+  componentImports?.forEach((packageEntry) => {
+    if (packageEntry.importInfo.namedImports) {
+      namedImports.push(
+        `import { ${packageEntry.importInfo.namedImports.join(', ')} } from '${
+          packageEntry.importInfo.importFrom
+        }';`
+      );
+      packageEntry.importInfo.namedImports.forEach((importName) => {
+        componentMapEntries.push(`['${importName}', ${importName}]`);
+      });
+    } else {
+      wildcardImports.push(
+        `import * as ${packageEntry.importName} from '${packageEntry.importInfo.importFrom}';`
+      );
+      componentMapEntries.push(`['${packageEntry.importName}', ${packageEntry.importName}]`);
+    }
+  });
+
+  return `// Below are built-in components that are available in the app, it's recommended to keep them as is
+import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
+import { Form } from '@sitecore-content-sdk/nextjs';
+// end of built-in components
+
+// Components imported from the app itself
+${wildcardImports.join('\n')}
+${namedImports.join('\n')}
+
+// Components must be registered within the map to match the string key with component name in Sitecore
+export const componentMap = new Map<string, NextjsContentSdkComponent>([
+  ['BYOCWrapper', BYOCWrapper],
+  ['FEaaSWrapper', FEaaSWrapper],
+  ['Form', Form],
+${componentMapEntries
+  .map((component) => {
+    return `  ${component},\n`;
+  })
+  .join('')}]);
+
+export default componentMap;
+`;
 };
 
 const nextjsMapTemplate = (
@@ -77,6 +177,61 @@ ${wildcardImports.join('\n')}
 ${namedImports.join('\n')}
 
 // Components must be registered within the map to match the string key with component name in Sitecore
+export const componentMap = new Map<string, NextjsContentSdkComponent>([
+  ['BYOCWrapper', BYOCWrapper],
+  ['FEaaSWrapper', FEaaSWrapper],
+  ['Form', Form],
+${componentMapEntries
+  .map((component) => {
+    return `  ${component},\n`;
+  })
+  .join('')}]);
+
+export default componentMap;
+`;
+};
+
+const nextjsClientMapTemplate = (
+  components: ComponentFileWithType[],
+  componentImports?: ComponentImport[]
+): string => {
+  const wildcardImports: string[] = [];
+  const namedImports: string[] = [];
+  const componentMapEntries: string[] = [];
+
+  components.forEach((component) => {
+    wildcardImports.push(`import * as ${component.moduleName} from '${component.importPath}';`);
+    componentMapEntries.push(`['${component.moduleName}', ${component.moduleName}]`);
+  });
+
+  // Include all component imports for client map (built-in components are universal)
+  const clientComponentImports = componentImports;
+
+  clientComponentImports?.forEach((packageEntry) => {
+    if (packageEntry.importInfo.namedImports) {
+      namedImports.push(
+        `import { ${packageEntry.importInfo.namedImports.join(', ')} } from '${
+          packageEntry.importInfo.importFrom
+        }';`
+      );
+      packageEntry.importInfo.namedImports.forEach((importName) => {
+        componentMapEntries.push(`['${importName}', ${importName}]`);
+      });
+    } else {
+      wildcardImports.push(
+        `import * as ${packageEntry.importName} from '${packageEntry.importInfo.importFrom}';`
+      );
+      componentMapEntries.push(`['${packageEntry.importName}', ${packageEntry.importName}]`);
+    }
+  });
+
+  return `// Client-safe component map for App Router
+import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
+import { Form } from '@sitecore-content-sdk/nextjs';
+
+${wildcardImports.join('\n')}
+${namedImports.join('\n')}
+
 export const componentMap = new Map<string, NextjsContentSdkComponent>([
   ['BYOCWrapper', BYOCWrapper],
   ['FEaaSWrapper', FEaaSWrapper],

--- a/packages/nextjs/src/tools/generate-map.ts
+++ b/packages/nextjs/src/tools/generate-map.ts
@@ -14,6 +14,18 @@ import * as fs from 'fs';
 
 /**
  * Generate and write componentMap.ts file based on provided params.
+ * 
+ * When clientComponentMap is true, generates:
+ * - component-map.ts: Full component map with all components (server, client, universal)
+ * - component-map.client.ts: Client-safe map with only client + universal components
+ * 
+ * When clientComponentMap is false, generates:
+ * - component-map.ts: Single component map (traditional behavior)
+ * 
+ * Template Customization:
+ * - mapTemplate: Custom template for main component map (works for both single and dual map modes)
+ * - clientMapTemplate: Custom template for client component map (only used when clientComponentMap is true)
+ * 
  * @param {GenerateMapArgs} param0 params for generateMap
  */
 export const generateMap: GenerateMapFunction = ({
@@ -22,16 +34,21 @@ export const generateMap: GenerateMapFunction = ({
   exclude,
   componentImports,
   mapTemplate = nextjsMapTemplate,
-  routerType,
+  clientMapTemplate,
+  clientComponentMap,
 }: GenerateMapArgs) => {
-  const detectedRouterType = routerType || detectRouterType();
-  const shouldGenerateClientMap = detectedRouterType === 'app';
+  // Default behavior: if clientComponentMap is not specified, auto-detect based on router type  
+  const shouldGenerateClientMap = clientComponentMap ?? (detectRouterType() === 'app');
 
   if (shouldGenerateClientMap) {
     const componentsWithTypes = getComponentListWithTypes(paths, exclude);
 
     // Generate regular component map (all components with type information)
-    const regularMapContent = nextjsMapTemplateWithTypes(componentsWithTypes, componentImports);
+    // Use custom mapTemplate if provided (assumes it can handle ComponentFileWithType[]), 
+    // otherwise use default template designed for typed components
+    const regularMapContent = mapTemplate 
+      ? mapTemplate(componentsWithTypes, componentImports)
+      : nextjsMapTemplateWithTypes(componentsWithTypes, componentImports);
     const regularMapFile = path.join(process.cwd(), destination, 'component-map.ts');
 
     try {
@@ -45,8 +62,10 @@ export const generateMap: GenerateMapFunction = ({
     }
 
     // Generate client component map (client + universal components only)
+    // Use custom clientMapTemplate if provided, otherwise use default
     const clientComponents = filterComponentsByType(componentsWithTypes, ['client', 'universal']);
-    const clientMapContent = nextjsClientMapTemplate(clientComponents, componentImports);
+    const clientMapTemplateToUse = clientMapTemplate || nextjsClientMapTemplate;
+    const clientMapContent = clientMapTemplateToUse(clientComponents, componentImports);
     const clientMapFile = path.join(process.cwd(), destination, 'component-map.client.ts');
 
     try {
@@ -76,23 +95,45 @@ export const generateMap: GenerateMapFunction = ({
   }
 };
 
-const nextjsMapTemplateWithTypes = (
-  components: ComponentFileWithType[],
-  componentImports?: ComponentImport[]
+/**
+ * Template options for component map generation
+ */
+type TemplateOptions = {
+  /** Whether to include inline componentType for non-universal components */
+  includeComponentType?: boolean;
+  /** Custom header comment for the generated map */
+  headerComment?: string;
+};
+
+/**
+ * Unified template function for all component map generation
+ */
+const nextjsUnifiedTemplate = (
+  components: (ComponentFile | ComponentFileWithType)[],
+  componentImports?: ComponentImport[],
+  options: TemplateOptions = {}
 ): string => {
+  const { includeComponentType = false, headerComment = 'Below are built-in components that are available in the app, it\'s recommended to keep them as is' } = options;
+  
   const wildcardImports: string[] = [];
   const namedImports: string[] = [];
   const componentMapEntries: string[] = [];
 
   components.forEach((component) => {
+    // Clean imports only
     wildcardImports.push(`import * as ${component.moduleName} from '${component.importPath}';`);
-    // Add fallback componentType if not exported by the component
-    wildcardImports.push(
-      `${component.moduleName}.componentType = ${component.moduleName}.componentType || '${component.componentType}';`
-    );
-    componentMapEntries.push(`['${component.moduleName}', ${component.moduleName}]`);
+    
+    // Handle componentType if requested and available
+    if (includeComponentType && 'componentType' in component && component.componentType !== 'universal') {
+      componentMapEntries.push(
+        `['${component.moduleName}', {...${component.moduleName}, componentType: '${component.componentType}'}]`
+      );
+    } else {
+      componentMapEntries.push(`['${component.moduleName}', ${component.moduleName}]`);
+    }
   });
 
+  // Process component imports (identical across all templates)
   componentImports?.forEach((packageEntry) => {
     if (packageEntry.importInfo.namedImports) {
       namedImports.push(
@@ -100,7 +141,7 @@ const nextjsMapTemplateWithTypes = (
           packageEntry.importInfo.importFrom
         }';`
       );
-      packageEntry.importInfo.namedImports.forEach((importName) => {
+      packageEntry.importInfo.namedImports.forEach((importName: string) => {
         componentMapEntries.push(`['${importName}', ${importName}]`);
       });
     } else {
@@ -111,16 +152,13 @@ const nextjsMapTemplateWithTypes = (
     }
   });
 
-  return `// Below are built-in components that are available in the app, it's recommended to keep them as is
+  return `// ${headerComment}
 import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
 import { Form } from '@sitecore-content-sdk/nextjs';
-// end of built-in components
-
-// Components imported from the app itself
+${headerComment.includes('built-in') ? '// end of built-in components\n' : ''}
 ${wildcardImports.join('\n')}
 ${namedImports.join('\n')}
 
-// Components must be registered within the map to match the string key with component name in Sitecore
 export const componentMap = new Map<string, NextjsContentSdkComponent>([
   ['BYOCWrapper', BYOCWrapper],
   ['FEaaSWrapper', FEaaSWrapper],
@@ -133,115 +171,35 @@ ${componentMapEntries
 
 export default componentMap;
 `;
+};
+
+// Wrapper functions for backward compatibility
+const nextjsMapTemplateWithTypes = (
+  components: ComponentFileWithType[],
+  componentImports?: ComponentImport[]
+): string => {
+  return nextjsUnifiedTemplate(components, componentImports, {
+    includeComponentType: true,
+    headerComment: 'Below are built-in components that are available in the app, it\'s recommended to keep them as is'
+  });
 };
 
 const nextjsMapTemplate = (
   components: ComponentFile[],
   componentImports?: ComponentImport[]
 ): string => {
-  const wildcardImports: string[] = [];
-  const namedImports: string[] = [];
-
-  const componentMapEntries: string[] = [];
-
-  components.forEach((component) => {
-    wildcardImports.push(`import * as ${component.moduleName} from '${component.importPath}';`);
-    componentMapEntries.push(`['${component.moduleName}', ${component.moduleName}]`);
+  return nextjsUnifiedTemplate(components, componentImports, {
+    includeComponentType: false,
+    headerComment: 'Below are built-in components that are available in the app, it\'s recommended to keep them as is'
   });
-
-  componentImports?.forEach((packageEntry) => {
-    if (packageEntry.importInfo.namedImports) {
-      namedImports.push(
-        `import { ${packageEntry.importInfo.namedImports.join(', ')} } from '${
-          packageEntry.importInfo.importFrom
-        }';`
-      );
-      packageEntry.importInfo.namedImports.forEach((importName) => {
-        componentMapEntries.push(`['${importName}', ${importName}]`);
-      });
-    } else {
-      wildcardImports.push(
-        `import * as ${packageEntry.importName} from '${packageEntry.importInfo.importFrom}';`
-      );
-      componentMapEntries.push(`['${packageEntry.importName}', ${packageEntry.importName}]`);
-    }
-  });
-
-  return `// Below are built-in components that are available in the app, it's recommended to keep them as is
-import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
-import { Form } from '@sitecore-content-sdk/nextjs';
-// end of built-in components
-
-// Components imported from the app itself
-${wildcardImports.join('\n')}
-${namedImports.join('\n')}
-
-// Components must be registered within the map to match the string key with component name in Sitecore
-export const componentMap = new Map<string, NextjsContentSdkComponent>([
-  ['BYOCWrapper', BYOCWrapper],
-  ['FEaaSWrapper', FEaaSWrapper],
-  ['Form', Form],
-${componentMapEntries
-  .map((component) => {
-    return `  ${component},\n`;
-  })
-  .join('')}]);
-
-export default componentMap;
-`;
 };
 
 const nextjsClientMapTemplate = (
   components: ComponentFileWithType[],
   componentImports?: ComponentImport[]
 ): string => {
-  const wildcardImports: string[] = [];
-  const namedImports: string[] = [];
-  const componentMapEntries: string[] = [];
-
-  components.forEach((component) => {
-    wildcardImports.push(`import * as ${component.moduleName} from '${component.importPath}';`);
-    componentMapEntries.push(`['${component.moduleName}', ${component.moduleName}]`);
+  return nextjsUnifiedTemplate(components, componentImports, {
+    includeComponentType: false, // Client components are already filtered, no need for type info
+    headerComment: 'Client-safe component map for App Router'
   });
-
-  // Include all component imports for client map (built-in components are universal)
-  const clientComponentImports = componentImports;
-
-  clientComponentImports?.forEach((packageEntry) => {
-    if (packageEntry.importInfo.namedImports) {
-      namedImports.push(
-        `import { ${packageEntry.importInfo.namedImports.join(', ')} } from '${
-          packageEntry.importInfo.importFrom
-        }';`
-      );
-      packageEntry.importInfo.namedImports.forEach((importName) => {
-        componentMapEntries.push(`['${importName}', ${importName}]`);
-      });
-    } else {
-      wildcardImports.push(
-        `import * as ${packageEntry.importName} from '${packageEntry.importInfo.importFrom}';`
-      );
-      componentMapEntries.push(`['${packageEntry.importName}', ${packageEntry.importName}]`);
-    }
-  });
-
-  return `// Client-safe component map for App Router
-import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
-import { Form } from '@sitecore-content-sdk/nextjs';
-
-${wildcardImports.join('\n')}
-${namedImports.join('\n')}
-
-export const componentMap = new Map<string, NextjsContentSdkComponent>([
-  ['BYOCWrapper', BYOCWrapper],
-  ['FEaaSWrapper', FEaaSWrapper],
-  ['Form', Form],
-${componentMapEntries
-  .map((component) => {
-    return `  ${component},\n`;
-  })
-  .join('')}]);
-
-export default componentMap;
-`;
 };

--- a/packages/react/src/components/Placeholder/models.ts
+++ b/packages/react/src/components/Placeholder/models.ts
@@ -1,6 +1,10 @@
 import { Page } from '@sitecore-content-sdk/core/client';
 import { ComponentRendering, Field, Item, RouteData } from '@sitecore-content-sdk/core/layout';
+import { ComponentType } from '@sitecore-content-sdk/core/tools';
 import { ComponentMap } from '../sharedTypes';
+
+// Re-export ComponentType to maintain API compatibility
+export type { ComponentType };
 
 type ErrorComponentProps = {
   [prop: string]: unknown;
@@ -11,8 +15,6 @@ export type ComponentProps = {
   [key: string]: unknown;
   rendering: ComponentRendering;
 };
-
-export type ComponentType = 'server' | 'client' | 'universal';
 
 export interface PlaceholderProps {
   [key: string]: unknown;


### PR DESCRIPTION

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
The current implementation adds dual component map generation for Next.js App Router projects to prevent environment poisoning between server and client components.

Key Changes

- Dual Maps: Generates both component-map.ts (all components) and component-map.client.ts (client-safe only)
- Component Type Detection: Auto-detects 'use client' directives and explicit componentType exports ('server'|'client'|'universal')
- Router Auto-Detection: Automatically identifies App Router vs Pages Router from project structure
- Environment Separation: Server uses regular map, client uses client-safe map
- Backward Compatible: Pages Router projects continue to generate single map

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
