### PR TITLE
Fix XM Cloud documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more information check out our [Getting Started Guide](https://doc.sitecore.
 ## Documentation and community resources
 
 - Official documentation:
-- [XM Cloud](https://doc.sitecore.com/xmc/en/developers/jss/latest/jss-xmc/index-en.html)
+- [XM Cloud](https://doc.sitecore.com/xmc/en/developers/content-sdk/sitecore-content-sdk-for-xm-cloud.html)
 - [StackExchange](https://sitecore.stackexchange.com/)
 - [Community Slack](https://sitecorechat.slack.com/messages/content-sdk)
 - [Sitecore Community Forum](https://community.sitecore.net/developers/f/40)


### PR DESCRIPTION
Replaced JSS link with link to Content SDK documentation.
