### PR TITLE
[core][nextjs] Fix issues related to app router component maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Our versioning strategy is as follows:
   - Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
   - Editing and preview support ([#198](https://github.com/Sitecore/content-sdk/pull/198))
   - Internationalization support ([#202](https://github.com/Sitecore/content-sdk/pull/202)) ([#214](https://github.com/Sitecore/content-sdk/pull/214))
-  - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))
+  - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))
 * [nextjs] Slim down sample even more ([#225](https://github.com/Sitecore/content-sdk/pull/225))
 * Mark client components with `use client` directive. ([#226](https://github.com/Sitecore/content-sdk/pull/226))
 

--- a/packages/core/src/tools/templating/components.test.ts
+++ b/packages/core/src/tools/templating/components.test.ts
@@ -360,6 +360,36 @@ export const componentType: 'server' = 'server';`);
       expect(result).to.equal('universal');
     });
 
+    it('should default to server for plain components in App Router', () => {
+      readFileSyncStub.returns(`export default function PlainComponent() {
+  return <div>Plain component</div>;
+}`);
+
+      const result = detectComponentType('test.tsx', 'app');
+      expect(result).to.equal('server');
+    });
+
+    it('should default to universal for plain components in Pages Router', () => {
+      readFileSyncStub.returns(`export default function PlainComponent() {
+  return <div>Plain component</div>;
+}`);
+
+      const result = detectComponentType('test.tsx', 'pages');
+      expect(result).to.equal('universal');
+    });
+
+    it('should respect explicit routerType parameter', () => {
+      readFileSyncStub.returns(`export default function PlainComponent() {
+  return <div>Plain component</div>;
+}`);
+
+      const appResult = detectComponentType('test.tsx', 'app');
+      const pagesResult = detectComponentType('test.tsx', 'pages');
+
+      expect(appResult).to.equal('server');
+      expect(pagesResult).to.equal('universal');
+    });
+
     it('should handle file read errors gracefully', () => {
       readFileSyncStub.throws(new Error('File not found'));
 

--- a/packages/core/src/tools/templating/components.ts
+++ b/packages/core/src/tools/templating/components.ts
@@ -83,6 +83,11 @@ export function getComponentList(paths: string[], exclude?: string[]): Component
   return components;
 }
 
+/**
+ * Detects the Next.js router type (App Router or Pages Router) based on directory structure.
+ * @param {string} projectRoot - The project root directory. Defaults to current working directory.
+ * @returns {RouterType} 'app' if App Router is detected, 'pages' otherwise
+ */
 export function detectRouterType(projectRoot: string = process.cwd()): RouterType {
   const appDirExists =
     fs.existsSync(`${projectRoot}/src/app`) || fs.existsSync(`${projectRoot}/app`);
@@ -100,21 +105,29 @@ export function detectRouterType(projectRoot: string = process.cwd()): RouterTyp
   return 'pages';
 }
 
-export function detectComponentType(filePath: string): ComponentType {
+/**
+ * Detects the component type based on directives, imports, and router context.
+ * - Checks for 'use client' directive
+ * - Checks for explicit componentType export
+ * - Checks for server-only imports (next/headers, etc.)
+ * - Defaults to 'server' for App Router, 'universal' for Pages Router
+ * @param {string} filePath - Path to the component file
+ * @param {RouterType} [routerType] - Optional router type override. Auto-detected if not provided.
+ * @returns {ComponentType} 'server', 'client', or 'universal'
+ */
+export function detectComponentType(filePath: string, routerType?: RouterType): ComponentType {
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
 
     // Parse using TypeScript AST (following patterns from import-map.ts and utils.ts)
-    const sourceFile = ts.createSourceFile(
-      filePath,
-      content,
-      ts.ScriptTarget.Latest,
-      true
-    );
+    const sourceFile = ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, true);
 
     let hasUseClientDirective = false;
     let explicitComponentType: ComponentType | null = null;
     let hasServerOnlyImports = false;
+
+    // Auto-detect router type if not provided
+    const detectedRouterType = routerType || detectRouterType();
 
     // Track position to ensure directives come before imports/other statements
     let foundFirstNonDirectiveStatement = false;
@@ -131,8 +144,12 @@ export function detectComponentType(filePath: string): ComponentType {
     // More comprehensive AST traversal (following patterns from import-map.ts and utils.ts)
     const traverseNode = (node: ts.Node) => {
       // Check for 'use client'/'use server' directives (must be at top, before imports)
-      if (isValidDirective(node) && ts.isStringLiteral((node as ts.ExpressionStatement).expression)) {
-        const directiveText = ((node as ts.ExpressionStatement).expression as ts.StringLiteral).text;
+      if (
+        isValidDirective(node) &&
+        ts.isStringLiteral((node as ts.ExpressionStatement).expression)
+      ) {
+        const directiveText = ((node as ts.ExpressionStatement).expression as ts.StringLiteral)
+          .text;
         if (directiveText === 'use client') {
           hasUseClientDirective = true;
           return; // Don't mark as non-directive statement
@@ -144,7 +161,13 @@ export function detectComponentType(filePath: string): ComponentType {
       }
 
       // Mark that we've seen a non-directive statement (imports, declarations, etc.)
-      if (ts.isImportDeclaration(node) || ts.isVariableStatement(node) || ts.isFunctionDeclaration(node) || ts.isExportDeclaration(node) || ts.isExportAssignment(node)) {
+      if (
+        ts.isImportDeclaration(node) ||
+        ts.isVariableStatement(node) ||
+        ts.isFunctionDeclaration(node) ||
+        ts.isExportDeclaration(node) ||
+        ts.isExportAssignment(node)
+      ) {
         foundFirstNonDirectiveStatement = true;
       }
 
@@ -201,7 +224,11 @@ export function detectComponentType(filePath: string): ComponentType {
       }
 
       // Check for named export of componentType (export const componentType = ...)
-      if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+      if (
+        ts.isExportDeclaration(node) &&
+        node.exportClause &&
+        ts.isNamedExports(node.exportClause)
+      ) {
         node.exportClause.elements.forEach((exportSpecifier: ts.ExportSpecifier) => {
           if (exportSpecifier.name.text === 'componentType') {
             // This would need additional logic to resolve the actual value, but for now
@@ -230,27 +257,47 @@ export function detectComponentType(filePath: string): ComponentType {
       return 'server';
     }
 
-    // Default to universal for components that can work in both environments
-    return 'universal';
-
+    // Router-aware defaults:
+    // - App Router: defaults to server (RSC by default)
+    // - Pages Router: defaults to universal (isomorphic by default)
+    if (detectedRouterType === 'app') {
+      return 'server';
+    } else {
+      return 'universal';
+    }
   } catch (error) {
     console.warn(`Failed to parse component file ${filePath}, defaulting to universal:`, error);
     return 'universal';
   }
 }
 
+/**
+ * Get list of components with detected types (server, client, or universal).
+ * @param {string[]} paths - Paths to search for components
+ * @param {string[]} [exclude] - Paths and glob patterns to exclude from final result
+ * @param {RouterType} [routerType] - Optional router type override for type detection. Auto-detected if not provided.
+ * @returns {ComponentFileWithType[]} Array of components with their detected types
+ */
 export function getComponentListWithTypes(
   paths: string[],
-  exclude?: string[]
+  exclude?: string[],
+  routerType?: RouterType
 ): ComponentFileWithType[] {
   const components = getComponentList(paths, exclude);
+  const detectedRouterType = routerType || detectRouterType();
 
   return components.map((component) => ({
     ...component,
-    componentType: detectComponentType(component.filePath),
+    componentType: detectComponentType(component.filePath, detectedRouterType),
   }));
 }
 
+/**
+ * Filters components by their detected type.
+ * @param {ComponentFileWithType[]} components - Array of components with types
+ * @param {ComponentType[]} allowedTypes - Array of allowed component types to filter by
+ * @returns {ComponentFileWithType[]} Filtered array containing only components matching allowed types
+ */
 export function filterComponentsByType(
   components: ComponentFileWithType[],
   allowedTypes: ComponentType[]

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/gitignore
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/gitignore
@@ -25,4 +25,5 @@
 .sitecore/*
 # except for component-map
 !.sitecore/component-map.ts
+!.sitecore/component-map.client.ts
 !.sitecore/import-map.ts

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/package.json
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/package.json
@@ -24,7 +24,7 @@
     "sitecore-tools:generate-map": "sitecore-tools project component generate-map",
     "sitecore-tools:generate-map:watch": "sitecore-tools project component generate-map --watch",
     "sitecore-tools:build": "sitecore-tools project build",
-    "dev": "cross-env NODE_ENV=development npm-run-all --serial sitecore-tools:build --parallel next:dev sitecore-tools:generate-map:watch",
+    "dev": "cross-env NODE_ENV=development npm-run-all --serial sitecore-tools:generate-map sitecore-tools:build --parallel next:dev sitecore-tools:generate-map:watch",
     "start": "cross-env-shell NODE_ENV=production npm-run-all --serial build next:start"
   },
   "dependencies": {

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/tsconfig.json
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/tsconfig.json
@@ -14,6 +14,9 @@
       "assets/*": [
         "src/assets/*"
       ],
+      ".sitecore/*": [
+        ".sitecore/*"
+      ],
       <%_ if (helper.isDev) { _%>
       "next/*": ["node_modules/next/*"],
       <%_ } _%>

--- a/packages/create-content-sdk-app/src/templates/nextjs/package.json
+++ b/packages/create-content-sdk-app/src/templates/nextjs/package.json
@@ -62,7 +62,7 @@
     "sitecore-tools:generate-map": "sitecore-tools project component generate-map",
     "sitecore-tools:generate-map:watch": "sitecore-tools project component generate-map --watch",
     "sitecore-tools:build": "sitecore-tools project build",
-    "dev": "cross-env NODE_ENV=development npm-run-all --serial sitecore-tools:build --parallel next:dev sitecore-tools:generate-map:watch",
+    "dev": "cross-env NODE_ENV=development npm-run-all --serial sitecore-tools:generate-map sitecore-tools:build --parallel next:dev sitecore-tools:generate-map:watch",
     "start": "cross-env-shell NODE_ENV=production npm-run-all --serial build next:start"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR fixes App Router component mapping issues that caused build failures and incorrect component registration. More specifically:

- **Import Resolution**: Add `.sitecore/*` path alias to tsconfig template to resolve component map imports from `src/` directory
- **Component Type Detection**: Make component type detection router-aware - App Router components default to 'server' instead of 'universal', preventing server components from appearing in client map

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
