### PR TITLE
[cli][nextjs] Fix client map generation control issue

### DIFF
--- a/packages/cli/src/scripts/project/component/generate-map.test.ts
+++ b/packages/cli/src/scripts/project/component/generate-map.test.ts
@@ -87,4 +87,27 @@ describe('generate-map CLI', () => {
     expect(generatorStub.firstCall.args[0]).to.deep.equal(args);
     expect(consoleLogStub.calledWithMatch(/Generating component map/)).to.be.true;
   });
+
+  it('should pass clientComponentMap: false to generator when explicitly set to false', () => {
+    const generatorStub = sinon.stub();
+    const args = {
+      paths: ['src'],
+      destination: 'dest',
+      componentImports: ['pkg'],
+      exclude: ['ex'],
+      clientComponentMap: false,
+    };
+    const fakeConfig = {
+      componentMap: {
+        generator: generatorStub,
+        ...args,
+      },
+    };
+    loadCliConfigStub.returns(fakeConfig);
+    generateMapModule.handler({});
+    expect(generatorStub.calledOnce).to.be.true;
+    expect(generatorStub.firstCall.args[0]).to.deep.equal(args);
+    expect(generatorStub.firstCall.args[0].clientComponentMap).to.be.false;
+    expect(consoleLogStub.calledWithMatch(/Generating component map/)).to.be.true;
+  });
 });

--- a/packages/cli/src/scripts/project/component/generate-map.test.ts
+++ b/packages/cli/src/scripts/project/component/generate-map.test.ts
@@ -73,6 +73,7 @@ describe('generate-map CLI', () => {
       destination: 'dest',
       componentImports: ['pkg'],
       exclude: ['ex'],
+      clientComponentMap: undefined,
     };
     const fakeConfig = {
       componentMap: {

--- a/packages/cli/src/scripts/project/component/generate-map.ts
+++ b/packages/cli/src/scripts/project/component/generate-map.ts
@@ -62,17 +62,24 @@ export function handler(argv: GenerateMapCliArgs) {
     return;
   }
   const componentMapGenerator = cliConfig.componentMap.generator;
-  const { paths, destination, componentImports, exclude } = cliConfig.componentMap;
+  const { paths, destination, componentImports, exclude, clientComponentMap } =
+    cliConfig.componentMap;
   if (argv.watch) {
     console.log(
       `Watching for component changes to component builder sources in:\n ${paths.join('\n')}`
     );
     watchItems(
       paths,
-      componentMapGenerator.bind(null, { paths, destination, componentImports, exclude })
+      componentMapGenerator.bind(null, {
+        paths,
+        destination,
+        componentImports,
+        exclude,
+        clientComponentMap,
+      })
     );
   } else {
     console.log(`Generating component map for:\n ${paths.join('\n')}`);
-    componentMapGenerator({ paths, destination, componentImports, exclude });
+    componentMapGenerator({ paths, destination, componentImports, exclude, clientComponentMap });
   }
 }

--- a/packages/nextjs/src/tools/generate-map.ts
+++ b/packages/nextjs/src/tools/generate-map.ts
@@ -14,18 +14,18 @@ import * as fs from 'fs';
 
 /**
  * Generate and write componentMap.ts file based on provided params.
- * 
+ *
  * When clientComponentMap is true, generates:
  * - component-map.ts: Full component map with all components (server, client, universal)
  * - component-map.client.ts: Client-safe map with only client + universal components
- * 
+ *
  * When clientComponentMap is false, generates:
  * - component-map.ts: Single component map (traditional behavior)
- * 
+ *
  * Template Customization:
  * - mapTemplate: Custom template for main component map (works for both single and dual map modes)
  * - clientMapTemplate: Custom template for client component map (only used when clientComponentMap is true)
- * 
+ *
  * @param {GenerateMapArgs} param0 params for generateMap
  */
 export const generateMap: GenerateMapFunction = ({
@@ -37,16 +37,16 @@ export const generateMap: GenerateMapFunction = ({
   clientMapTemplate,
   clientComponentMap,
 }: GenerateMapArgs) => {
-  // Default behavior: if clientComponentMap is not specified, auto-detect based on router type  
-  const shouldGenerateClientMap = clientComponentMap ?? (detectRouterType() === 'app');
+  // Default behavior: if clientComponentMap is not specified, auto-detect based on router type
+  const shouldGenerateClientMap = clientComponentMap ?? detectRouterType() === 'app';
 
   if (shouldGenerateClientMap) {
     const componentsWithTypes = getComponentListWithTypes(paths, exclude);
 
     // Generate regular component map (all components with type information)
-    // Use custom mapTemplate if provided (assumes it can handle ComponentFileWithType[]), 
+    // Use custom mapTemplate if provided (assumes it can handle ComponentFileWithType[]),
     // otherwise use default template designed for typed components
-    const regularMapContent = mapTemplate 
+    const regularMapContent = mapTemplate
       ? mapTemplate(componentsWithTypes, componentImports)
       : nextjsMapTemplateWithTypes(componentsWithTypes, componentImports);
     const regularMapFile = path.join(process.cwd(), destination, 'component-map.ts');
@@ -113,8 +113,11 @@ const nextjsUnifiedTemplate = (
   componentImports?: ComponentImport[],
   options: TemplateOptions = {}
 ): string => {
-  const { includeComponentType = false, headerComment = 'Below are built-in components that are available in the app, it\'s recommended to keep them as is' } = options;
-  
+  const {
+    includeComponentType = false,
+    headerComment = "Below are built-in components that are available in the app, it's recommended to keep them as is",
+  } = options;
+
   const wildcardImports: string[] = [];
   const namedImports: string[] = [];
   const componentMapEntries: string[] = [];
@@ -122,9 +125,13 @@ const nextjsUnifiedTemplate = (
   components.forEach((component) => {
     // Clean imports only
     wildcardImports.push(`import * as ${component.moduleName} from '${component.importPath}';`);
-    
+
     // Handle componentType if requested and available
-    if (includeComponentType && 'componentType' in component && component.componentType !== 'universal') {
+    if (
+      includeComponentType &&
+      'componentType' in component &&
+      component.componentType !== 'universal'
+    ) {
       componentMapEntries.push(
         `['${component.moduleName}', {...${component.moduleName}, componentType: '${component.componentType}'}]`
       );
@@ -152,12 +159,18 @@ const nextjsUnifiedTemplate = (
     }
   });
 
+  // Build imports section, filtering out empty arrays
+  const importLines = [
+    headerComment.includes('built-in') ? '// end of built-in components' : null,
+    ...wildcardImports,
+    ...namedImports,
+  ].filter((line) => line !== null && line !== '');
+
+  const importsSection = importLines.length > 0 ? `\n${importLines.join('\n')}` : '';
+
   return `// ${headerComment}
 import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
-import { Form } from '@sitecore-content-sdk/nextjs';
-${headerComment.includes('built-in') ? '// end of built-in components\n' : ''}
-${wildcardImports.join('\n')}
-${namedImports.join('\n')}
+import { Form } from '@sitecore-content-sdk/nextjs';${importsSection}
 
 export const componentMap = new Map<string, NextjsContentSdkComponent>([
   ['BYOCWrapper', BYOCWrapper],
@@ -180,7 +193,8 @@ const nextjsMapTemplateWithTypes = (
 ): string => {
   return nextjsUnifiedTemplate(components, componentImports, {
     includeComponentType: true,
-    headerComment: 'Below are built-in components that are available in the app, it\'s recommended to keep them as is'
+    headerComment:
+      "Below are built-in components that are available in the app, it's recommended to keep them as is",
   });
 };
 
@@ -190,7 +204,8 @@ const nextjsMapTemplate = (
 ): string => {
   return nextjsUnifiedTemplate(components, componentImports, {
     includeComponentType: false,
-    headerComment: 'Below are built-in components that are available in the app, it\'s recommended to keep them as is'
+    headerComment:
+      "Below are built-in components that are available in the app, it's recommended to keep them as is",
   });
 };
 
@@ -200,6 +215,6 @@ const nextjsClientMapTemplate = (
 ): string => {
   return nextjsUnifiedTemplate(components, componentImports, {
     includeComponentType: false, // Client components are already filtered, no need for type info
-    headerComment: 'Client-safe component map for App Router'
+    headerComment: 'Client-safe component map for App Router',
   });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
## Fixes

- **CLI Option Handling**: Fixed `clientComponentMap` option not being passed from `sitecore.cli.config.ts` to the generator, allowing users to explicitly control dual component map generation

- **Template Formatting**: Cleaned up generated component map files to remove excessive empty lines when no custom components exist, maintaining one clean line between imports and exports for readability

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other => Testing: Verified by setting `clientComponentMap: false` in `sitecore.cli.config.ts` and confirming only `component-map.ts` was generated while `component-map.client.ts` was correctly skipped, then tested auto-detection still works when the option is omitted.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
