### PR TITLE
[create-content-sdk-app][nextjs] Fix client map import in Providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Our versioning strategy is as follows:
   - Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
   - Editing and preview support ([#198](https://github.com/Sitecore/content-sdk/pull/198))
   - Internationalization support ([#202](https://github.com/Sitecore/content-sdk/pull/202)) ([#214](https://github.com/Sitecore/content-sdk/pull/214))
-  - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))
+  - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))([#234](https://github.com/Sitecore/content-sdk/pull/234))
 * [nextjs] Slim down sample even more ([#225](https://github.com/Sitecore/content-sdk/pull/225))
 * Mark client components with `use client` directive. ([#226](https://github.com/Sitecore/content-sdk/pull/226))
 

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/.sitecore/component-map.client.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/.sitecore/component-map.client.ts
@@ -1,0 +1,11 @@
+// Client-safe component map for App Router
+import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
+import { Form } from '@sitecore-content-sdk/nextjs';
+
+export const componentMap = new Map<string, NextjsContentSdkComponent>([
+  ['BYOCWrapper', BYOCWrapper],
+  ['FEaaSWrapper', FEaaSWrapper],
+  ['Form', Form],
+]);
+
+export default componentMap;

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Providers.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Providers.tsx
@@ -5,21 +5,12 @@ import {
   ComponentPropsContext,
   Page,
   SitecoreProvider,
-  ComponentMap,
 } from '@sitecore-content-sdk/nextjs';
 import scConfig from 'sitecore.config';
 
-// Conditionally import component map based on availability
-let components: ComponentMap;
-try {
-  // Try to import client-specific map first (App Router with dual maps)
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  components = require('.sitecore/component-map.client').default;
-} catch {
-  // Fallback to main component map (Pages Router or single map mode)
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  components = require('.sitecore/component-map').default;
-}
+// Always use client-safe component map to maintain server/client boundary
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const components = require('.sitecore/component-map.client').default;
 
 export default function Providers({
   children,

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Providers.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Providers.tsx
@@ -7,10 +7,7 @@ import {
   SitecoreProvider,
 } from '@sitecore-content-sdk/nextjs';
 import scConfig from 'sitecore.config';
-
-// Always use client-safe component map to maintain server/client boundary
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const components = require('.sitecore/component-map.client').default;
+import components from '.sitecore/component-map.client';
 
 export default function Providers({
   children,

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Providers.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Providers.tsx
@@ -5,9 +5,21 @@ import {
   ComponentPropsContext,
   Page,
   SitecoreProvider,
+  ComponentMap,
 } from '@sitecore-content-sdk/nextjs';
-import components from '.sitecore/component-map.client';
 import scConfig from 'sitecore.config';
+
+// Conditionally import component map based on availability
+let components: ComponentMap;
+try {
+  // Try to import client-specific map first (App Router with dual maps)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  components = require('.sitecore/component-map.client').default;
+} catch {
+  // Fallback to main component map (Pages Router or single map mode)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  components = require('.sitecore/component-map').default;
+}
 
 export default function Providers({
   children,

--- a/packages/nextjs/src/tools/generate-map.test.ts
+++ b/packages/nextjs/src/tools/generate-map.test.ts
@@ -57,7 +57,7 @@ describe('generateMap', () => {
       const paths = ['src/components'];
       generateMap({ paths });
 
-      expect(fs.writeFileSync).to.have.been.calledTwice;
+      expect(fs.writeFileSync).to.have.been.calledOnce;
       const [dest, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
       expect(dest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.ts'));
 
@@ -97,7 +97,7 @@ describe('generateMap', () => {
       expect(customTemplate).to.have.been.calledOnce;
       expect(customTemplate.getCall(0).args[0]).to.deep.equal(fakeComponentList);
       expect(customTemplate.getCall(0).args[1]).to.deep.equal(fakePackages);
-      expect(fs.writeFileSync).to.have.been.calledTwice;
+      expect(fs.writeFileSync).to.have.been.calledOnce;
       const [, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
       expect(content).to.equal('// custom template output');
     });
@@ -107,7 +107,7 @@ describe('generateMap', () => {
       const paths = ['src/components'];
       generateMap({ paths });
 
-      expect(fs.writeFileSync).to.have.been.calledTwice;
+      expect(fs.writeFileSync).to.have.been.calledOnce;
       const [, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
       expect(content).to.include(
         'export const componentMap = new Map<string, NextjsContentSdkComponent>('
@@ -145,14 +145,14 @@ describe('generateMap', () => {
     it('should not fail if packages is undefined', async () => {
       const paths = ['src/components'];
       expect(() => generateMap({ paths, componentImports: undefined })).to.not.throw();
-      expect(fs.writeFileSync).to.have.been.calledTwice;
+      expect(fs.writeFileSync).to.have.been.calledOnce;
     });
 
     it('should write componentMap.ts file with components from "paths" and "packages" parameters, when provided', async () => {
       const paths = ['src/components'];
       generateMap({ paths, componentImports: fakePackages });
 
-      expect(fs.writeFileSync).to.have.been.calledTwice;
+      expect(fs.writeFileSync).to.have.been.calledOnce;
       const [, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
       expect(content).to.include("import * as MyLib from '@my/lib';");
       expect(content).to.include("import { CompA, CompB } from '@other/lib';");
@@ -170,7 +170,7 @@ describe('generateMap', () => {
       const customDest = path.join(process.cwd(), 'custom/path', 'component-map.ts');
       generateMap({ paths, destination: 'custom/path' });
 
-      expect(fs.writeFileSync).to.have.been.calledTwice;
+      expect(fs.writeFileSync).to.have.been.calledOnce;
       expect(fs.writeFileSync).to.have.been.calledWith(
         customDest,
         sinon.match.string,
@@ -326,7 +326,7 @@ describe('generateMap', () => {
       expect(clientContent).to.include("['UniversalCard', UniversalCard],");
     });
 
-    it('should generate both maps when clientComponentMap is false (for safety)', async () => {
+    it('should generate only main component map when clientComponentMap is false', async () => {
       const paths = ['src/components'];
       // Reset stubs for this test - use getComponentList instead of getComponentListWithTypes
       sandbox.restore();
@@ -356,25 +356,16 @@ describe('generateMap', () => {
 
       generateMap({ paths, clientComponentMap: false });
 
-      expect(fs.writeFileSync).to.have.been.calledTwice;
+      expect(fs.writeFileSync).to.have.been.calledOnce;
       expect(getComponentListStub).to.have.been.calledOnce;
 
-      // Check main component map (includes all components)
-      const [mainDest, mainContent] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
-      expect(mainDest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.ts'));
-      expect(mainContent).to.include(
-        "import * as ClientButton from './src/components/ClientButton';"
-      );
-      expect(mainContent).to.include("import * as ServerData from './src/components/ServerData';");
-      expect(mainContent).to.include(
+      const [dest, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
+      expect(dest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.ts'));
+      expect(content).to.include("import * as ClientButton from './src/components/ClientButton';");
+      expect(content).to.include("import * as ServerData from './src/components/ServerData';");
+      expect(content).to.include(
         "import * as UniversalCard from './src/components/UniversalCard';"
       );
-
-      // Check client component map (empty for safety)
-      const [clientDest, clientContent] = (fs.writeFileSync as sinon.SinonStub).getCall(1).args;
-      expect(clientDest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.client.ts'));
-      expect(clientContent).to.include('Client-safe component map for App Router');
-      expect(clientContent).to.not.include('ServerData'); // Should not include server components
 
       newSandbox.restore();
     });
@@ -387,13 +378,13 @@ describe('generateMap', () => {
       expect(fs.writeFileSync).to.have.been.calledTwice;
     });
 
-    it('should auto-detect Pages Router and generate both maps when clientComponentMap is undefined', async () => {
+    it('should auto-detect Pages Router and generate single map when clientComponentMap is undefined', async () => {
       detectRouterTypeStub.returns('pages');
       const paths = ['src/components'];
       generateMap({ paths }); // clientComponentMap is undefined
 
       expect(detectRouterTypeStub).to.have.been.calledOnce;
-      expect(fs.writeFileSync).to.have.been.calledTwice; // Now always generates both maps
+      expect(fs.writeFileSync).to.have.been.calledOnce;
     });
 
     it('should use custom clientMapTemplate when provided', async () => {

--- a/packages/nextjs/src/tools/generate-map.test.ts
+++ b/packages/nextjs/src/tools/generate-map.test.ts
@@ -241,4 +241,194 @@ describe('generateMap', () => {
       expect(content).to.include("['NamedB', NamedB],");
     });
   });
+
+  describe('clientComponentMap functionality', () => {
+    const fakeComponentsWithTypes = [
+      {
+        componentName: 'ClientButton',
+        moduleName: 'ClientButton',
+        importPath: './src/components/ClientButton',
+        componentType: 'client' as const,
+      },
+      {
+        componentName: 'ServerData',
+        moduleName: 'ServerData',
+        importPath: './src/components/ServerData',
+        componentType: 'server' as const,
+      },
+      {
+        componentName: 'UniversalCard',
+        moduleName: 'UniversalCard',
+        importPath: './src/components/UniversalCard',
+        componentType: 'universal' as const,
+      },
+    ];
+
+    let getComponentListWithTypesStub: sinon.SinonStub;
+    let detectRouterTypeStub: sinon.SinonStub;
+    let filterComponentsByTypeStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      getComponentListWithTypesStub = sandbox.stub().returns(fakeComponentsWithTypes);
+      detectRouterTypeStub = sandbox.stub().returns('app');
+      filterComponentsByTypeStub = sandbox.stub().returns([
+        fakeComponentsWithTypes[0], // ClientButton
+        fakeComponentsWithTypes[2], // UniversalCard
+      ]);
+
+      sandbox.replaceGetter(
+        coreTools,
+        'getComponentListWithTypes',
+        () => getComponentListWithTypesStub
+      );
+      sandbox.replaceGetter(coreTools, 'detectRouterType', () => detectRouterTypeStub);
+      sandbox.replaceGetter(coreTools, 'filterComponentsByType', () => filterComponentsByTypeStub);
+      sandbox.stub(fs, 'writeFileSync');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should generate both component maps when clientComponentMap is true', async () => {
+      const paths = ['src/components'];
+      generateMap({ paths, clientComponentMap: true });
+
+      expect(fs.writeFileSync).to.have.been.calledTwice;
+
+      // Check main component map
+      const [mainDest, mainContent] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
+      expect(mainDest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.ts'));
+      expect(mainContent).to.include(
+        "import * as ClientButton from './src/components/ClientButton';"
+      );
+      expect(mainContent).to.include("import * as ServerData from './src/components/ServerData';");
+      expect(mainContent).to.include(
+        "import * as UniversalCard from './src/components/UniversalCard';"
+      );
+      expect(mainContent).to.include("['ClientButton', ClientButton],");
+      expect(mainContent).to.include("['ServerData', ServerData],");
+      expect(mainContent).to.include("['UniversalCard', UniversalCard],");
+
+      // Check client component map
+      const [clientDest, clientContent] = (fs.writeFileSync as sinon.SinonStub).getCall(1).args;
+      expect(clientDest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.client.ts'));
+      expect(clientContent).to.include('Client-safe component map for App Router');
+      expect(clientContent).to.include(
+        "import * as ClientButton from './src/components/ClientButton';"
+      );
+      expect(clientContent).to.include(
+        "import * as UniversalCard from './src/components/UniversalCard';"
+      );
+      expect(clientContent).to.not.include('ServerData'); // Should exclude server components
+      expect(clientContent).to.include("['ClientButton', ClientButton],");
+      expect(clientContent).to.include("['UniversalCard', UniversalCard],");
+    });
+
+    it('should generate only main component map when clientComponentMap is false', async () => {
+      const paths = ['src/components'];
+      // Reset stubs for this test - use getComponentList instead of getComponentListWithTypes
+      sandbox.restore();
+      const newSandbox = sinon.createSandbox();
+
+      const fakeComponentList = [
+        {
+          componentName: 'ClientButton',
+          moduleName: 'ClientButton',
+          importPath: './src/components/ClientButton',
+        },
+        {
+          componentName: 'ServerData',
+          moduleName: 'ServerData',
+          importPath: './src/components/ServerData',
+        },
+        {
+          componentName: 'UniversalCard',
+          moduleName: 'UniversalCard',
+          importPath: './src/components/UniversalCard',
+        },
+      ];
+
+      const getComponentListStub = newSandbox.stub().returns(fakeComponentList);
+      newSandbox.replaceGetter(coreTools, 'getComponentList', () => getComponentListStub);
+      newSandbox.stub(fs, 'writeFileSync');
+
+      generateMap({ paths, clientComponentMap: false });
+
+      expect(fs.writeFileSync).to.have.been.calledOnce;
+      expect(getComponentListStub).to.have.been.calledOnce;
+
+      const [dest, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
+      expect(dest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.ts'));
+      expect(content).to.include("import * as ClientButton from './src/components/ClientButton';");
+      expect(content).to.include("import * as ServerData from './src/components/ServerData';");
+      expect(content).to.include(
+        "import * as UniversalCard from './src/components/UniversalCard';"
+      );
+
+      newSandbox.restore();
+    });
+
+    it('should auto-detect App Router and generate both maps when clientComponentMap is undefined', async () => {
+      const paths = ['src/components'];
+      generateMap({ paths }); // clientComponentMap is undefined
+
+      expect(detectRouterTypeStub).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledTwice;
+    });
+
+    it('should auto-detect Pages Router and generate single map when clientComponentMap is undefined', async () => {
+      detectRouterTypeStub.returns('pages');
+      const paths = ['src/components'];
+      generateMap({ paths }); // clientComponentMap is undefined
+
+      expect(detectRouterTypeStub).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledOnce;
+    });
+
+    it('should use custom clientMapTemplate when provided', async () => {
+      const paths = ['src/components'];
+      const customClientTemplate = sandbox.stub().returns('// custom client template');
+      generateMap({ paths, clientComponentMap: true, clientMapTemplate: customClientTemplate });
+
+      expect(customClientTemplate).to.have.been.calledOnce;
+      expect(customClientTemplate.getCall(0).args[0]).to.deep.equal([
+        fakeComponentsWithTypes[0], // ClientButton
+        fakeComponentsWithTypes[2], // UniversalCard
+      ]);
+
+      const [, clientContent] = (fs.writeFileSync as sinon.SinonStub).getCall(1).args;
+      expect(clientContent).to.equal('// custom client template');
+    });
+
+    it('should handle errors when writing client component map fails', async () => {
+      const paths = ['src/components'];
+      (fs.writeFileSync as sinon.SinonStub)
+        .onFirstCall()
+        .returns(undefined) // Main map succeeds
+        .onSecondCall()
+        .throws(new Error('Client map write failed'));
+
+      expect(() => generateMap({ paths, clientComponentMap: true })).to.throw(
+        'Client map write failed'
+      );
+    });
+
+    it('should call getComponentListWithTypes when generating dual maps', async () => {
+      const paths = ['src/components'];
+      generateMap({ paths, clientComponentMap: true });
+
+      expect(getComponentListWithTypesStub).to.have.been.calledOnce;
+      expect(getComponentListWithTypesStub.getCall(0).args[0]).to.deep.equal(paths);
+    });
+
+    it('should call filterComponentsByType with correct component types for client map', async () => {
+      const paths = ['src/components'];
+      generateMap({ paths, clientComponentMap: true });
+
+      expect(filterComponentsByTypeStub).to.have.been.calledOnce;
+      expect(filterComponentsByTypeStub.getCall(0).args[0]).to.deep.equal(fakeComponentsWithTypes);
+      expect(filterComponentsByTypeStub.getCall(0).args[1]).to.deep.equal(['client', 'universal']);
+    });
+  });
 });

--- a/packages/nextjs/src/tools/generate-map.test.ts
+++ b/packages/nextjs/src/tools/generate-map.test.ts
@@ -57,7 +57,7 @@ describe('generateMap', () => {
       const paths = ['src/components'];
       generateMap({ paths });
 
-      expect(fs.writeFileSync).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledTwice;
       const [dest, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
       expect(dest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.ts'));
 
@@ -97,7 +97,7 @@ describe('generateMap', () => {
       expect(customTemplate).to.have.been.calledOnce;
       expect(customTemplate.getCall(0).args[0]).to.deep.equal(fakeComponentList);
       expect(customTemplate.getCall(0).args[1]).to.deep.equal(fakePackages);
-      expect(fs.writeFileSync).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledTwice;
       const [, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
       expect(content).to.equal('// custom template output');
     });
@@ -107,7 +107,7 @@ describe('generateMap', () => {
       const paths = ['src/components'];
       generateMap({ paths });
 
-      expect(fs.writeFileSync).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledTwice;
       const [, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
       expect(content).to.include(
         'export const componentMap = new Map<string, NextjsContentSdkComponent>('
@@ -145,14 +145,14 @@ describe('generateMap', () => {
     it('should not fail if packages is undefined', async () => {
       const paths = ['src/components'];
       expect(() => generateMap({ paths, componentImports: undefined })).to.not.throw();
-      expect(fs.writeFileSync).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledTwice;
     });
 
     it('should write componentMap.ts file with components from "paths" and "packages" parameters, when provided', async () => {
       const paths = ['src/components'];
       generateMap({ paths, componentImports: fakePackages });
 
-      expect(fs.writeFileSync).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledTwice;
       const [, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
       expect(content).to.include("import * as MyLib from '@my/lib';");
       expect(content).to.include("import { CompA, CompB } from '@other/lib';");
@@ -170,7 +170,8 @@ describe('generateMap', () => {
       const customDest = path.join(process.cwd(), 'custom/path', 'component-map.ts');
       generateMap({ paths, destination: 'custom/path' });
 
-      expect(fs.writeFileSync).to.have.been.calledOnceWith(
+      expect(fs.writeFileSync).to.have.been.calledTwice;
+      expect(fs.writeFileSync).to.have.been.calledWith(
         customDest,
         sinon.match.string,
         sinon.match.object
@@ -325,7 +326,7 @@ describe('generateMap', () => {
       expect(clientContent).to.include("['UniversalCard', UniversalCard],");
     });
 
-    it('should generate only main component map when clientComponentMap is false', async () => {
+    it('should generate both maps when clientComponentMap is false (for safety)', async () => {
       const paths = ['src/components'];
       // Reset stubs for this test - use getComponentList instead of getComponentListWithTypes
       sandbox.restore();
@@ -355,16 +356,25 @@ describe('generateMap', () => {
 
       generateMap({ paths, clientComponentMap: false });
 
-      expect(fs.writeFileSync).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledTwice;
       expect(getComponentListStub).to.have.been.calledOnce;
 
-      const [dest, content] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
-      expect(dest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.ts'));
-      expect(content).to.include("import * as ClientButton from './src/components/ClientButton';");
-      expect(content).to.include("import * as ServerData from './src/components/ServerData';");
-      expect(content).to.include(
+      // Check main component map (includes all components)
+      const [mainDest, mainContent] = (fs.writeFileSync as sinon.SinonStub).getCall(0).args;
+      expect(mainDest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.ts'));
+      expect(mainContent).to.include(
+        "import * as ClientButton from './src/components/ClientButton';"
+      );
+      expect(mainContent).to.include("import * as ServerData from './src/components/ServerData';");
+      expect(mainContent).to.include(
         "import * as UniversalCard from './src/components/UniversalCard';"
       );
+
+      // Check client component map (empty for safety)
+      const [clientDest, clientContent] = (fs.writeFileSync as sinon.SinonStub).getCall(1).args;
+      expect(clientDest).to.equal(path.join(process.cwd(), '.sitecore', 'component-map.client.ts'));
+      expect(clientContent).to.include('Client-safe component map for App Router');
+      expect(clientContent).to.not.include('ServerData'); // Should not include server components
 
       newSandbox.restore();
     });
@@ -377,13 +387,13 @@ describe('generateMap', () => {
       expect(fs.writeFileSync).to.have.been.calledTwice;
     });
 
-    it('should auto-detect Pages Router and generate single map when clientComponentMap is undefined', async () => {
+    it('should auto-detect Pages Router and generate both maps when clientComponentMap is undefined', async () => {
       detectRouterTypeStub.returns('pages');
       const paths = ['src/components'];
       generateMap({ paths }); // clientComponentMap is undefined
 
       expect(detectRouterTypeStub).to.have.been.calledOnce;
-      expect(fs.writeFileSync).to.have.been.calledOnce;
+      expect(fs.writeFileSync).to.have.been.calledTwice; // Now always generates both maps
     });
 
     it('should use custom clientMapTemplate when provided', async () => {

--- a/packages/nextjs/src/tools/generate-map.ts
+++ b/packages/nextjs/src/tools/generate-map.ts
@@ -78,7 +78,7 @@ export const generateMap: GenerateMapFunction = ({
       throw error;
     }
   } else {
-    // Pages Router - generate single component map + empty client map for safety
+    // Pages Router - generate single component map
     const components = getComponentList(paths, exclude);
     const componentMapContent = mapTemplate(components, componentImports);
     const componentMapFile = path.join(process.cwd(), destination, 'component-map.ts');
@@ -88,20 +88,6 @@ export const generateMap: GenerateMapFunction = ({
     } catch (error) {
       console.error(
         `Component Map generation failed. Error writing to file ${destination}:`,
-        error
-      );
-      throw error;
-    }
-
-    // Always generate client map for safety (even in Pages Router mode)
-    const emptyClientMapContent = nextjsClientMapTemplate([], componentImports);
-    const clientMapFile = path.join(process.cwd(), destination, 'component-map.client.ts');
-
-    try {
-      fs.writeFileSync(clientMapFile, emptyClientMapContent, { encoding: 'utf8' });
-    } catch (error) {
-      console.error(
-        `Client Component Map generation failed. Error writing to file ${destination}:`,
         error
       );
       throw error;

--- a/packages/nextjs/src/tools/generate-map.ts
+++ b/packages/nextjs/src/tools/generate-map.ts
@@ -78,7 +78,7 @@ export const generateMap: GenerateMapFunction = ({
       throw error;
     }
   } else {
-    // Pages Router - generate single component map
+    // Pages Router - generate single component map + empty client map for safety
     const components = getComponentList(paths, exclude);
     const componentMapContent = mapTemplate(components, componentImports);
     const componentMapFile = path.join(process.cwd(), destination, 'component-map.ts');
@@ -88,6 +88,20 @@ export const generateMap: GenerateMapFunction = ({
     } catch (error) {
       console.error(
         `Component Map generation failed. Error writing to file ${destination}:`,
+        error
+      );
+      throw error;
+    }
+
+    // Always generate client map for safety (even in Pages Router mode)
+    const emptyClientMapContent = nextjsClientMapTemplate([], componentImports);
+    const clientMapFile = path.join(process.cwd(), destination, 'component-map.client.ts');
+
+    try {
+      fs.writeFileSync(clientMapFile, emptyClientMapContent, { encoding: 'utf8' });
+    } catch (error) {
+      console.error(
+        `Client Component Map generation failed. Error writing to file ${destination}:`,
         error
       );
       throw error;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

With this PR,  we've added a default client map to the App Router template to ensure new projects always have the required file. This fixes the import issue in `Providers.tsx` that caused the generated app to fail.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
