### PR TITLE
[nextjs] Explictly mark components in full component map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Our versioning strategy is as follows:
   - Robots.txt and Sitemap.xml support ([#197](https://github.com/Sitecore/content-sdk/pull/197))
   - Editing and preview support ([#198](https://github.com/Sitecore/content-sdk/pull/198))
   - Internationalization support ([#202](https://github.com/Sitecore/content-sdk/pull/202)) ([#214](https://github.com/Sitecore/content-sdk/pull/214))
-  - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))([#234](https://github.com/Sitecore/content-sdk/pull/234))
+  - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))([#234](https://github.com/Sitecore/content-sdk/pull/234))([#235](https://github.com/Sitecore/content-sdk/pull/235))
 * [nextjs] Slim down sample even more ([#225](https://github.com/Sitecore/content-sdk/pull/225))
 * Mark client components with `use client` directive. ([#226](https://github.com/Sitecore/content-sdk/pull/226))
 

--- a/packages/nextjs/src/tools/generate-map.test.ts
+++ b/packages/nextjs/src/tools/generate-map.test.ts
@@ -307,7 +307,9 @@ describe('generateMap', () => {
       expect(mainContent).to.include(
         "import * as UniversalCard from './src/components/UniversalCard';"
       );
-      expect(mainContent).to.include("['ClientButton', ClientButton],");
+      expect(mainContent).to.include(
+        "['ClientButton', {...ClientButton, componentType: 'client'}],"
+      );
       expect(mainContent).to.include("['ServerData', ServerData],");
       expect(mainContent).to.include("['UniversalCard', UniversalCard],");
 

--- a/packages/nextjs/src/tools/generate-map.ts
+++ b/packages/nextjs/src/tools/generate-map.ts
@@ -25,7 +25,6 @@ import * as fs from 'fs';
  * Template Customization:
  * - mapTemplate: Custom template for main component map (works for both single and dual map modes)
  * - clientMapTemplate: Custom template for client component map (only used when clientComponentMap is true)
- *
  * @param {GenerateMapArgs} param0 params for generateMap
  */
 export const generateMap: GenerateMapFunction = ({
@@ -99,14 +98,18 @@ export const generateMap: GenerateMapFunction = ({
  * Template options for component map generation
  */
 type TemplateOptions = {
-  /** Whether to include inline componentType for non-universal components */
-  includeComponentType?: boolean;
   /** Custom header comment for the generated map */
   headerComment?: string;
+  /** Whether this is a client-only map (no need for componentType annotations) */
+  isClientMap?: boolean;
 };
 
 /**
  * Unified template function for all component map generation
+ * @param {ComponentFile[] | ComponentFileWithType[]} components - Array of components to include in the map
+ * @param {ComponentImport[]} [componentImports] - Optional array of component imports to include
+ * @param {TemplateOptions} [options] - Template generation options
+ * @returns {string} Generated component map content
  */
 const nextjsUnifiedTemplate = (
   components: (ComponentFile | ComponentFileWithType)[],
@@ -114,8 +117,8 @@ const nextjsUnifiedTemplate = (
   options: TemplateOptions = {}
 ): string => {
   const {
-    includeComponentType = false,
     headerComment = "Below are built-in components that are available in the app, it's recommended to keep them as is",
+    isClientMap = false,
   } = options;
 
   const wildcardImports: string[] = [];
@@ -126,14 +129,12 @@ const nextjsUnifiedTemplate = (
     // Clean imports only
     wildcardImports.push(`import * as ${component.moduleName} from '${component.importPath}';`);
 
-    // Handle componentType if requested and available
-    if (
-      includeComponentType &&
-      'componentType' in component &&
-      component.componentType !== 'universal'
-    ) {
+    // Handle componentType for client components (components with 'use client' directive)
+    // Only add componentType: 'client' for components that actually use 'use client' directive
+    // Skip this for client-only maps since all components are already client components
+    if (!isClientMap && 'componentType' in component && component.componentType === 'client') {
       componentMapEntries.push(
-        `['${component.moduleName}', {...${component.moduleName}, componentType: '${component.componentType}'}]`
+        `['${component.moduleName}', {...${component.moduleName}, componentType: 'client'}]`
       );
     } else {
       componentMapEntries.push(`['${component.moduleName}', ${component.moduleName}]`);
@@ -192,7 +193,6 @@ const nextjsMapTemplateWithTypes = (
   componentImports?: ComponentImport[]
 ): string => {
   return nextjsUnifiedTemplate(components, componentImports, {
-    includeComponentType: true,
     headerComment:
       "Below are built-in components that are available in the app, it's recommended to keep them as is",
   });
@@ -203,7 +203,6 @@ const nextjsMapTemplate = (
   componentImports?: ComponentImport[]
 ): string => {
   return nextjsUnifiedTemplate(components, componentImports, {
-    includeComponentType: false,
     headerComment:
       "Below are built-in components that are available in the app, it's recommended to keep them as is",
   });
@@ -214,7 +213,7 @@ const nextjsClientMapTemplate = (
   componentImports?: ComponentImport[]
 ): string => {
   return nextjsUnifiedTemplate(components, componentImports, {
-    includeComponentType: false, // Client components are already filtered, no need for type info
     headerComment: 'Client-safe component map for App Router',
+    isClientMap: true,
   });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Only add `componentType: 'client' ` to components with `'use client'` directive in the main component map. Client component map remains unchanged.

Examples:
Full map: `['ClientComp', {...ClientComp, componentType: 'client'}]` for client components
Client map:` ['ClientComp', ClientComp]` (no annotations)

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
