### PR TITLE
[App Router] Prevent build-time Edge fetches (guarded not-found, SSR default, gated SSG)

### DIFF
--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/not-found.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/not-found.tsx
@@ -8,14 +8,20 @@ import Layout from 'src/Layout';
 import Providers from 'src/Providers';
 import { NextIntlClientProvider } from 'next-intl';
 
+export const dynamic = 'force-dynamic';
+
 export default async function NotFound() {
   const headersList = await headers();
   const { site, locale } = parseRewriteHeader(headersList);
 
-  const page = await client.getErrorPage(ErrorPage.NotFound, {
-    site: site || scConfig.defaultSite,
-    locale: locale || scConfig.defaultLanguage,
-  });
+  const resolvedSite = site || scConfig.defaultSite;
+  const resolvedLocale = locale || scConfig.defaultLanguage;
+  const page = resolvedSite
+    ? await client.getErrorPage(ErrorPage.NotFound, {
+        site: resolvedSite,
+        locale: resolvedLocale,
+      })
+    : null;
 
   if (page) {
     return (

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/page.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/page.tsx
@@ -1,13 +1,14 @@
 import { isDesignLibraryPreviewData } from '@sitecore-content-sdk/nextjs/editing';
 import { notFound } from 'next/navigation';
-import { draftMode } from 'next/headers'
+import { draftMode } from 'next/headers';
 <% if (prerender === 'SSG') { -%>
 import { SiteInfo } from '@sitecore-content-sdk/nextjs';
 import sites from '.sitecore/sites.json';
 import { routing } from 'src/i18n/routing';
+import scConfig from 'sitecore.config';
 <% } -%>
 import client from 'src/lib/sitecore-client';
-import Layout, { RouteFields } from 'src/Layout';
+import Layout from 'src/Layout';
 import components from '.sitecore/component-map';
 import Providers from 'src/Providers';
 import Bootstrap from 'src/Bootstrap';
@@ -15,7 +16,12 @@ import { NextIntlClientProvider } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
 
 type PageProps = {
-  params: Promise<{ site: string; locale: string; path?: string[]; [key: string]: string | string[] | undefined }>;
+  params: Promise<{
+    site: string;
+    locale: string;
+    path?: string[];
+    [key: string]: string | string[] | undefined;
+  }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
@@ -59,22 +65,25 @@ export default async function Page({ params, searchParams }: PageProps) {
   );
 }
 
-<% if (prerender === 'SSG') { -%>
-// This function gets called at build and export time to determine
-// pages for SSG ("paths", as tokenized array).
-export const generateStaticParams = async () => {
-  return await client.getAppRouterStaticParams(
-    sites.map((site: SiteInfo) => site.name),
-    routing.locales.slice()
-  );
-};
+<% if (prerender === 'SSR') { -%>
+export const dynamic = 'force-dynamic';
 <% } -%>
 // Metadata fields for the page.
-export const generateMetadata = async ({ params }: PageProps) => {
-  const { path } = await params;
-  // The same call as for rendering the page. Should be cached by default react behavior
-  const page = await client.getPage(path ?? [], { locale: 'en' });
-  return {
-    title: (page?.layout.sitecore.route?.fields as RouteFields)?.Title?.value?.toString() || 'Page',
-  };
+export const generateMetadata = async () => ({
+  title: 'Page',
+});
+
+<% if (prerender === 'SSG') { -%>
+// Generate static params only when explicitly enabled and sites/locales exist
+export const generateStaticParams = async () => {
+  if (!scConfig?.generateStaticPaths) {
+    return [];
+  }
+  const siteNames = Array.isArray(sites) ? sites.map((s: SiteInfo) => s.name).filter(Boolean) : [];
+  const locales = Array.isArray(routing.locales) ? routing.locales.slice() : [];
+  if (!siteNames.length || !locales.length) {
+    return [];
+  }
+  return await client.getAppRouterStaticParams(siteNames, locales);
 };
+<% } -%>

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/not-found.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/not-found.tsx
@@ -5,11 +5,16 @@ import { ErrorPage } from '@sitecore-content-sdk/nextjs';
 import Layout from 'src/Layout';
 import Providers from 'src/Providers';
 
+export const dynamic = 'force-dynamic';
+
 export default async function NotFound() {
-  const page = await client.getErrorPage(ErrorPage.NotFound, {
-    site: scConfig.defaultSite,
-    locale: scConfig.defaultLanguage,
-  });
+  const site = scConfig.defaultSite;
+  const page = site
+    ? await client.getErrorPage(ErrorPage.NotFound, {
+        site,
+        locale: scConfig.defaultLanguage,
+      })
+    : null;
 
   if (page) {
     return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
**Problem**: App Router builds failed during prerender of /_not-found when NEXT_PUBLIC_DEFAULT_SITE_NAME cant be found

**Changes by file:**

src/app/not-found.tsx
- Added export const dynamic = 'force-dynamic'.
- Guarded getErrorPage to only call when scConfig.defaultSite is provided; otherwise render the existing simple fallback.

src/app/[site]/[locale]/[[...path]]/not-found.tsx
- Added export const dynamic = 'force-dynamic'.
- Resolved site/locale from rewrite header (middleware) or scConfig.defaultSite/defaultLanguage; call getErrorPage only when a site is present; otherwise render fallback.

src/app/[site]/[locale]/[[...path]]/page.tsx
- Default SSR: export const dynamic = 'force-dynamic'.
- Replaced metadata with a static generateMetadata (no Edge calls at build).
- Re-enabled optional SSG: when the scaffold selects SSG, export generateStaticParams gated by scConfig.generateStaticPaths and available sites/locales; otherwise return []. This mirrors Pages Router’s gated SSG behavior and avoids build-time GraphQL when not explicitly enabled.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
