### PR TITLE
[App Router] Guard static params generation and harden not-found routes for XM Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[template/nextjs]` `[template/next-app-router]` Fix imports for SSR/SSG ([#229](https://github.com/Sitecore/content-sdk/pull/229))
-* `[app-router]` Guard static params generation and harden not-found routes for XM Cloud ([#242](https://github.com/Sitecore/content-sdk/pull/242))
+* `[template/next-app-router]` Guard static params generation and harden not-found routes for XM Cloud ([#242](https://github.com/Sitecore/content-sdk/pull/242))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[template/nextjs]` `[template/next-app-router]` Fix imports for SSR/SSG ([#229](https://github.com/Sitecore/content-sdk/pull/229))
+* `[app-router]` Guard static params generation and harden not-found routes for XM Cloud ([#242](https://github.com/Sitecore/content-sdk/pull/242))
 
 ### 🧹 Chores
 

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/not-found.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/not-found.tsx
@@ -12,6 +12,16 @@ export default async function NotFound() {
   const headersList = await headers();
   const { site, locale } = parseRewriteHeader(headersList);
 
+  if (!(site && site.trim()) && (!scConfig.defaultSite || scConfig.defaultSite.trim() === '')) {
+    return (
+      <div style={{ padding: 10 }}>
+        <h1>Page not found</h1>
+        <p>This page does not exist.</p>
+        <Link href="/">Go to the Home page</Link>
+      </div>
+    );
+  }
+
   const page = await client.getErrorPage(ErrorPage.NotFound, {
     site: site || scConfig.defaultSite,
     locale: locale || scConfig.defaultLanguage,

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/not-found.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/not-found.tsx
@@ -12,16 +12,6 @@ export default async function NotFound() {
   const headersList = await headers();
   const { site, locale } = parseRewriteHeader(headersList);
 
-  if (!(site && site.trim()) && (!scConfig.defaultSite || scConfig.defaultSite.trim() === '')) {
-    return (
-      <div style={{ padding: 10 }}>
-        <h1>Page not found</h1>
-        <p>This page does not exist.</p>
-        <Link href="/">Go to the Home page</Link>
-      </div>
-    );
-  }
-
   const page = await client.getErrorPage(ErrorPage.NotFound, {
     site: site || scConfig.defaultSite,
     locale: locale || scConfig.defaultLanguage,

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/page.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/page.tsx
@@ -5,6 +5,7 @@ import { draftMode } from 'next/headers'
 import { SiteInfo } from '@sitecore-content-sdk/nextjs';
 import sites from '.sitecore/sites.json';
 import { routing } from 'src/i18n/routing';
+import scConfig from 'sitecore.config';
 <% } -%>
 import client from 'src/lib/sitecore-client';
 import Layout, { RouteFields } from 'src/Layout';
@@ -63,10 +64,13 @@ export default async function Page({ params, searchParams }: PageProps) {
 // This function gets called at build and export time to determine
 // pages for SSG ("paths", as tokenized array).
 export const generateStaticParams = async () => {
-  return await client.getAppRouterStaticParams(
-    sites.map((site: SiteInfo) => site.name),
-    routing.locales.slice()
-  );
+  if (process.env.NODE_ENV !== 'development' && scConfig.generateStaticPaths) {
+    return await client.getAppRouterStaticParams(
+      sites.map((site: SiteInfo) => site.name),
+      routing.locales.slice()
+    );
+  }
+  return [];
 };
 <% } -%>
 // Metadata fields for the page.

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/not-found.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/not-found.tsx
@@ -6,7 +6,7 @@ import Layout from 'src/Layout';
 import Providers from 'src/Providers';
 
 export default async function NotFound() {
-  if (scConfig.defaultSite && scConfig.defaultSite.trim() !== '') {
+  if (scConfig.defaultSite) {
     const page = await client.getErrorPage(ErrorPage.NotFound, {
       site: scConfig.defaultSite,
       locale: scConfig.defaultLanguage,

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/not-found.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/not-found.tsx
@@ -6,6 +6,16 @@ import Layout from 'src/Layout';
 import Providers from 'src/Providers';
 
 export default async function NotFound() {
+  if (!scConfig.defaultSite || scConfig.defaultSite.trim() === '') {
+    return (
+      <div style={{ padding: 10 }}>
+        <h1>Page not found</h1>
+        <p>This page does not exist.</p>
+        <Link href="/">Go to the Home page</Link>
+      </div>
+    );
+  }
+
   const page = await client.getErrorPage(ErrorPage.NotFound, {
     site: scConfig.defaultSite,
     locale: scConfig.defaultLanguage,

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/not-found.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/not-found.tsx
@@ -6,27 +6,19 @@ import Layout from 'src/Layout';
 import Providers from 'src/Providers';
 
 export default async function NotFound() {
-  if (!scConfig.defaultSite || scConfig.defaultSite.trim() === '') {
-    return (
-      <div style={{ padding: 10 }}>
-        <h1>Page not found</h1>
-        <p>This page does not exist.</p>
-        <Link href="/">Go to the Home page</Link>
-      </div>
-    );
-  }
+  if (scConfig.defaultSite && scConfig.defaultSite.trim() !== '') {
+    const page = await client.getErrorPage(ErrorPage.NotFound, {
+      site: scConfig.defaultSite,
+      locale: scConfig.defaultLanguage,
+    });
 
-  const page = await client.getErrorPage(ErrorPage.NotFound, {
-    site: scConfig.defaultSite,
-    locale: scConfig.defaultLanguage,
-  });
-
-  if (page) {
-    return (
-      <Providers page={page}>
-        <Layout page={page} />
-      </Providers>
-    );
+    if (page) {
+      return (
+        <Providers page={page}>
+          <Layout page={page} />
+        </Providers>
+      );
+    }
   }
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Problem:

- XM Cloud builds failed with “siteName not found” when GENERATE_STATIC_PATHS was not defined. In XMC there are no sites at deploy time, so static path generation and Sitecore error page fetches must be skipped.

Changes

- Added a guard to generateStaticParams to only generate static params when not in development and when scConfig.generateStaticPaths is true; otherwise return [].
- Modify not-found pages to render a local fallback when no site is configured/derivable, avoiding Sitecore error page fetches that require a siteName.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
