### PR TITLE
[create-content-sdk-app] Prevent CloudSDK re-initialization on client-side navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,16 @@ Our versioning strategy is as follows:
   - Editing and preview support ([#198](https://github.com/Sitecore/content-sdk/pull/198))
   - Internationalization support ([#202](https://github.com/Sitecore/content-sdk/pull/202)) ([#214](https://github.com/Sitecore/content-sdk/pull/214))
   - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))([#234](https://github.com/Sitecore/content-sdk/pull/234))([#235](https://github.com/Sitecore/content-sdk/pull/235))([#241](https://github.com/Sitecore/content-sdk/pull/241))
-  - Prevent CloudSDK re-initialization on client-side navigation ([#243](https://github.com/Sitecore/content-sdk/pull/243))
+ 
 * [nextjs] Slim down sample even more ([#225](https://github.com/Sitecore/content-sdk/pull/225))
 * Mark client components with `use client` directive. ([#226](https://github.com/Sitecore/content-sdk/pull/226))
 * Add LLMs and Copilot instruction files for improved AI guidance ([#239](https://github.com/Sitecore/content-sdk/pull/239))
 
-### 🐛 Bug Fixes	
+### 🐛 Bug Fixes
 
 * `[template/nextjs]` `[template/next-app-router]` Fix imports for SSR/SSG ([#229](https://github.com/Sitecore/content-sdk/pull/229))
 * `[template/next-app-router]` Guard static params generation and harden not-found routes for XM Cloud ([#242](https://github.com/Sitecore/content-sdk/pull/242))
+* `[template/next-app-router]` Prevent CloudSDK re-initialization on client-side navigation ([#243](https://github.com/Sitecore/content-sdk/pull/243))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Our versioning strategy is as follows:
   - Editing and preview support ([#198](https://github.com/Sitecore/content-sdk/pull/198))
   - Internationalization support ([#202](https://github.com/Sitecore/content-sdk/pull/202)) ([#214](https://github.com/Sitecore/content-sdk/pull/214))
   - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))([#234](https://github.com/Sitecore/content-sdk/pull/234))([#235](https://github.com/Sitecore/content-sdk/pull/235))([#241](https://github.com/Sitecore/content-sdk/pull/241))
- 
 * [nextjs] Slim down sample even more ([#225](https://github.com/Sitecore/content-sdk/pull/225))
 * Mark client components with `use client` directive. ([#226](https://github.com/Sitecore/content-sdk/pull/226))
 * Add LLMs and Copilot instruction files for improved AI guidance ([#239](https://github.com/Sitecore/content-sdk/pull/239))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Our versioning strategy is as follows:
   - Editing and preview support ([#198](https://github.com/Sitecore/content-sdk/pull/198))
   - Internationalization support ([#202](https://github.com/Sitecore/content-sdk/pull/202)) ([#214](https://github.com/Sitecore/content-sdk/pull/214))
   - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))([#234](https://github.com/Sitecore/content-sdk/pull/234))([#235](https://github.com/Sitecore/content-sdk/pull/235))([#241](https://github.com/Sitecore/content-sdk/pull/241))
+	- Prevent CloudSDK re-initialization on client-side navigation ([#243](https://github.com/Sitecore/content-sdk/pull/243))
 * [nextjs] Slim down sample even more ([#225](https://github.com/Sitecore/content-sdk/pull/225))
 * Mark client components with `use client` directive. ([#226](https://github.com/Sitecore/content-sdk/pull/226))
 * Add LLMs and Copilot instruction files for improved AI guidance ([#239](https://github.com/Sitecore/content-sdk/pull/239))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Our versioning strategy is as follows:
 * Mark client components with `use client` directive. ([#226](https://github.com/Sitecore/content-sdk/pull/226))
 * Add LLMs and Copilot instruction files for improved AI guidance ([#239](https://github.com/Sitecore/content-sdk/pull/239))
 
-### 🐛 Bug Fixes
+### 🐛 Bug Fixes	
 
 * `[template/nextjs]` `[template/next-app-router]` Fix imports for SSR/SSG ([#229](https://github.com/Sitecore/content-sdk/pull/229))
 * `[template/next-app-router]` Guard static params generation and harden not-found routes for XM Cloud ([#242](https://github.com/Sitecore/content-sdk/pull/242))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Our versioning strategy is as follows:
   - Editing and preview support ([#198](https://github.com/Sitecore/content-sdk/pull/198))
   - Internationalization support ([#202](https://github.com/Sitecore/content-sdk/pull/202)) ([#214](https://github.com/Sitecore/content-sdk/pull/214))
   - Client-server component map separation ([#230](https://github.com/Sitecore/content-sdk/pull/230))([#232](https://github.com/Sitecore/content-sdk/pull/232))([#234](https://github.com/Sitecore/content-sdk/pull/234))([#235](https://github.com/Sitecore/content-sdk/pull/235))([#241](https://github.com/Sitecore/content-sdk/pull/241))
-	- Prevent CloudSDK re-initialization on client-side navigation ([#243](https://github.com/Sitecore/content-sdk/pull/243))
+  - Prevent CloudSDK re-initialization on client-side navigation ([#243](https://github.com/Sitecore/content-sdk/pull/243))
 * [nextjs] Slim down sample even more ([#225](https://github.com/Sitecore/content-sdk/pull/225))
 * Mark client components with `use client` directive. ([#226](https://github.com/Sitecore/content-sdk/pull/226))
 * Add LLMs and Copilot instruction files for improved AI guidance ([#239](https://github.com/Sitecore/content-sdk/pull/239))

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Bootstrap.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Bootstrap.tsx
@@ -1,48 +1,47 @@
 'use client';
-import { useEffect, JSX } from 'react';
+import { useEffect, useRef, JSX } from 'react';
 import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
-import { SitecorePageProps } from '@sitecore-content-sdk/nextjs';
+import { useSearchParams } from 'next/navigation';
 import '@sitecore-cloudsdk/events/browser';
 import config from 'sitecore.config';
 
-/**
- * The Bootstrap component is the entry point for performing any initialization logic
- * that needs to happen early in the application's lifecycle.
- * @param props
- */
-const Bootstrap = (props: SitecorePageProps): JSX.Element | null => {
-  const { page } = props;
-
-  // Browser ClientSDK init allows for page view events to be tracked
+const Bootstrap = ({ siteName }: { siteName: string }): JSX.Element | null => {
+  const searchParams = useSearchParams();
+  const sdkInitialized = useRef(false);
+  const currentSiteName = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!page) {
+    const isPreviewMode = searchParams.has('sc_itemid') || searchParams.has('sc_mode');
+
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('Browser Events SDK is not initialized in development environment');
       return;
     }
 
-    const mode = page.mode;
-    if (process.env.NODE_ENV === 'development') {
-      console.debug('Browser Events SDK is not initialized in development environment');
-    } else if (!mode.isNormal) {
+    if (isPreviewMode) {
       console.debug('Browser Events SDK is not initialized in edit and preview modes');
-    } else {
+      return;
+    }
+
+    if (!sdkInitialized.current || currentSiteName.current !== siteName) {
       if (config.api.edge?.clientContextId) {
         CloudSDK({
           sitecoreEdgeUrl: config.api.edge.edgeUrl,
           sitecoreEdgeContextId: config.api.edge.clientContextId,
-          siteName: page.siteName || config.defaultSite,
+          siteName: siteName || config.defaultSite,
           enableBrowserCookie: true,
-          // Replace with the top level cookie domain of the website that is being integrated e.g ".example.com" and not "www.example.com"
           cookieDomain: window.location.hostname.replace(/^www\./, ''),
         })
           .addEvents()
           .initialize();
+
+        sdkInitialized.current = true;
+        currentSiteName.current = siteName;
       } else {
         console.error('Client Edge API settings missing from configuration');
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page?.siteName]);
+  }, [siteName, searchParams]);
 
   return null;
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Bootstrap.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Bootstrap.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useRef, JSX } from 'react';
+import { useEffect, JSX } from 'react';
 import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
 import '@sitecore-cloudsdk/events/browser';
 import config from 'sitecore.config';
@@ -11,8 +11,6 @@ const Bootstrap = ({
   siteName: string;
   isPreviewMode: boolean;
 }): JSX.Element | null => {
-  const sdkInitialized = useRef(false);
-
   useEffect(() => {
     if (process.env.NODE_ENV === 'development') {
       console.debug('Browser Events SDK is not initialized in development environment');
@@ -24,11 +22,8 @@ const Bootstrap = ({
       return;
     }
 
-    if (sdkInitialized.current) {
-      return;
-    }
-
     if (config.api.edge?.clientContextId) {
+      console.log('✨ Initializing CloudSDK for site:', siteName);
       CloudSDK({
         sitecoreEdgeUrl: config.api.edge.edgeUrl,
         sitecoreEdgeContextId: config.api.edge.clientContextId,
@@ -38,8 +33,6 @@ const Bootstrap = ({
       })
         .addEvents()
         .initialize();
-
-      sdkInitialized.current = true;
     } else {
       console.error('Client Edge API settings missing from configuration');
     }

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Bootstrap.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Bootstrap.tsx
@@ -1,18 +1,19 @@
 'use client';
 import { useEffect, useRef, JSX } from 'react';
 import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
-import { useSearchParams } from 'next/navigation';
 import '@sitecore-cloudsdk/events/browser';
 import config from 'sitecore.config';
 
-const Bootstrap = ({ siteName }: { siteName: string }): JSX.Element | null => {
-  const searchParams = useSearchParams();
+const Bootstrap = ({
+  siteName,
+  isPreviewMode,
+}: {
+  siteName: string;
+  isPreviewMode: boolean;
+}): JSX.Element | null => {
   const sdkInitialized = useRef(false);
-  const currentSiteName = useRef<string | null>(null);
 
   useEffect(() => {
-    const isPreviewMode = searchParams.has('sc_itemid') || searchParams.has('sc_mode');
-
     if (process.env.NODE_ENV === 'development') {
       console.debug('Browser Events SDK is not initialized in development environment');
       return;
@@ -23,25 +24,26 @@ const Bootstrap = ({ siteName }: { siteName: string }): JSX.Element | null => {
       return;
     }
 
-    if (!sdkInitialized.current || currentSiteName.current !== siteName) {
-      if (config.api.edge?.clientContextId) {
-        CloudSDK({
-          sitecoreEdgeUrl: config.api.edge.edgeUrl,
-          sitecoreEdgeContextId: config.api.edge.clientContextId,
-          siteName: siteName || config.defaultSite,
-          enableBrowserCookie: true,
-          cookieDomain: window.location.hostname.replace(/^www\./, ''),
-        })
-          .addEvents()
-          .initialize();
-
-        sdkInitialized.current = true;
-        currentSiteName.current = siteName;
-      } else {
-        console.error('Client Edge API settings missing from configuration');
-      }
+    if (sdkInitialized.current) {
+      return;
     }
-  }, [siteName, searchParams]);
+
+    if (config.api.edge?.clientContextId) {
+      CloudSDK({
+        sitecoreEdgeUrl: config.api.edge.edgeUrl,
+        sitecoreEdgeContextId: config.api.edge.clientContextId,
+        siteName: siteName || config.defaultSite,
+        enableBrowserCookie: true,
+        cookieDomain: window.location.hostname.replace(/^www\./, ''),
+      })
+        .addEvents()
+        .initialize();
+
+      sdkInitialized.current = true;
+    } else {
+      console.error('Client Edge API settings missing from configuration');
+    }
+  }, [siteName, isPreviewMode]);
 
   return null;
 };

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/page.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/page.tsx
@@ -10,7 +10,6 @@ import client from 'src/lib/sitecore-client';
 import Layout, { RouteFields } from 'src/Layout';
 import components from '.sitecore/component-map';
 import Providers from 'src/Providers';
-import Bootstrap from 'src/Bootstrap';
 import { NextIntlClientProvider } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
 
@@ -48,14 +47,11 @@ export default async function Page({ params, searchParams }: PageProps) {
   const componentProps = await client.getComponentData(page.layout, {}, components);
 
   return (
-    <>
-      <Bootstrap page={page} />
-      <NextIntlClientProvider>
-        <Providers page={page} componentProps={componentProps}>
-          <Layout page={page} />
-        </Providers>
-      </NextIntlClientProvider>
-    </>
+    <NextIntlClientProvider>
+      <Providers page={page} componentProps={componentProps}>
+        <Layout page={page} />
+      </Providers>
+    </NextIntlClientProvider>
   );
 }
 

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/layout.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/layout.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { draftMode } from 'next/headers';
 import Bootstrap from 'src/Bootstrap';
 
 export default async function SiteLayout({
@@ -9,12 +9,11 @@ export default async function SiteLayout({
   params: Promise<{ site: string }>;
 }) {
   const { site } = await params;
+  const { isEnabled } = await draftMode();
 
   return (
     <>
-      <Suspense fallback={null}>
-        <Bootstrap siteName={site} />
-      </Suspense>
+      <Bootstrap siteName={site} isPreviewMode={isEnabled} />
       {children}
     </>
   );

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/layout.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/layout.tsx
@@ -1,0 +1,18 @@
+import Bootstrap from 'src/Bootstrap';
+
+export default async function SiteLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ site: string }>;
+}) {
+  const { site } = await params;
+
+  return (
+    <>
+      <Bootstrap siteName={site} />
+      {children}
+    </>
+  );
+}

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/layout.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import Bootstrap from 'src/Bootstrap';
 
 export default async function SiteLayout({
@@ -11,7 +12,9 @@ export default async function SiteLayout({
 
   return (
     <>
-      <Bootstrap siteName={site} />
+      <Suspense fallback={null}>
+        <Bootstrap siteName={site} />
+      </Suspense>
       {children}
     </>
   );


### PR DESCRIPTION
- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
The issue was that CloudSDK was re-initializing on every route change due to Bootstrap component unmounting/remounting with each navigation, causing unnecessary overhead and potential side effects.

### Solution
Moved Bootstrap component from `[[...path]]/page.tsx` to `[site]/layout.tsx`. This keeps the component mounted across navigations since the site-level layout has a stable React key that only changes when the site changes.

With this fix, CloudSDK now initializes once per site and only re-initializes when switching between sites. Client-side navigation within the same site skips initialization entirely.

### Changes
- Created `app/[site]/layout.tsx` with Bootstrap component
- Updated `Bootstrap.tsx` to accept `siteName` prop and use `useRef` for initialization tracking
- Removed Bootstrap from `page.tsx`

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other 

Verified fix by adding test navigation component with Next.js Links to sample app. Navigated between multiple pages and confirmed:

- Initial page load: CloudSDK initializes once
- Client-side navigation: Using Console logs, it shows "already initialized - skipping" with no unmount messages
- Full page reload: Re-initializes correctly (expected behavior for new app instance)
- Cross-site navigation: Re-initializes with new site name (expected behavior)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
