### PR TITLE
[App Router] Unable to render 'preview' without default sitename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[template/nextjs]` `[template/next-app-router]` Fix imports for SSR/SSG ([#229](https://github.com/Sitecore/content-sdk/pull/229))
+* `[template/next-app-router]` Unable to render 'preview' without default sitename ([#247](https://github.com/Sitecore/content-sdk/pull/247))
 * `[template/next-app-router]` Guard static params generation and harden not-found routes for XM Cloud ([#242](https://github.com/Sitecore/content-sdk/pull/242))
 * `[template/next-app-router]` Prevent CloudSDK re-initialization on client-side navigation ([#243](https://github.com/Sitecore/content-sdk/pull/243))
 

--- a/packages/core/src/i18n/utils.test.ts
+++ b/packages/core/src/i18n/utils.test.ts
@@ -20,7 +20,7 @@ describe('utils', () => {
     it('should return the root path with the locale', () => {
       const pathname = '/';
       const result = getLocaleRewrite(pathname, defaultLocale);
-      expect(result).to.equal(`/en/`);
+      expect(result).to.equal(`/en`);
     });
   });
 });

--- a/packages/core/src/i18n/utils.ts
+++ b/packages/core/src/i18n/utils.ts
@@ -5,6 +5,8 @@
  * @returns {string} the rewrite path
  */
 export function getLocaleRewrite(pathname: string, locale: string): string {
+  if (pathname === '/') return `/${locale}`;
+  
   const path = pathname.startsWith('/') ? pathname : '/' + pathname;
 
   return `/${locale}${path}`;

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/page.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/app/[site]/[locale]/[[...path]]/page.tsx
@@ -71,9 +71,10 @@ export const generateStaticParams = async () => {
 <% } -%>
 // Metadata fields for the page.
 export const generateMetadata = async ({ params }: PageProps) => {
-  const { path } = await params;
+  const { path, site, locale } = await params;
+
   // The same call as for rendering the page. Should be cached by default react behavior
-  const page = await client.getPage(path ?? [], { locale: 'en' });
+  const page = await client.getPage(path ?? [], { site, locale });
   return {
     title: (page?.layout.sitecore.route?.fields as RouteFields)?.Title?.value?.toString() || 'Page',
   };

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/middleware.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/middleware.ts
@@ -74,12 +74,15 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
 export const config = {
   /*
    * Match all paths except for:
-   * 1. API route handlers: /sitemap.xml and /robots.txt routes
+   * 1. API route handlers
    * 2. /_next (Next.js internals)
    * 3. /sitecore/api (Sitecore API routes)
    * 4. /- (Sitecore media)
    * 5. /healthz (Health check)
    * 7. all root files inside /public
    */
-  matcher: ['/', '/((?!sitemap|robots|_next/|healthz|sitecore/api/|-/|favicon.ico|sc_logo.svg).*)'],
+  matcher: [
+    '/',
+    '/((?!api/|sitemap|robots|_next/|healthz|sitecore/api/|-/|favicon.ico|sc_logo.svg).*)',
+  ],
 };

--- a/packages/nextjs/src/middleware/multisite-middleware.test.ts
+++ b/packages/nextjs/src/middleware/multisite-middleware.test.ts
@@ -624,6 +624,49 @@ describe('MultisiteMiddleware', () => {
       });
     });
 
+    it('site querystring parameter is provided', async () => {
+      const req = createRequest({
+        searchParams: { site: 'qsFoo' },
+      });
+
+      const res = createResponse();
+
+      nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
+      const { middleware, siteResolver } = createMiddleware({
+        useCookieResolution: () => true,
+      });
+
+      const finalRes = await middleware.handle(req, res);
+
+      validateDebugLog('multisite middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+        hostname: 'foo.net',
+      });
+
+      validateEndMessageDebugLog('multisite middleware end in %dms: %o', {
+        rewritePath: '/_site_qsFoo/styleguide',
+        siteName: 'qsFoo',
+        headers: {
+          'x-sc-rewrite': '/_site_qsFoo/styleguide',
+        },
+        cookies: {
+          ...res.cookies,
+        },
+      });
+
+      expect(siteResolver.getByHost).not.called.equal(true);
+      expect(siteResolver.getByName).not.called.equal(true);
+
+      expect(finalRes).to.deep.equal(res);
+
+      expect(nextRewriteStub).calledWith({
+        ...req.nextUrl,
+        pathname: '/_site_qsFoo/styleguide',
+      });
+    });
+
     it('sc_site querystring parameter is provided', async () => {
       const req = createRequest({
         searchParams: { sc_site: 'qsFoo' },

--- a/packages/nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/multisite-middleware.ts
@@ -74,8 +74,10 @@ export class MultisiteMiddleware extends MiddlewareBase {
         siteName = req.cookies.get(SITE_KEY)?.value!;
       } else {
         // Site name can be forced by query string parameter or cookie
+        // 'site' is provided when running "preview" in AppRouter
         siteName =
           req.nextUrl.searchParams.get(SITE_KEY) ||
+          req.nextUrl.searchParams.get('site') ||
           (this.config.useCookieResolution &&
             this.config.useCookieResolution(req) &&
             req.cookies.get(SITE_KEY)?.value) ||

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.ts
@@ -22,7 +22,10 @@ import {
 } from '../editing/utils';
 import { SITE_KEY } from '@sitecore-content-sdk/core/site';
 
-// Helper function to handle cookie operations - can be mocked for testing
+/**
+ * Helper function to handle cookie operations - can be mocked for testing
+ * @returns {Promise<NextCookies>} Next cookies
+ */
 export async function getNextCookies() {
   // In test environment, use mock cookie store only if specifically provided
   if (process.env.TEST === 'true' && (global as any).__TEST_COOKIE_STORE__) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

This Pull Request addresses several issues related to the **`preview` mode** when using the **App Router** template:

1. **API routes not excluded**  
   API routes were not added to the middleware’s `exclude` list, causing API requests to fail during preview.

2. **`generateMetadata` failure**  
   The `generateMetadata` function was failing in preview mode because `siteName` and `locale` were not provided.

3. **Extra slash in `LocaleMiddleware`**  
   The locale middleware rewrite was adding an extra `/` at the end of URLs, resulting in a `"URL mismatch /en/ - /en"` error.

4. **Multisite detection in preview**  
   The Multisite middleware couldn’t identify `siteName` while running in preview mode.  
   Since we rely on query string parameters, an additional check for the `site` parameter has been added.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other - Tested by connecting local application to XM Cloud

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
