### PR TITLE
[core] Expose `getData` on SitecoreClient to run raw GraphQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Our versioning strategy is as follows:
 * Add LLMs and Copilot instruction files for improved AI guidance ([#239](https://github.com/Sitecore/content-sdk/pull/239))
 * Add LLMs and Copilot instruction files for improved AI guidance ([#239](https://github.com/Sitecore/content-sdk/pull/239))
 * `[core]` `[nextjs]` Enable component variants in component-map & also send variants files in code extraction ([#245](https://github.com/Sitecore/content-sdk/pull/245))
+* `[core]` Expose `getData` on `SitecoreClient` to run raw GraphQL queries. ([#249](https://github.com/Sitecore/content-sdk/pull/249))
 
 ### 🐛 Bug Fixes
 

--- a/packages/core/src/client/sitecore-client.test.ts
+++ b/packages/core/src/client/sitecore-client.test.ts
@@ -3,6 +3,7 @@
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
+import { DocumentNode } from 'graphql';
 import { ErrorPage, SitecoreClient } from './sitecore-client';
 import { LayoutKind, DesignLibraryMode } from '../../editing';
 import { LayoutServiceData } from '../../layout';
@@ -104,6 +105,92 @@ describe('SitecoreClient', () => {
     (sitecoreClient as any).componentService = restComponentServiceStub;
     (sitecoreClient as any).sitePathService = sitePathServiceStub;
     (sitecoreClient as any).sitemapXmlService = sitemapXmlServiceStub;
+  });
+
+  describe('getData', () => {
+    let requestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      // Attach a fake GraphQL client to the instance
+      const fakeGraphQLClient = { request: sandbox.stub() };
+      (sitecoreClient as any).graphQLClient = fakeGraphQLClient as any;
+      requestStub = fakeGraphQLClient.request as sinon.SinonStub;
+    });
+
+    it('should forwards query, variables, and fetchOptions to graphQLClient.request and returns the result', async () => {
+      const query = 'query ($id: String!) { item(id: $id) { id name } }';
+      const variables = { id: '123' };
+      const fetchOptions = {
+        headers: { 'x-test': 'ok' },
+        retries: 0,
+      };
+
+      const expected = { item: { id: '123', name: 'Home' } };
+      requestStub.resolves(expected);
+
+      const result = await sitecoreClient.getData<typeof expected>(query, variables, fetchOptions);
+
+      expect(result).to.equal(expected);
+      sinon.assert.calledOnceWithExactly(requestStub, query, variables, fetchOptions);
+    });
+
+    it('should accept a DocumentNode as the query', async () => {
+      const doc = { kind: 'Document' } as unknown as DocumentNode;
+
+      const expected = { ok: true };
+      requestStub.resolves(expected);
+
+      const result = await sitecoreClient.getData<typeof expected>(doc);
+
+      expect(result).to.equal(expected);
+      sinon.assert.calledOnceWithExactly(requestStub, doc, undefined, undefined);
+    });
+
+    it('should work when variables and fetchOptions are omitted', async () => {
+      const query = 'query { ping }';
+      const expected = { ping: 'pong' };
+      requestStub.resolves(expected);
+
+      const result = await sitecoreClient.getData<typeof expected>(query);
+
+      expect(result).to.equal(expected);
+      sinon.assert.calledOnceWithExactly(requestStub, query, undefined, undefined);
+    });
+
+    it('should allow per-call fetchOptions overrides (e.g., headers, retries, fetch impl)', async () => {
+      const query = 'query { me { id } }';
+      const customFetch = sinon.stub() as unknown as typeof fetch;
+      const fetchOptions = {
+        headers: { Authorization: 'Bearer test' },
+        retries: 2,
+        fetch: customFetch,
+      };
+      const expected = { me: { id: 'u1' } };
+      requestStub.resolves(expected);
+
+      await sitecoreClient.getData(query, undefined, fetchOptions);
+
+      sinon.assert.calledOnce(requestStub);
+      const [, , passedOptions] = requestStub.firstCall.args;
+      expect(passedOptions).to.include({
+        retries: 2,
+        fetch: customFetch,
+      });
+      expect(passedOptions?.headers).to.deep.equal({ Authorization: 'Bearer test' });
+    });
+
+    it('should propagate errors from graphQLClient.request', async () => {
+      const query = 'query { broken }';
+      const boom = new Error('Boom');
+      requestStub.rejects(boom);
+
+      try {
+        await sitecoreClient.getData(query);
+        expect.fail('Expected getData to throw');
+      } catch (err: any) {
+        expect(err).to.equal(boom);
+      }
+    });
   });
 
   describe('Extensibility', () => {

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -301,7 +301,7 @@ export class SitecoreClient implements BaseSitecoreClient {
   /**
    * Execute a raw GraphQL request using the client's configured GraphQL endpoint(s).
    * This is a thin pass-through to the underlying {@link GraphQLClient.request},
-   * @param {string | DocumentNode} query GraphQL string or DocumentNode
+   * @param {string | DocumentNode} query GraphQL query
    * @param {Record<string, unknown>} [variables] Optional variables bag
    * @param {FetchOptions} [fetchOptions] Optional fetch overrides (e.g. fetch, headers)
    */

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -5,7 +5,8 @@ import {
   ComponentLayoutService,
   DesignLibraryMode,
 } from '../editing';
-import { GraphQLRequestClientFactory } from '../graphql-request-client';
+import { DocumentNode } from 'graphql';
+import { GraphQLClient, GraphQLRequestClientFactory } from '../graphql-request-client';
 import { DictionaryPhrases, DictionaryService } from '../i18n';
 import {
   getDesignLibraryStylesheetLinks,
@@ -128,6 +129,18 @@ export type RobotsOptions = {
  */
 export interface BaseSitecoreClient {
   /**
+   * Execute a raw GraphQL request against the configured Sitecore endpoint(s).
+   * Mirrors GraphQLClient.request for familiarity.
+   * @param query GraphQL string or DocumentNode
+   * @param variables Optional variables bag
+   * @param fetchOptions Optional fetch/retry overrides (headers, retries, fetch impl, debugger)
+   */
+  getData<T = unknown>(
+    query: string | DocumentNode,
+    variables?: Record<string, unknown>,
+    fetchOptions?: FetchOptions
+  ): Promise<T>;
+  /**
    * Retrieves page layoutData and returns page details like language, layoutData and site info for current request
    * @param {string} path current request path
    * @param {PageOptions} pageOptions additional overrides like language, site name and personalization variants
@@ -246,6 +259,7 @@ export class SitecoreClient implements BaseSitecoreClient {
   protected errorPagesService: ErrorPagesService;
   protected componentService: ComponentLayoutService;
   protected sitePathService: SitePathService;
+  protected graphQLClient: GraphQLClient;
 
   /**
    * Init SitecoreClient
@@ -253,6 +267,7 @@ export class SitecoreClient implements BaseSitecoreClient {
    */
   constructor(protected initOptions: SitecoreClientInit) {
     this.clientFactory = this.getClientFactory();
+    this.graphQLClient = this.getGraphQLClient();
 
     const baseServiceOptions = this.getBaseServiceOptions();
 
@@ -281,6 +296,21 @@ export class SitecoreClient implements BaseSitecoreClient {
           .filter((part) => part !== '/')
           .map((part) => part.replace(/^\/+/, '').replace(/\/+$/, ''))
           .join('/')}`;
+  }
+
+  /**
+   * GraphQL pass-through: make any GraphQL call via the client's configured endpoint(s).
+   * Honors retries, custom fetch, headers, and debugger from FetchOptions.
+   * @param {string | DocumentNode} query GraphQL string or DocumentNode
+   * @param {Record<string, unknown>} [variables] Optional variables bag
+   * @param {FetchOptions} [fetchOptions] Optional fetch/retry overrides (headers, retries, fetch impl, debugger)
+   */
+  getData<T = unknown>(
+    query: string | DocumentNode,
+    variables?: Record<string, unknown>,
+    fetchOptions?: FetchOptions
+  ): Promise<T> {
+    return this.graphQLClient.request<T>(query, variables, fetchOptions);
   }
 
   /**
@@ -695,6 +725,13 @@ export class SitecoreClient implements BaseSitecoreClient {
     }
 
     return pageMode;
+  }
+
+  private getGraphQLClient(): GraphQLClient {
+    return this.clientFactory({
+      retries: this.initOptions.retries.count,
+      retryStrategy: this.initOptions.retries.retryStrategy,
+    });
   }
 
   private getClientFactory(): GraphQLRequestClientFactory {

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -299,7 +299,7 @@ export class SitecoreClient implements BaseSitecoreClient {
   }
 
   /**
-   * Execute a raw GraphQL request using the client's configured GraphQL endpoint(s).
+   * Execute a raw GraphQL request using the client's configured GraphQL Edge endpoint.
    * This is a thin pass-through to the underlying {@link GraphQLClient.request},
    * @param {string | DocumentNode} query GraphQL query
    * @param {Record<string, unknown>} [variables] Optional variables bag

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -129,8 +129,8 @@ export type RobotsOptions = {
  */
 export interface BaseSitecoreClient {
   /**
-   * Execute a raw GraphQL request against the configured Sitecore endpoint(s).
-   * Mirrors GraphQLClient.request for familiarity.
+   * Execute a raw GraphQL request using the client's configured GraphQL endpoint(s).
+   * This is a thin pass-through to the underlying {@link GraphQLClient.request},
    * @param query GraphQL string or DocumentNode
    * @param variables Optional variables bag
    * @param fetchOptions Optional fetch/retry overrides (headers, retries, fetch impl, debugger)

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -299,8 +299,8 @@ export class SitecoreClient implements BaseSitecoreClient {
   }
 
   /**
-   * GraphQL pass-through: make any GraphQL call via the client's configured endpoint(s).
-   * Honors retries, custom fetch, headers, and debugger from FetchOptions.
+   * Execute a raw GraphQL request using the client's configured GraphQL endpoint(s).
+   * This is a thin pass-through to the underlying {@link GraphQLClient.request},
    * @param {string | DocumentNode} query GraphQL string or DocumentNode
    * @param {Record<string, unknown>} [variables] Optional variables bag
    * @param {FetchOptions} [fetchOptions] Optional fetch/retry overrides (headers, retries, fetch impl, debugger)

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -303,7 +303,7 @@ export class SitecoreClient implements BaseSitecoreClient {
    * This is a thin pass-through to the underlying {@link GraphQLClient.request},
    * @param {string | DocumentNode} query GraphQL string or DocumentNode
    * @param {Record<string, unknown>} [variables] Optional variables bag
-   * @param {FetchOptions} [fetchOptions] Optional fetch/retry overrides (headers, retries, fetch impl, debugger)
+   * @param {FetchOptions} [fetchOptions] Optional fetch overrides (e.g. fetch, headers)
    */
   getData<T = unknown>(
     query: string | DocumentNode,

--- a/packages/core/src/client/sitecore-client.ts
+++ b/packages/core/src/client/sitecore-client.ts
@@ -25,6 +25,7 @@ import { createGraphQLClientFactory, GraphQLClientOptions } from './utils';
 import { NativeDataFetcher } from '../native-fetcher';
 import { RobotsService } from '../site/robots-service';
 import { DesignLibraryVariantGeneration } from '../editing/models';
+import debug from '../debug';
 
 /**
  * Error page codes
@@ -267,7 +268,9 @@ export class SitecoreClient implements BaseSitecoreClient {
    */
   constructor(protected initOptions: SitecoreClientInit) {
     this.clientFactory = this.getClientFactory();
-    this.graphQLClient = this.getGraphQLClient();
+    this.graphQLClient = this.clientFactory({
+      debugger: debug.http,
+    });
 
     const baseServiceOptions = this.getBaseServiceOptions();
 
@@ -725,13 +728,6 @@ export class SitecoreClient implements BaseSitecoreClient {
     }
 
     return pageMode;
-  }
-
-  private getGraphQLClient(): GraphQLClient {
-    return this.clientFactory({
-      retries: this.initOptions.retries.count,
-      retryStrategy: this.initOptions.retries.retryStrategy,
-    });
   }
 
   private getClientFactory(): GraphQLRequestClientFactory {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR makes it easier for customers to make fetch data through graphql by adding a simple `getData<T>(query, variables?, fetchOptions?)` method to SitecoreClient. It delegates to the existing `GraphQLClient.request`, preserving retries, headers, custom fetch, and debugger behavior.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
