### PR TITLE
[nextjs] Fix double spread operators in component map when no variants

### DIFF
--- a/packages/nextjs/src/tools/generate-map.test.ts
+++ b/packages/nextjs/src/tools/generate-map.test.ts
@@ -396,7 +396,7 @@ describe('generateMap', () => {
       expect(mainContent).to.include("import * as Button from './src/components/Button';");
 
       expect(mainContent.replace(/\s+/g, ' ')).to.include(
-        "['Button', { ...{ ...Buttonextra, ...Button }, componentType: 'client' }]"
+        "['Button', { ...Buttonextra, ...Button, componentType: 'client' }],"
       );
 
       expect(mainContent).to.match(/\['Link',\s*(\{[^]*?\.{3}Link[^]*?\}|Link)\s*\],/);
@@ -775,8 +775,9 @@ describe('generateMap', () => {
       expect(mainContent).to.include(
         "import * as UniversalCard from './src/components/UniversalCard';"
       );
+
       expect(mainContent).to.include(
-        "['ClientButton', { ...ClientButton, componentType: 'client' }],"
+        "['ClientButton', { ClientButton, componentType: 'client' }],"
       );
       expect(mainContent).to.include("['ServerData', ServerData],");
       expect(mainContent).to.include("['UniversalCard', UniversalCard],");

--- a/packages/nextjs/src/tools/generate-map.ts
+++ b/packages/nextjs/src/tools/generate-map.ts
@@ -81,14 +81,19 @@ const prepareComponentsForMap = (
       const annotateClient =
         !!group.base && 'componentType' in group.base && group.base.componentType === 'client';
 
+       let valueExpr: string;
+      if (spreads.length) {
+        valueExpr = spreads.join(', ');
+      } else {
+        valueExpr = group.base
+          ? group.base.moduleName
+          : group.neighbors[0].moduleName;
+      }
+
       entries.push({
         key: group.prefix,
         imports,
-        valueExpr: spreads.length
-          ? `{ ${spreads.join(', ')} }`
-          : group.base
-          ? group.base.moduleName
-          : group.neighbors[0].moduleName,
+        valueExpr,
         annotateClient,
       });
     } else {
@@ -169,12 +174,14 @@ import { Form } from '@sitecore-content-sdk/nextjs';
   // Build entry lines (package named imports are appended below)
   const componentMapEntries: string[] = builtInMapEntries;
   for (const e of entries) {
-    const value =
-      !isClientMap && e.annotateClient
-        ? `{ ...${e.valueExpr}, componentType: 'client' }`
-        : e.valueExpr;
-    componentMapEntries.push(`['${e.key}', ${value}]`);
-  }
+  const value =
+    !isClientMap && e.annotateClient
+      ? `{ ${e.valueExpr}, componentType: 'client' }`
+      : e.valueExpr.includes('...')
+      ? `{ ${e.valueExpr} }`
+      : e.valueExpr;
+  componentMapEntries.push(`['${e.key}', ${value}]`);
+}
 
   // Add package-based entries
   componentImports?.forEach((pkg) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fix double spread operators in component map when no variants

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
