### PR TITLE
[react][nextjs] Introduce an `rsc` submodule for RSC specific logic

### DIFF
--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Layout.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/src/Layout.tsx
@@ -1,5 +1,6 @@
 import React, { JSX } from 'react';
-import { AppPlaceholder, Field, Page } from '@sitecore-content-sdk/nextjs';
+import { Field, Page } from '@sitecore-content-sdk/nextjs';
+import { AppPlaceholder } from '@sitecore-content-sdk/nextjs/rsc';
 import Scripts from 'src/Scripts';
 import SitecoreStyles from 'components/content-sdk/SitecoreStyles';
 import { DesignLibraryLayout } from './DesignLibraryLayout';

--- a/packages/nextjs/rsc.d.ts
+++ b/packages/nextjs/rsc.d.ts
@@ -1,0 +1,1 @@
+export * from './types/rsc.d.ts';

--- a/packages/nextjs/rsc.js
+++ b/packages/nextjs/rsc.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/cjs/rsc.js');

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -162,6 +162,4 @@ export {
   EditingScripts,
   Form,
   ClientEditingChromesUpdate,
-  AppPlaceholder,
-  AppPlaceholderProps,
 } from '@sitecore-content-sdk/react';

--- a/packages/nextjs/src/rsc.ts
+++ b/packages/nextjs/src/rsc.ts
@@ -1,0 +1,1 @@
+export { AppPlaceholder, AppPlaceholderProps } from '@sitecore-content-sdk/react/rsc';

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -22,6 +22,7 @@
     "route-handler.d.ts",
     "editing.d.ts",
     "monitoring.d.ts",
+    "rsc.d.ts",
     "component-props-loader.d.ts",
     "site.d.ts",
     "client.d.ts",
@@ -32,6 +33,6 @@
     "src/test-data/*",
     "**/*.test.ts",
     "**/*.test.tsx",
-    "src/tools/codegen/test-data/*",
+    "src/tools/codegen/test-data/*"
   ]
 }

--- a/packages/react/rsc.d.ts
+++ b/packages/react/rsc.d.ts
@@ -1,0 +1,1 @@
+export * from './types/rsc.d.ts';

--- a/packages/react/rsc.js
+++ b/packages/react/rsc.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/cjs/rsc.js');

--- a/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
@@ -32,13 +32,15 @@ import * as FEAASWrapper from '../FEaaS/FEaaSWrapper';
 import * as HiddenRendering from '../HiddenRendering';
 import * as ErrorBoundary from '../ErrorBoundary';
 import { MissingComponent, MissingComponentProps } from '../MissingComponent';
-import { AppPlaceholder } from './AppPlaceholder';
-import { AppComponentProps, ComponentProps } from './models';
+import * as AppPlaceholderImport from './AppPlaceholder';
+import { AppComponentProps } from './models';
 import { Page, PageMode } from '@sitecore-content-sdk/core/client';
-import * as placeholderUtils from './AppPlaceholder';
 import * as ClientComponentWrapperModule from './ClientComponentWrapper';
+import { unitMocks } from './AppPlaceholder';
 
 describe('App Placeholder logic', () => {
+  const AppPlaceholder = AppPlaceholderImport.AppPlaceholder;
+
   // Global sinon sandbox for all tests
   let sandbox: SinonSandbox;
 
@@ -1042,7 +1044,7 @@ describe('App Placeholder logic', () => {
     });
 
     it('should render client component wrapper when component is marker as client and rendered in RSC context', () => {
-      sandbox.stub(placeholderUtils, 'getRSC').returns(true);
+      unitMocks.getRSC = sandbox.stub().returns(true);
       sandbox
         .stub(ClientComponentWrapperModule, 'ClientComponentWrapper')
         .returns(<div className="client-component-wrapper">Client Component Wrapper</div>);

--- a/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
@@ -35,7 +35,7 @@ import { MissingComponent, MissingComponentProps } from '../MissingComponent';
 import { AppPlaceholder } from './AppPlaceholder';
 import { AppComponentProps, ComponentProps } from './models';
 import { Page, PageMode } from '@sitecore-content-sdk/core/client';
-import * as placeholderUtils from './placeholder-utils';
+import * as placeholderUtils from './AppPlaceholder';
 import * as ClientComponentWrapperModule from './ClientComponentWrapper';
 
 describe('App Placeholder logic', () => {

--- a/packages/react/src/components/Placeholder/AppPlaceholder.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.tsx
@@ -4,13 +4,21 @@ import {
   getComponentForRendering,
   getPlaceholderRenderings,
   renderEmptyPlaceholder,
-  getRSC,
 } from './placeholder-utils';
 import React from 'react';
 import { PlaceholderMetadata } from './PlaceholderMetadata';
 import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
 import ErrorBoundary from '../ErrorBoundary';
 import { ClientComponentWrapper } from './ClientComponentWrapper';
+import { rsc } from 'rsc-env';
+
+/**
+ * Get the RSC environment variable.
+ * @returns {boolean} true if RSC is enabled, false otherwise.
+ */
+export function getRSC(): boolean {
+  return rsc;
+}
 
 /**
  * The implemention of placeholder compatible with React Server Components.

--- a/packages/react/src/components/Placeholder/AppPlaceholder.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.tsx
@@ -12,13 +12,27 @@ import ErrorBoundary from '../ErrorBoundary';
 import { ClientComponentWrapper } from './ClientComponentWrapper';
 import { rsc } from 'rsc-env';
 
+// mock setup for unit tests to make sinon happy and mock-able
+// https://sinonjs.org/how-to/typescript-swc/
+// This, plus the `_` names make the exports writable for sinon
+export const unitMocks = {
+  set getRSC(mockImplementation) {
+    getRSC = mockImplementation;
+  },
+  get getRSC() {
+    return _getRSC;
+  },
+};
+
 /**
  * Get the RSC environment variable.
  * @returns {boolean} true if RSC is enabled, false otherwise.
  */
-export function getRSC(): boolean {
+const _getRSC = (): boolean => {
   return rsc;
-}
+};
+
+export let getRSC = _getRSC;
 
 /**
  * The implemention of placeholder compatible with React Server Components.

--- a/packages/react/src/components/Placeholder/index-rsc.ts
+++ b/packages/react/src/components/Placeholder/index-rsc.ts
@@ -1,0 +1,2 @@
+export { AppPlaceholder, getRSC } from './AppPlaceholder';
+export { AppPlaceholderProps } from './models';

--- a/packages/react/src/components/Placeholder/index.ts
+++ b/packages/react/src/components/Placeholder/index.ts
@@ -1,5 +1,4 @@
 export { Placeholder, PlaceholderComponent } from './Placeholder';
 export { PlaceholderMetadata } from './PlaceholderMetadata';
-export { PlaceholderProps, AppPlaceholderProps } from './models';
-export { AppPlaceholder } from './AppPlaceholder';
+export { PlaceholderProps } from './models';
 export * from './placeholder-utils';

--- a/packages/react/src/components/Placeholder/placeholder-utils.tsx
+++ b/packages/react/src/components/Placeholder/placeholder-utils.tsx
@@ -26,7 +26,6 @@ import {
   PlaceholderProps,
   RenderedProps,
 } from './models';
-import { rsc } from 'rsc-env';
 
 /**
  * Get the renderings for the specified placeholder from the rendering data.
@@ -261,11 +260,3 @@ export const getComponentForRendering = (
     isEmpty: false,
   };
 };
-
-/**
- * Get the RSC environment variable.
- * @returns {boolean} true if RSC is enabled, false otherwise.
- */
-export function getRSC(): boolean {
-  return rsc;
-}

--- a/packages/react/src/enhancers/withAppPlaceholder.test.tsx
+++ b/packages/react/src/enhancers/withAppPlaceholder.test.tsx
@@ -11,7 +11,7 @@ import * as metadataData from '../test-data/metadata-data';
 import { withAppPlaceholder, ComponentProps, WrapperProps } from './withAppPlaceholder';
 import { SitecoreProvider } from '../components/SitecoreProvider';
 import { ComponentRendering, RouteData } from '@sitecore-content-sdk/core/layout';
-import { AppPlaceholder } from '../components/Placeholder';
+import { AppPlaceholder } from '../components/Placeholder/index-rsc';
 
 type CalloutProps = ComponentProps & {
   [prop: string]: unknown;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -47,8 +47,6 @@ export {
   Placeholder,
   PlaceholderProps,
   PlaceholderProps as PlaceholderComponentProps,
-  AppPlaceholder,
-  AppPlaceholderProps,
 } from './components/Placeholder';
 export {
   Image,

--- a/packages/react/src/rsc.ts
+++ b/packages/react/src/rsc.ts
@@ -1,0 +1,1 @@
+export * from './components/Placeholder/index-rsc';

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -16,6 +16,7 @@
     "types",
     "typings",
     "dist",
+    "rsc.d.ts",
     "src/tests/*",
     "src/test-data/*",
     "**/*.test.ts",


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
`rsc` dependency (required for app router) in react package does not gel well with CJS imports in pages router sample. So we introduce a submodule to make everything work together again.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - monorepo apps build OK

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
