### PR TITLE
[react]Replace rsc-env dependency with private conditional imports

### DIFF
--- a/.github/workflows/generate_pr_metrics_report.yml
+++ b/.github/workflows/generate_pr_metrics_report.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: |
@@ -32,3 +32,4 @@ jobs:
         with:
           header: Metrics Report
           path: metrics-report.md
+

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -88,10 +88,10 @@
     "#rsc-env": {
       "react-server": {
         "import": "./dist/esm/rsc-utils/rsc.js",
-        "require": "./dist/cjs/rsc-utils/rsc.js"
+        "default": "./dist/cjs/rsc-utils/rsc.js"
       },
       "import": "./dist/esm/rsc-utils/no-rsc.js",
-      "require": "./dist/cjs/rsc-utils/no-rsc.js"
+      "default": "./dist/cjs/rsc-utils/no-rsc.js"
     }
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -75,8 +75,7 @@
   },
   "dependencies": {
     "@sitecore-content-sdk/core": "1.3.0-canary.2",
-    "fast-deep-equal": "^3.1.3",
-    "rsc-env": "^0.0.2"
+    "fast-deep-equal": "^3.1.3"
   },
   "description": "",
   "types": "types/index.d.ts",
@@ -84,5 +83,15 @@
   "files": [
     "dist",
     "types"
-  ]
+  ],
+  "imports": {
+    "#rsc-env": {
+      "react-server": {
+        "import": "./dist/esm/rsc-utils/rsc.js",
+        "require": "./dist/cjs/rsc-utils/rsc.js"
+      },
+      "import": "./dist/esm/rsc-utils/no-rsc.js",
+      "require": "./dist/cjs/rsc-utils/no-rsc.js"
+    }
+  }
 }

--- a/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
@@ -35,7 +35,7 @@ import { MissingComponent, MissingComponentProps } from '../MissingComponent';
 import { AppPlaceholder } from './AppPlaceholder';
 import { AppComponentProps, ComponentProps } from './models';
 import { Page, PageMode } from '@sitecore-content-sdk/core/client';
-import * as placeholderUtils from './placeholder-utils';
+import * as rscUtils from '#rsc-env';
 import * as ClientComponentWrapperModule from './ClientComponentWrapper';
 
 describe('App Placeholder logic', () => {
@@ -1042,7 +1042,7 @@ describe('App Placeholder logic', () => {
     });
 
     it('should render client component wrapper when component is marker as client and rendered in RSC context', () => {
-      sandbox.stub(placeholderUtils, 'getRSC').returns(true);
+      sandbox.replace(rscUtils, 'rsc', true as any);
       sandbox
         .stub(ClientComponentWrapperModule, 'ClientComponentWrapper')
         .returns(<div className="client-component-wrapper">Client Component Wrapper</div>);

--- a/packages/react/src/components/Placeholder/AppPlaceholder.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.tsx
@@ -4,13 +4,13 @@ import {
   getComponentForRendering,
   getPlaceholderRenderings,
   renderEmptyPlaceholder,
-  getRSC,
 } from './placeholder-utils';
 import React from 'react';
 import { PlaceholderMetadata } from './PlaceholderMetadata';
 import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
 import ErrorBoundary from '../ErrorBoundary';
 import { ClientComponentWrapper } from './ClientComponentWrapper';
+import { rsc } from '#rsc-env';
 
 /**
  * The implemention of placeholder compatible with React Server Components.
@@ -53,7 +53,7 @@ export const AppPlaceholder = (props: AppPlaceholderProps) => {
       // Client wrapper is required only when component crosses boundary from server to client.
       // It happens when component is marker as client and rendered in RSC context.
       // Also, it is not required when component is hidden or empty, as it will be rendered whthout boundary crossing.
-      const useClientWrapper = isClient && getRSC() && !isEmpty;
+      const useClientWrapper = isClient && rsc && !isEmpty;
       let rendered = useClientWrapper ? (
         <ClientComponentWrapper
           rendering={rendering}

--- a/packages/react/src/components/Placeholder/placeholder-utils.tsx
+++ b/packages/react/src/components/Placeholder/placeholder-utils.tsx
@@ -26,7 +26,6 @@ import {
   PlaceholderProps,
   RenderedProps,
 } from './models';
-import { rsc } from 'rsc-env';
 
 /**
  * Get the renderings for the specified placeholder from the rendering data.
@@ -261,11 +260,3 @@ export const getComponentForRendering = (
     isEmpty: false,
   };
 };
-
-/**
- * Get the RSC environment variable.
- * @returns {boolean} true if RSC is enabled, false otherwise.
- */
-export function getRSC(): boolean {
-  return rsc;
-}

--- a/packages/react/src/rsc-utils/no-rsc.ts
+++ b/packages/react/src/rsc-utils/no-rsc.ts
@@ -1,0 +1,1 @@
+export const rsc = false;

--- a/packages/react/src/rsc-utils/no-rsc.ts
+++ b/packages/react/src/rsc-utils/no-rsc.ts
@@ -1,1 +1,2 @@
+// Always false constant to import in the non-RSC contexts using conditional imports
 export const rsc = false;

--- a/packages/react/src/rsc-utils/rsc.d.ts
+++ b/packages/react/src/rsc-utils/rsc.d.ts
@@ -1,0 +1,2 @@
+declare const rsc: boolean;
+export { rsc };

--- a/packages/react/src/rsc-utils/rsc.d.ts
+++ b/packages/react/src/rsc-utils/rsc.d.ts
@@ -1,2 +1,3 @@
+// Utility constant to identify if code is bundeled for RSC environment or client environment
 declare const rsc: boolean;
 export { rsc };

--- a/packages/react/src/rsc-utils/rsc.ts
+++ b/packages/react/src/rsc-utils/rsc.ts
@@ -1,0 +1,1 @@
+export const rsc = true;

--- a/packages/react/src/rsc-utils/rsc.ts
+++ b/packages/react/src/rsc-utils/rsc.ts
@@ -1,1 +1,2 @@
+// Always true constant to import in the RSC environment using conditional imports
 export const rsc = true;

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -9,7 +9,8 @@
     "types": ["node", "mocha"],
     "typeRoots": ["node_modules/@types"],
     "declarationDir": "./types",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": { "#rsc-env": ["./src/rsc-utils/rsc.d.ts"] }
   },
   "exclude": [
     "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,7 +2937,6 @@ __metadata:
     proxyquire: ^2.1.3
     react: ^19.1.0
     react-dom: ^19.1.0
-    rsc-env: ^0.0.2
     sinon: ^20.0.0
     sinon-chai: ^3.7.0
     ts-node: ^10.9.2
@@ -10691,13 +10690,6 @@ __metadata:
   version: 0.8.0
   resolution: "rrweb-cssom@npm:0.8.0"
   checksum: b84912cd1fbab9c972bf3fd5ca27b492efb442cacb23b6fd5a5ef6508572a91e411d325692609bf758865bc38a01b876e343c552d0e2ae87d0ff9907d96ef622
-  languageName: node
-  linkType: hard
-
-"rsc-env@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "rsc-env@npm:0.0.2"
-  checksum: 450462b17405088bab5b8874fb15d31e3cf57039153fd971d820f00812d07994ec76c744c8125296b2b1f581e6b8e20d9e30282adda13bfb6c8f8386edbefec1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
AppPlaceholder used `rsc-env` library to check if current context is RSC. However `rsc-env` doesn't produnce CommonJS target, and it affects NextJs Pages router template, due to mixed usage of CommonJs and ESM.
Replace `rsc-env` with local solution using condition private imports and 'react-server' conventional condition.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
