### PR TITLE
[core][nextjs]: Add comments/fallbacks for multisite config in App Router

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -131,6 +131,17 @@ export type SitecoreConfigInput = {
   multisite?: {
     /**
      * Enable multisite
+     *
+     * **WARNING: Do NOT disable multisite in App Router applications.**
+     *
+     * The App Router route structure requires the `[site]` segment in the path (`/[site]/[locale]/[[...path]]`).
+     * Disabling this will break routing and cause 404 errors for regular requests.
+     *
+     * Preview and Editing modes will still work (they bypass this check), but regular page requests will fail.
+     *
+     * **For single-site setups**: Keep `enabled: true` and configure only one site in your sites configuration.
+     * The middleware will always use that single site, achieving the desired single-site behavior.
+     *
      * @default true
      */
     enabled?: boolean;

--- a/packages/nextjs/src/middleware/app-router-multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/app-router-multisite-middleware.ts
@@ -1,9 +1,20 @@
+import { NextResponse } from 'next/server';
 import { MultisiteMiddleware } from './multisite-middleware';
 
 /**
  * Middleware/handler for enabling multisite support in the Next.js App Router.
  */
 export class AppRouterMultisiteMiddleware extends MultisiteMiddleware {
+  /**
+   * Always warn when multisite is disabled in App Router, as it will break regular requests.
+   * @param {NextResponse} _res response (unused, kept for method signature compatibility)
+   * @returns {boolean} always returns true for App Router
+   */
+  // eslint-disable-next-line no-unused-vars
+  protected shouldWarnWhenDisabled(_res: NextResponse): boolean {
+    return true;
+  }
+
   /**
    * Generates a site-specific rewrite path for app router based on the provided pathname and site name.
    * @param {string} pathname - The pathname to be rewritten.

--- a/packages/nextjs/src/middleware/app-router-multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/app-router-multisite-middleware.ts
@@ -6,13 +6,16 @@ import { MultisiteMiddleware } from './multisite-middleware';
  */
 export class AppRouterMultisiteMiddleware extends MultisiteMiddleware {
   /**
-   * Always warn when multisite is disabled in App Router, as it will break regular requests.
+   * Warns when multisite is disabled in App Router, as it will break regular requests.
    * @param {NextResponse} _res response (unused, kept for method signature compatibility)
-   * @returns {boolean} always returns true for App Router
    */
   // eslint-disable-next-line no-unused-vars
-  protected shouldWarnWhenDisabled(_res: NextResponse): boolean {
-    return true;
+  protected shouldWarnWhenDisabled(_res: NextResponse): void {
+    console.warn(
+      '⚠️ Warning: Multisite is disabled but App Router requires the [site] segment in routes. ' +
+        'Regular requests will fail with 404 errors. Preview/Editing modes will still work. ' +
+        'For single-site setups, keep multisite enabled and configure only one site.'
+    );
   }
 
   /**

--- a/packages/nextjs/src/middleware/app-router-multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/app-router-multisite-middleware.ts
@@ -1,4 +1,3 @@
-import { NextResponse } from 'next/server';
 import { MultisiteMiddleware } from './multisite-middleware';
 
 /**
@@ -7,10 +6,8 @@ import { MultisiteMiddleware } from './multisite-middleware';
 export class AppRouterMultisiteMiddleware extends MultisiteMiddleware {
   /**
    * Warns when multisite is disabled in App Router, as it will break regular requests.
-   * @param {NextResponse} _res response (unused, kept for method signature compatibility)
    */
-  // eslint-disable-next-line no-unused-vars
-  protected shouldWarnWhenDisabled(_res: NextResponse): void {
+  protected shouldWarnWhenDisabled() {
     console.warn(
       '⚠️ Warning: Multisite is disabled but App Router requires the [site] segment in routes. ' +
         'Regular requests will fail with 404 errors. Preview/Editing modes will still work. ' +

--- a/packages/nextjs/src/middleware/app-router-multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/app-router-multisite-middleware.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server';
 import { MultisiteMiddleware } from './multisite-middleware';
 
 /**
@@ -5,14 +6,27 @@ import { MultisiteMiddleware } from './multisite-middleware';
  */
 export class AppRouterMultisiteMiddleware extends MultisiteMiddleware {
   /**
-   * Warns when multisite is disabled in App Router, as it will break regular requests.
+   * Warns when multisite is disabled in App Router.
+   * The middleware will still run to prevent routing errors.
+   * @param {NextResponse} _res response (unused, kept for method signature compatibility)
    */
-  protected shouldWarnWhenDisabled() {
+  // eslint-disable-next-line no-unused-vars
+  protected shouldWarnWhenDisabled(_res: NextResponse): void {
     console.warn(
-      '⚠️ Warning: Multisite is disabled but App Router requires the [site] segment in routes. ' +
-        'Regular requests will fail with 404 errors. Preview/Editing modes will still work. ' +
+      '⚠️ Warning: Multisite is disabled in App Router configuration, but the middleware will continue running. ' +
+        'Disabling multisite in App Router would cause 404 errors for regular page requests because the route structure requires the [site] segment. ' +
+        'Preview/Editing modes will still work. ' +
         'For single-site setups, keep multisite enabled and configure only one site.'
     );
+  }
+
+  /**
+   * In App Router, we cannot skip the middleware even if enabled is false,
+   * because the route structure requires the [site] segment.
+   * @returns {boolean} always returns false (never skip) for App Router
+   */
+  protected shouldSkipWhenDisabled(): boolean {
+    return false; // Never skip in App Router - route structure requires [site] segment
   }
 
   /**

--- a/packages/nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/multisite-middleware.ts
@@ -66,8 +66,11 @@ export class MultisiteMiddleware extends MiddlewareBase {
       if (!isSitecorePreview) {
         if (!this.config.enabled) {
           this.shouldWarnWhenDisabled(res);
-          debug.multisite('skipped (multisite middleware is disabled globally)');
-          return res;
+          if (this.shouldSkipWhenDisabled()) {
+            debug.multisite('skipped (multisite middleware is disabled globally)');
+            return res;
+          }
+          // Continue execution if shouldSkipWhenDisabled returns false (App Router case)
         }
 
         if (this.disabled(req, res)) {
@@ -137,6 +140,15 @@ export class MultisiteMiddleware extends MiddlewareBase {
   // eslint-disable-next-line no-unused-vars
   protected shouldWarnWhenDisabled(_res: NextResponse): void {
     // Base implementation does nothing - subclasses can override to show warnings
+  }
+
+  /**
+   * Determines if middleware should be skipped when multisite is disabled.
+   * Override in subclasses to provide router-specific behavior.
+   * @returns {boolean} true if middleware should be skipped when disabled
+   */
+  protected shouldSkipWhenDisabled(): boolean {
+    return true; // Base class skips when disabled
   }
 
   /**

--- a/packages/nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/multisite-middleware.ts
@@ -65,13 +65,7 @@ export class MultisiteMiddleware extends MiddlewareBase {
 
       if (!isSitecorePreview) {
         if (!this.config.enabled) {
-          if (this.shouldWarnWhenDisabled(res)) {
-            console.warn(
-              '⚠️ Warning: Multisite is disabled but App Router requires the [site] segment in routes. ' +
-                'Regular requests will fail with 404 errors. Preview/Editing modes will still work. ' +
-                'For single-site setups, keep multisite enabled and configure only one site.'
-            );
-          }
+          this.shouldWarnWhenDisabled(res);
           debug.multisite('skipped (multisite middleware is disabled globally)');
           return res;
         }
@@ -137,13 +131,12 @@ export class MultisiteMiddleware extends MiddlewareBase {
   }
 
   /**
-   * Determines if a warning should be shown when multisite is disabled.
-   * Override this method in subclasses to provide router-specific behavior.
-   * @param {NextResponse} res response
-   * @returns {boolean} true if warning should be shown
+   * Called when multisite is disabled. Override this method in subclasses to show router-specific warnings.
+   * @param {NextResponse} _res response
    */
-  protected shouldWarnWhenDisabled(res: NextResponse): boolean {
-    return false;
+  // eslint-disable-next-line no-unused-vars
+  protected shouldWarnWhenDisabled(_res: NextResponse): void {
+    // Base implementation does nothing - subclasses can override to show warnings
   }
 
   /**

--- a/packages/nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/multisite-middleware.ts
@@ -51,6 +51,8 @@ export class MultisiteMiddleware extends MiddlewareBase {
 
       // We can't skip site name preservation for App Router in Preview since currently we rely on the site segment
       // to be present in the path.
+      // Additionally, App Router route structure always requires [site] segment, so disabling multisite
+      // will break regular requests even though Preview/Editing modes will still work.
 
       if (this.isPreview(req) && !this.isAppRouter(res)) {
         debug.multisite('skipped (preview)');
@@ -63,6 +65,14 @@ export class MultisiteMiddleware extends MiddlewareBase {
 
       if (!isSitecorePreview) {
         if (!this.config.enabled) {
+          // Warn if multisite is disabled in App Router - this will break regular requests
+          if (this.isAppRouter(res)) {
+            console.warn(
+              '⚠️ Warning: Multisite is disabled but App Router requires the [site] segment in routes. ' +
+                'Regular requests will fail with 404 errors. Preview/Editing modes will still work. ' +
+                'For single-site setups, keep multisite enabled and configure only one site.'
+            );
+          }
           debug.multisite('skipped (multisite middleware is disabled globally)');
           return res;
         }
@@ -79,7 +89,16 @@ export class MultisiteMiddleware extends MiddlewareBase {
       if (isSitecorePreview) {
         // This cookie is required to be set in the Sitecore Preview mode to support navigation
         // and preserve the site name
-        siteName = req.cookies.get(SITE_KEY)?.value!;
+        // Fallback to hostname resolution if cookie is missing (shouldn't happen in normal flow)
+        const siteCookie = req.cookies.get(SITE_KEY)?.value;
+        if (!siteCookie) {
+          debug.multisite(
+            'warning: sc_site cookie missing in preview mode, falling back to hostname resolution'
+          );
+          siteName = this.siteResolver.getByHost(hostname).name;
+        } else {
+          siteName = siteCookie;
+        }
       } else {
         // Site name can be forced by query string parameter or cookie
         // 'site' is provided when running "preview" in AppRouter

--- a/packages/nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/nextjs/src/middleware/multisite-middleware.ts
@@ -65,8 +65,7 @@ export class MultisiteMiddleware extends MiddlewareBase {
 
       if (!isSitecorePreview) {
         if (!this.config.enabled) {
-          // Warn if multisite is disabled in App Router - this will break regular requests
-          if (this.isAppRouter(res)) {
+          if (this.shouldWarnWhenDisabled(res)) {
             console.warn(
               '⚠️ Warning: Multisite is disabled but App Router requires the [site] segment in routes. ' +
                 'Regular requests will fail with 404 errors. Preview/Editing modes will still work. ' +
@@ -89,16 +88,7 @@ export class MultisiteMiddleware extends MiddlewareBase {
       if (isSitecorePreview) {
         // This cookie is required to be set in the Sitecore Preview mode to support navigation
         // and preserve the site name
-        // Fallback to hostname resolution if cookie is missing (shouldn't happen in normal flow)
-        const siteCookie = req.cookies.get(SITE_KEY)?.value;
-        if (!siteCookie) {
-          debug.multisite(
-            'warning: sc_site cookie missing in preview mode, falling back to hostname resolution'
-          );
-          siteName = this.siteResolver.getByHost(hostname).name;
-        } else {
-          siteName = siteCookie;
-        }
+        siteName = req.cookies.get(SITE_KEY)?.value!;
       } else {
         // Site name can be forced by query string parameter or cookie
         // 'site' is provided when running "preview" in AppRouter
@@ -144,6 +134,16 @@ export class MultisiteMiddleware extends MiddlewareBase {
   protected disabled(req: NextRequest, res: NextResponse): boolean | undefined {
     // ignore files
     return req.nextUrl.pathname.includes('.') || super.disabled(req, res);
+  }
+
+  /**
+   * Determines if a warning should be shown when multisite is disabled.
+   * Override this method in subclasses to provide router-specific behavior.
+   * @param {NextResponse} res response
+   * @returns {boolean} true if warning should be shown
+   */
+  protected shouldWarnWhenDisabled(res: NextResponse): boolean {
+    return false;
   }
 
   /**

--- a/ref-docs/nextjs/middleware/MULTISITE_CONFIGURATION.md
+++ b/ref-docs/nextjs/middleware/MULTISITE_CONFIGURATION.md
@@ -6,28 +6,11 @@
 
 ## Why It Can't Be Disabled
 
-The App Router route structure is hardcoded at build time:
-- Route: `src/app/[site]/[locale]/[[...path]]/`
-- Components expect `site` in params: `const { site, locale, path } = await params`
+The App Router route structure is hardcoded at build time: `src/app/[site]/[locale]/[[...path]]/`. Components expect `site` in params, so the `[site]` segment is required.
 
-### What Happens If You Try to Disable Multisite
-
-**⚠️ Warning**: Setting `multisite.enabled: false` in App Router will break your application.
-
-**Steps to reproduce the issue** (for testing purposes only):
-
-1. Set `multisite.enabled: false` in `sitecore.config.ts`
-2. Make a regular page request (e.g., navigate to `/en/home`)
-3. **Result**: 404 error - route doesn't match because `[site]` segment is missing
-
-**What breaks**:
-- ❌ All regular page requests return 404
-- ❌ Static generation fails
-- ❌ Client-side navigation breaks
-- ✅ Preview mode still works (middleware bypasses enabled check)
-- ✅ Editing mode still works (middleware bypasses enabled check)
-
-**Why it breaks**: The App Router route structure requires `/[site]/[locale]/[[...path]]`, but when disabled, the middleware doesn't add the site segment, so routes don't match.
+**If you set `multisite.enabled: false`**:
+- ❌ Regular requests: 404 errors (no site segment)
+- ✅ Preview/Editing: Still works (middleware bypasses enabled check)
 
 ## Steps to Configure Single-Site Setup
 
@@ -63,13 +46,9 @@ In `.sitecore/sites.json`, configure only one site:
 ]
 ```
 
-### Step 3: Verify Configuration
+### Step 3: Verify
 
-- The middleware will always resolve to your single site
-- All requests will use the same site name
-- You achieve single-site behavior without breaking the App Router
-
-**Result**: Your application behaves as a single-site setup while maintaining the required route structure.
+The middleware will always resolve to your single site, achieving single-site behavior without breaking the App Router.
 
 ## Configuration
 
@@ -88,33 +67,12 @@ multisite: {
 }
 ```
 
-## Preview/Editing Modes Behavior
+## Preview/Editing Modes
 
-### When Multisite is Enabled (`enabled: true`)
+Preview and Editing modes always run the middleware (even when `enabled: false`) to preserve site name via cookies. Site resolution: `sc_site` cookie → hostname fallback.
 
-| Mode | Middleware Behavior | Site Resolution | Result |
-|------|-------------------|-----------------|--------|
-| **Preview** | ✅ Runs | From `sc_site` cookie → hostname fallback | ✅ Works correctly |
-| **Editing** | ✅ Runs | From `sc_site` cookie → hostname fallback | ✅ Works correctly |
-| **Regular** | ✅ Runs | From hostname, query params, or cookie | ✅ Works correctly |
-
-### When Multisite is Disabled (`enabled: false`)
-
-| Mode | Middleware Behavior | Site Resolution | Result |
-|------|-------------------|-----------------|--------|
-| **Preview** | ✅ Runs (bypasses enabled check) | From `sc_site` cookie → hostname fallback | ✅ Works correctly |
-| **Editing** | ✅ Runs (bypasses enabled check) | From `sc_site` cookie → hostname fallback | ✅ Works correctly |
-| **Regular** | ❌ Skips | No site segment added | ❌ 404 errors |
-
-**Key Insight**: Preview and Editing modes always require the middleware to run (even when disabled) to preserve site name via cookies for navigation between pages.
-
-### Middleware Adjustments Made
-
-The middleware includes the following adjustments for correct site resolution:
-
-1. **Fallback for missing site cookie**: If `sc_site` cookie is missing in Preview/Editing mode, falls back to hostname resolution instead of crashing
-2. **Runtime warning**: Logs a warning when multisite is disabled in App Router to alert developers
-3. **Cookie validation**: Validates site cookie presence and provides graceful fallback
+**When enabled**: All modes work correctly  
+**When disabled**: Preview/Editing work, regular requests break (404)
 
 ## Troubleshooting
 

--- a/ref-docs/nextjs/middleware/MULTISITE_CONFIGURATION.md
+++ b/ref-docs/nextjs/middleware/MULTISITE_CONFIGURATION.md
@@ -1,0 +1,132 @@
+# Multisite Configuration in App Router
+
+## ⚠️ Important Limitation
+
+**Multisite cannot be disabled in App Router applications.** The route structure requires a `[site]` segment: `/[site]/[locale]/[[...path]]`.
+
+## Why It Can't Be Disabled
+
+The App Router route structure is hardcoded at build time:
+- Route: `src/app/[site]/[locale]/[[...path]]/`
+- Components expect `site` in params: `const { site, locale, path } = await params`
+
+### What Happens If You Try to Disable Multisite
+
+**⚠️ Warning**: Setting `multisite.enabled: false` in App Router will break your application.
+
+**Steps to reproduce the issue** (for testing purposes only):
+
+1. Set `multisite.enabled: false` in `sitecore.config.ts`
+2. Make a regular page request (e.g., navigate to `/en/home`)
+3. **Result**: 404 error - route doesn't match because `[site]` segment is missing
+
+**What breaks**:
+- ❌ All regular page requests return 404
+- ❌ Static generation fails
+- ❌ Client-side navigation breaks
+- ✅ Preview mode still works (middleware bypasses enabled check)
+- ✅ Editing mode still works (middleware bypasses enabled check)
+
+**Why it breaks**: The App Router route structure requires `/[site]/[locale]/[[...path]]`, but when disabled, the middleware doesn't add the site segment, so routes don't match.
+
+## Steps to Configure Single-Site Setup
+
+**Note**: Multisite cannot be disabled in App Router. To achieve single-site behavior, follow these steps:
+
+### Step 1: Keep Multisite Enabled
+
+In `sitecore.config.ts`, ensure `multisite.enabled` is `true`:
+
+```typescript
+// sitecore.config.ts
+export default defineConfig({
+  multisite: {
+    enabled: true, // ✅ Required - do not set to false
+  },
+  defaultSite: 'my-site',
+  // ... other config
+});
+```
+
+### Step 2: Configure Single Site
+
+In `.sitecore/sites.json`, configure only one site:
+
+```json
+// .sitecore/sites.json
+[
+  {
+    "name": "my-site",
+    "hostName": "*",
+    "language": "en"
+  }
+]
+```
+
+### Step 3: Verify Configuration
+
+- The middleware will always resolve to your single site
+- All requests will use the same site name
+- You achieve single-site behavior without breaking the App Router
+
+**Result**: Your application behaves as a single-site setup while maintaining the required route structure.
+
+## Configuration
+
+### `enabled`
+- **App Router**: Must be `true` (disabling breaks regular requests)
+- **Pages Router**: Can be `false` for single-site
+- **Preview/Editing**: Always runs regardless of this setting
+
+### `useCookieResolution`
+Function to resolve site from `sc_site` cookie when present.
+
+```typescript
+multisite: {
+  enabled: true,
+  useCookieResolution: () => process.env.VERCEL_ENV === 'preview',
+}
+```
+
+## Preview/Editing Modes Behavior
+
+### When Multisite is Enabled (`enabled: true`)
+
+| Mode | Middleware Behavior | Site Resolution | Result |
+|------|-------------------|-----------------|--------|
+| **Preview** | ✅ Runs | From `sc_site` cookie → hostname fallback | ✅ Works correctly |
+| **Editing** | ✅ Runs | From `sc_site` cookie → hostname fallback | ✅ Works correctly |
+| **Regular** | ✅ Runs | From hostname, query params, or cookie | ✅ Works correctly |
+
+### When Multisite is Disabled (`enabled: false`)
+
+| Mode | Middleware Behavior | Site Resolution | Result |
+|------|-------------------|-----------------|--------|
+| **Preview** | ✅ Runs (bypasses enabled check) | From `sc_site` cookie → hostname fallback | ✅ Works correctly |
+| **Editing** | ✅ Runs (bypasses enabled check) | From `sc_site` cookie → hostname fallback | ✅ Works correctly |
+| **Regular** | ❌ Skips | No site segment added | ❌ 404 errors |
+
+**Key Insight**: Preview and Editing modes always require the middleware to run (even when disabled) to preserve site name via cookies for navigation between pages.
+
+### Middleware Adjustments Made
+
+The middleware includes the following adjustments for correct site resolution:
+
+1. **Fallback for missing site cookie**: If `sc_site` cookie is missing in Preview/Editing mode, falls back to hostname resolution instead of crashing
+2. **Runtime warning**: Logs a warning when multisite is disabled in App Router to alert developers
+3. **Cookie validation**: Validates site cookie presence and provides graceful fallback
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| Regular requests return 404 | `enabled: false` in App Router | Set `enabled: true` |
+| Preview shows wrong site | Missing/incorrect `sc_site` cookie | Check editing route handler |
+| Cookie missing warning | Cookie not set or expired | Verify route handler configuration |
+
+## See Also
+
+- [MultisiteMiddleware](classes/MultisiteMiddleware.md)
+- [AppRouterMultisiteMiddleware](classes/AppRouterMultisiteMiddleware.md)
+- [MultisiteMiddlewareConfig](type-aliases/MultisiteMiddlewareConfig.md)
+

--- a/ref-docs/nextjs/middleware/MULTISITE_CONFIGURATION.md
+++ b/ref-docs/nextjs/middleware/MULTISITE_CONFIGURATION.md
@@ -69,7 +69,7 @@ multisite: {
 
 ## Preview/Editing Modes
 
-Preview and Editing modes always run the middleware (even when `enabled: false`) to preserve site name via cookies. Site resolution: `sc_site` cookie → hostname fallback.
+Preview and Editing modes always run the middleware (even when `enabled: false`) to preserve site name via cookies. Site name comes from the `sc_site` cookie set by the editing route handler.
 
 **When enabled**: All modes work correctly  
 **When disabled**: Preview/Editing work, regular requests break (404)

--- a/ref-docs/nextjs/middleware/README.md
+++ b/ref-docs/nextjs/middleware/README.md
@@ -31,6 +31,10 @@
 
 - [defineMiddleware](functions/defineMiddleware.md)
 
+## Documentation
+
+- [Multisite Configuration in App Router](MULTISITE_CONFIGURATION.md) - Important information about multisite limitations and single-site setups
+
 ## References
 
 ### debug


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
After investigating, my conclusion is that **multisite** cannot be disabled in App Router due to route structure constraints ([site] segment required). I have documented the limitations and the correct approach for single-site setups.

Changes:
- Added `MULTISITE_CONFIGURATION.md` file that explains the current setup and how to work with it
- Added warning comment in config
- Added fallback for missing site cookie in Preview/Editing modes
- Added runtime warning when disabled in App Router

_Key finding: For single-site setups, keep multisite.enabled: true and configure one site — achieves the same result without breaking the app._

## Testing Details
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
