### PR TITLE
[react] [nextjs] [create-content-sdk-app/nextjs-app-router] Follow up to DesignLibrary for server side components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs]` [App Router] Add support for server components in Design Studio ([#280](https://github.com/Sitecore/content-sdk/pull/280))
+* `[nextjs]` [App Router] Add support for server components in Design Studio ([#280](https://github.com/Sitecore/content-sdk/pull/280))([#300](https://github.com/Sitecore/content-sdk/pull/300))
   - additional react components to handle dynamic rendering of server components
   - includes refactoring of existing Design Library functionality
   - this is a breaking change for applications based on Next.js App Router (beta) template. Please refer to the detailed upgrade guide for further instructions

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/gitignore
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/gitignore
@@ -28,3 +28,4 @@
 !.sitecore/component-map.client.ts
 !.sitecore/import-map.ts
 !.sitecore/import-map.server.ts
+!.sitecore/import-map.client.ts

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/gitignore
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router (beta)/gitignore
@@ -27,3 +27,4 @@
 !.sitecore/component-map.ts
 !.sitecore/component-map.client.ts
 !.sitecore/import-map.ts
+!.sitecore/import-map.server.ts

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
@@ -663,7 +663,22 @@ describe('createEditingRenderRouteHandlers', () => {
   });
 
   describe('POST handler', () => {
+    let mockQuery: { [key: string]: string };
+
     beforeEach(() => {
+      mockQuery = {
+        [QUERY_PARAM_EDITING_SECRET]: secret,
+        mode: 'edit',
+        route: '/styleguide',
+        sc_itemid: '{11111111-1111-1111-1111-111111111111}',
+        sc_lang: 'en',
+        sc_site: 'website',
+        sc_variant: 'dev',
+        sc_version: 'latest',
+        sc_layoutKind: 'shared',
+        sc_language: 'en',
+      };
+
       req = {
         method: 'POST',
         headers: new Headers({
@@ -671,17 +686,7 @@ describe('createEditingRenderRouteHandlers', () => {
           host: 'localhost:3000',
         }),
         nextUrl: {
-          searchParams: mockSearchParams({
-            [QUERY_PARAM_EDITING_SECRET]: secret,
-            mode: 'edit',
-            route: '/styleguide',
-            sc_itemid: '{11111111-1111-1111-1111-111111111111}',
-            sc_lang: 'en',
-            sc_site: 'website',
-            sc_variant: 'dev',
-            sc_version: 'latest',
-            sc_layoutKind: 'shared',
-          }),
+          searchParams: mockSearchParams(mockQuery),
         } as any,
       };
     });
@@ -750,6 +755,43 @@ describe('createEditingRenderRouteHandlers', () => {
       const fetchCall = fetchStub.getCall(0);
       const fetchHeaders = fetchCall.args[1].headers as Headers;
       expect(fetchHeaders.get('cookie')).to.include('__prerender_bypass=some-value');
+    });
+
+    it('should proxy POST request with mapped querry string parameters and propagated vercel protection parameters', async () => {
+      const protectionParams = {
+        [QUERY_PARAM_VERCEL_PROTECTION_BYPASS]: 'bypass-token-123',
+        [QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE]: 'true',
+      };
+
+      getQueryParamsForPropagationStub.returns(protectionParams);
+
+      fetchStub.resolves({
+        status: 200,
+        statusText: 'OK',
+        data: '<html>Server Action Response</html>',
+      });
+
+      const res = await handlers.POST(req);
+      const text = await res.body;
+
+      expect(res.status).to.equal(200);
+      expect(text).to.equal('<html>Server Action Response</html>');
+      expect(fetchStub.calledOnce).to.be.true;
+
+      const fetchCall = fetchStub.getCall(0);
+
+      const targetUrl = new URL(fetchCall.args[0]);
+      expect(targetUrl.searchParams.get('itemId')).to.equal(mockQuery.sc_itemid);
+      expect(targetUrl.searchParams.get('language')).to.equal(mockQuery.sc_language);
+      expect(targetUrl.searchParams.get('site')).to.equal(mockQuery.sc_site);
+      expect(targetUrl.searchParams.get('mode')).to.equal(mockQuery.mode);
+      expect(targetUrl.searchParams.get('variantIds')).to.equal(mockQuery.sc_variant);
+      expect(targetUrl.searchParams.get('version')).to.equal(mockQuery.sc_version);
+      expect(targetUrl.searchParams.get('layoutKind')).to.equal(mockQuery.sc_layoutKind);
+      expect(targetUrl.searchParams.get(QUERY_PARAM_VERCEL_PROTECTION_BYPASS)).to.equal(
+        'bypass-token-123'
+      );
+      expect(targetUrl.searchParams.get(QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE)).to.equal('true');
     });
 
     it('should filter out x-middleware and content-encoding headers', async () => {

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.ts
@@ -290,14 +290,10 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
       query[key] = value;
     });
 
-    console.log('query', query);
-
     const propagatedQsParams = {
       ...getQueryParamsForPropagation(query as { [key: string]: string }),
       ...mapEditingParams(query as { [key: string]: string }),
     };
-
-    console.log('propagatedQsParams', propagatedQsParams);
 
     const base = resolveServerUrl(req);
     const targetUrl = new URL('/', base);

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.ts
@@ -284,9 +284,30 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
       );
     }
 
-    const queryString = req.nextUrl.searchParams.toString();
+    // propagate vercel protection query parameters; map query parameters for design library request
+    const query: EditingRenderQueryParams = {} as EditingRenderQueryParams;
+    req.nextUrl.searchParams.forEach((value, key) => {
+      query[key] = value;
+    });
+
+    console.log('query', query);
+
+    const propagatedQsParams = {
+      ...getQueryParamsForPropagation(query as { [key: string]: string }),
+      ...mapEditingParams(query as { [key: string]: string }),
+    };
+
+    console.log('propagatedQsParams', propagatedQsParams);
+
     const base = resolveServerUrl(req);
-    const targetUrl = new URL(`/?${queryString}`, base).toString();
+    const targetUrl = new URL('/', base);
+
+    for (const key in propagatedQsParams) {
+      if ({}.hasOwnProperty.call(propagatedQsParams, key)) {
+        propagatedQsParams[key] && targetUrl.searchParams.append(key, propagatedQsParams[key]);
+      }
+    }
+    targetUrl.searchParams.append('timestamp', Date.now().toString());
 
     // enable draft mode in order to get prerender bypass cookie from request
     const draft = await draftMode();
@@ -305,7 +326,7 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
     const forwardHeaders = new Headers(req.headers);
     forwardHeaders.set('cookie', forwardCookie);
 
-    const forwardedResponse = await dataFetcher.fetch<string>(targetUrl, {
+    const forwardedResponse = await dataFetcher.fetch<string>(targetUrl.toString(), {
       method: req.method,
       headers: forwardHeaders,
       body: req.body,

--- a/packages/react/src/components/DesignLibrary/DesignLibraryServer.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryServer.tsx
@@ -153,7 +153,11 @@ export const DesignLibraryServerVariantGeneration = async ({
       {Component ? (
         <DesignLibraryErrorBoundary uid={componentToUpdate.uid}>
           <PlaceholderMetadata rendering={componentToUpdate}>
-            <Component fields={componentToUpdate.fields} params={componentToUpdate.params} />
+            <Component
+              fields={componentToUpdate.fields}
+              params={componentToUpdate.params}
+              key={Date.now()}
+            />
           </PlaceholderMetadata>
         </DesignLibraryErrorBoundary>
       ) : (
@@ -162,6 +166,7 @@ export const DesignLibraryServerVariantGeneration = async ({
           page={page}
           rendering={rendering}
           componentMap={componentMap}
+          key={Date.now()}
         />
       )}
       <DesignLibraryVariantGenerationEvents


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a follow up to #280 and addresses several issues found during testing:
- when POST editing route handler proxies the request it needs to map the query parameters names for a design library request
- POST editing handler need to propagate vercel bypass protection query parameters
- the static (for now) server import map needs to not be git ignored
- added key props when rendering the server components in design library server

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
