### PR TITLE
[nextjs] Follow up to DesignLibrary for server side components - allow internal POST requests in editing handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs]` [App Router] Add support for server components in Design Studio ([#280](https://github.com/Sitecore/content-sdk/pull/280))([#300](https://github.com/Sitecore/content-sdk/pull/300))
+* `[nextjs]` [App Router] Add support for server components in Design Studio ([#280](https://github.com/Sitecore/content-sdk/pull/280))([#300](https://github.com/Sitecore/content-sdk/pull/300))([#301](https://github.com/Sitecore/content-sdk/pull/301))
   - additional react components to handle dynamic rendering of server components
   - includes refactoring of existing Design Library functionality
   - this is a breaking change for applications based on Next.js App Router (beta) template. Please refer to the detailed upgrade guide for further instructions

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
@@ -709,14 +709,14 @@ describe('createEditingRenderRouteHandlers', () => {
       expect(res.body).to.include('not allowed');
     });
 
-    it('should allow request when in xmc environment - internalServerUrl is https://localhost:3000', async () => {
+    it('should allow request when in xmc or local environment - request hostname is localhost', async () => {
       getEnforcedCorsHeadersStub.returns(null);
       const mockResponseHeaders = new Headers({
         'content-type': 'text/html',
         'Set-Cookie': 'session=abc123',
       });
 
-      req.nextUrl!.host = 'localhost:3000';
+      req.nextUrl!.hostname = 'localhost';
 
       fetchStub.resolves({
         status: 200,
@@ -733,7 +733,7 @@ describe('createEditingRenderRouteHandlers', () => {
       expect(fetchStub.calledOnce).to.be.true;
     });
 
-    it('should allow request when request origin is the same as internalServerUrl', async () => {
+    it('should allow request when request host is the same as origin host', async () => {
       getEnforcedCorsHeadersStub.returns(null);
       const mockResponseHeaders = new Headers({
         'content-type': 'text/html',
@@ -744,7 +744,6 @@ describe('createEditingRenderRouteHandlers', () => {
 
       req.headers = new Headers({
         origin: 'https://some-url',
-        host: 'localhost:3000',
       });
 
       fetchStub.resolves({

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
@@ -687,6 +687,7 @@ describe('createEditingRenderRouteHandlers', () => {
         }),
         nextUrl: {
           searchParams: mockSearchParams(mockQuery),
+          host: '',
         } as any,
       };
     });
@@ -697,6 +698,68 @@ describe('createEditingRenderRouteHandlers', () => {
 
       expect(res.status).to.equal(401);
       expect(res.body).to.include('not allowed');
+    });
+
+    it('should return 401 when invalid origin and POST request is not same origin or localhost', async () => {
+      getEnforcedCorsHeadersStub.returns(null);
+      resolveServerUrlStub.returns('http://some-other-host:8080');
+      const res = await handlers.POST(req as NextRequest);
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.include('not allowed');
+    });
+
+    it('should allow request when in xmc environment - internalServerUrl is https://localhost:3000', async () => {
+      getEnforcedCorsHeadersStub.returns(null);
+      const mockResponseHeaders = new Headers({
+        'content-type': 'text/html',
+        'Set-Cookie': 'session=abc123',
+      });
+
+      req.nextUrl!.host = 'localhost:3000';
+
+      fetchStub.resolves({
+        status: 200,
+        statusText: 'OK',
+        headers: mockResponseHeaders,
+        data: '<html>Server Action Response</html>',
+      });
+
+      const res = await handlers.POST(req);
+      const text = await res.body;
+
+      expect(res.status).to.equal(200);
+      expect(text).to.equal('<html>Server Action Response</html>');
+      expect(fetchStub.calledOnce).to.be.true;
+    });
+
+    it('should allow request when request origin is the same as internalServerUrl', async () => {
+      getEnforcedCorsHeadersStub.returns(null);
+      const mockResponseHeaders = new Headers({
+        'content-type': 'text/html',
+        'Set-Cookie': 'session=abc123',
+      });
+
+      req.nextUrl!.host = 'some-url';
+
+      req.headers = new Headers({
+        origin: 'https://some-url',
+        host: 'localhost:3000',
+      });
+
+      fetchStub.resolves({
+        status: 200,
+        statusText: 'OK',
+        headers: mockResponseHeaders,
+        data: '<html>Server Action Response</html>',
+      });
+
+      const res = await handlers.POST(req);
+      const text = await res.body;
+
+      expect(res.status).to.equal(200);
+      expect(text).to.equal('<html>Server Action Response</html>');
+      expect(fetchStub.calledOnce).to.be.true;
     });
 
     it('should return 401 for invalid editing secret', async () => {

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.ts
@@ -267,9 +267,18 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
    * @param {NextRequest} req - The incoming request
    */
   const POST = async (req: NextRequest) => {
+    const requestOrigin = req.headers.get('origin') || '';
+    const originHost = new URL(requestOrigin).host;
     const expectedCorsHeaders = getCorsHeaders(req);
-    if (!expectedCorsHeaders) {
-      return new Response(getOriginNotAllowedMessage(req.headers.get('origin') || ''), {
+
+    // Allow request if:
+    // we are in local or sitecore environment - requested host is 'localhost:3000'
+    // or the request is same origin (e.g. in vercel netlify environment)
+    const isAllowedRequest =
+      req.nextUrl.host === 'localhost:3000' || req.nextUrl.host === originHost;
+
+    if (!isAllowedRequest && !expectedCorsHeaders) {
+      return new Response(getOriginNotAllowedMessage(requestOrigin), {
         status: 401,
       });
     }
@@ -280,7 +289,7 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
         {
           html: INVALID_SECRET_HTML_MESSAGE,
         },
-        { status: 401, headers: expectedCorsHeaders }
+        { status: 401, headers: expectedCorsHeaders ?? {} }
       );
     }
 
@@ -348,7 +357,7 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
     filteredHeaders.set('Content-Security-Policy', getCSPHeader());
 
     // add expected CORS headers to response
-    Object.entries(expectedCorsHeaders).forEach(([key, value]: [string, string]) => {
+    Object.entries(expectedCorsHeaders ?? {}).forEach(([key, value]: [string, string]) => {
       filteredHeaders.set(key, value);
     });
 

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.ts
@@ -271,13 +271,12 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
     const originHost = new URL(requestOrigin).host;
     const expectedCorsHeaders = getCorsHeaders(req);
 
-    // Allow request if:
-    // we are in local or sitecore environment - requested host is 'localhost:3000'
+    // Bypass CORS if:
+    // we are in local or sitecore environment - requested hostname is 'localhost'
     // or the request is same origin (e.g. in vercel netlify environment)
-    const isAllowedRequest =
-      req.nextUrl.host === 'localhost:3000' || req.nextUrl.host === originHost;
+    const bypassCors = req.nextUrl.hostname === 'localhost' || req.nextUrl.host === originHost;
 
-    if (!isAllowedRequest && !expectedCorsHeaders) {
+    if (!bypassCors && !expectedCorsHeaders) {
       return new Response(getOriginNotAllowedMessage(requestOrigin), {
         status: 401,
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a follow up to https://github.com/Sitecore/content-sdk/pull/280 and addresses the issue where same origin and internal xmc editing host requests are blocked by CORS check

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
