### PR TITLE
[core] Add DL host to default allowed editing origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Our versioning strategy is as follows:
   * `[react]` Added React hooks for search functionality
     - `useSearch` hook for paginated search queries with automatic state management, request cancellation, request status tracking.
     - `useInfiniteSearch` hook for infinite scroll/search patterns with `loadMore` functionality, request cancellation, request status tracking.
-* `[nextjs]` [App Router] Add support for server components in Design Studio ([#280](https://github.com/Sitecore/content-sdk/pull/280))([#300](https://github.com/Sitecore/content-sdk/pull/300))([#301](https://github.com/Sitecore/content-sdk/pull/301))
+* `[nextjs]` [App Router] Add support for server components in Design Studio ([#280](https://github.com/Sitecore/content-sdk/pull/280))([#300](https://github.com/Sitecore/content-sdk/pull/300))([#301](https://github.com/Sitecore/content-sdk/pull/301))([#303](https://github.com/Sitecore/content-sdk/pull/303))
   - additional react components to handle dynamic rendering of server components
   - includes refactoring of existing Design Library functionality
   - this is a breaking change for applications based on Next.js App Router (beta) template. Please refer to the detailed upgrade guide for further instructions

--- a/packages/core/src/editing/utils.ts
+++ b/packages/core/src/editing/utils.ts
@@ -36,7 +36,10 @@ export const PAGES_EDITING_MARKER = 'jss-hrz-editing';
  * Default allowed origins for editing requests. This is used to enforce CORS, CSP headers.
  * @internal
  */
-export const EDITING_ALLOWED_ORIGINS = ['https://pages.sitecorecloud.io'];
+export const EDITING_ALLOWED_ORIGINS = [
+  'https://pages.sitecorecloud.io',
+  'https://xmapps.sitecorecloud.io/',
+];
 
 type ExtendedWindow = Window &
   typeof globalThis & {

--- a/packages/core/src/editing/utils.ts
+++ b/packages/core/src/editing/utils.ts
@@ -38,7 +38,7 @@ export const PAGES_EDITING_MARKER = 'jss-hrz-editing';
  */
 export const EDITING_ALLOWED_ORIGINS = [
   'https://pages.sitecorecloud.io',
-  'https://xmapps.sitecorecloud.io/',
+  'https://xmapps.sitecorecloud.io',
   'https://designlibrary.sitecorecloud.io',
 ];
 

--- a/packages/core/src/editing/utils.ts
+++ b/packages/core/src/editing/utils.ts
@@ -39,6 +39,7 @@ export const PAGES_EDITING_MARKER = 'jss-hrz-editing';
 export const EDITING_ALLOWED_ORIGINS = [
   'https://pages.sitecorecloud.io',
   'https://xmapps.sitecorecloud.io/',
+  'https://designlibrary.sitecorecloud.io',
 ];
 
 type ExtendedWindow = Window &

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -110,7 +110,7 @@ describe('utils', () => {
     });
   });
 
-  describe.only('getEnforcedCorsHeaders', () => {
+  describe('getEnforcedCorsHeaders', () => {
     const mockOrigin = 'https://maybeallowed.com';
     const mockHeaders = {
       origin: mockOrigin,

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -110,7 +110,7 @@ describe('utils', () => {
     });
   });
 
-  describe('getEnforcedCorsHeaders', () => {
+  describe.only('getEnforcedCorsHeaders', () => {
     const mockOrigin = 'https://maybeallowed.com';
     const mockHeaders = {
       origin: mockOrigin,
@@ -125,6 +125,8 @@ describe('utils', () => {
       expect(result).to.deep.equal({
         'Access-Control-Allow-Origin': mockOrigin,
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+        'x-middleware-cache': 'no-cache',
+        'Cache-Control': 'no-store, must-revalidate',
       });
       delete process.env.JSS_ALLOWED_ORIGINS;
     });
@@ -146,6 +148,8 @@ describe('utils', () => {
       expect(result).to.deep.equal({
         'Access-Control-Allow-Origin': 'http://allowed.com',
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+        'x-middleware-cache': 'no-cache',
+        'Cache-Control': 'no-store, must-revalidate',
       });
     });
 
@@ -169,6 +173,8 @@ describe('utils', () => {
       expect(result).to.deep.equal({
         'Access-Control-Allow-Origin': 'https://allowed.dev.com',
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+        'x-middleware-cache': 'no-cache',
+        'Cache-Control': 'no-store, must-revalidate',
       });
     });
 
@@ -182,6 +188,8 @@ describe('utils', () => {
         'Access-Control-Allow-Origin': mockOrigin,
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PUT, PATCH',
         'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        'x-middleware-cache': 'no-cache',
+        'Cache-Control': 'no-store, must-revalidate',
       });
     });
 
@@ -194,6 +202,8 @@ describe('utils', () => {
       expect(result).to.deep.equal({
         'Access-Control-Allow-Origin': 'https://preallowed.com',
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+        'x-middleware-cache': 'no-cache',
+        'Cache-Control': 'no-store, must-revalidate',
       });
     });
     it('should handle two different types of headers', () => {
@@ -211,6 +221,8 @@ describe('utils', () => {
       expect(result1).to.deep.equal({
         'Access-Control-Allow-Origin': 'http://allowed.com',
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+        'x-middleware-cache': 'no-cache',
+        'Cache-Control': 'no-store, must-revalidate',
       });
 
       // Test with Headers
@@ -226,6 +238,8 @@ describe('utils', () => {
       expect(result2).to.deep.equal({
         'Access-Control-Allow-Origin': 'http://allowed.com',
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+        'x-middleware-cache': 'no-cache',
+        'Cache-Control': 'no-store, must-revalidate',
       });
     });
   });

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -206,6 +206,8 @@ export const getEnforcedCorsHeaders = ({
     const corsHeaders: { [key: string]: string } = {
       'Access-Control-Allow-Origin': origin,
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+      'x-middleware-cache': 'no-cache',
+      'Cache-Control': 'no-store, must-revalidate',
     };
     // set the allowed headers for preflight requests
     if (requestMethod === 'OPTIONS') {

--- a/packages/nextjs/src/editing/editing-config-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-config-middleware.test.ts
@@ -126,18 +126,18 @@ describe('EditingConfigMiddleware', () => {
 
     await handler(req, res);
 
-    expect(res.setHeader.getCall(0).args).to.deep.equal([
-      'Access-Control-Allow-Origin',
-      allowedOrigin,
-    ]);
-    expect(res.setHeader.getCall(1).args).to.deep.equal([
+    const setHeaders = res.setHeader.getCalls().map((call) => call.args);
+
+    expect(setHeaders).to.deep.include(['Access-Control-Allow-Origin', allowedOrigin]);
+    expect(setHeaders).to.deep.include([
       'Access-Control-Allow-Methods',
       'GET, POST, OPTIONS, DELETE, PUT, PATCH',
     ]);
-    expect(res.setHeader.getCall(2).args).to.deep.equal([
+    expect(setHeaders).to.deep.include([
       'Access-Control-Allow-Headers',
       'Content-Type, Authorization',
     ]);
+
     expect(res.status).to.have.been.calledWith(204);
     expect(res.send).to.have.been.calledOnceWith(null);
   });

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -126,16 +126,15 @@ describe('EditingRenderMiddleware', () => {
 
     await handler(req, res);
 
+    const setHeaders = res.setHeader.getCalls().map((call) => call.args);
+
     expect(res.status).to.have.been.calledOnceWith(204);
-    expect(res.setHeader.getCall(0).args).to.deep.equal([
-      'Access-Control-Allow-Origin',
-      allowedOrigin,
-    ]);
-    expect(res.setHeader.getCall(1).args).to.deep.equal([
+    expect(setHeaders).to.deep.include(['Access-Control-Allow-Origin', allowedOrigin]);
+    expect(setHeaders).to.deep.include([
       'Access-Control-Allow-Methods',
       'GET, POST, OPTIONS, DELETE, PUT, PATCH',
     ]);
-    expect(res.setHeader.getCall(2).args).to.deep.equal([
+    expect(setHeaders).to.deep.include([
       'Access-Control-Allow-Headers',
       'Content-Type, Authorization',
     ]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Update the `EDITING_ALLOWED_ORIGINS` constant to include the prod design library hostname, to allow it to frame external editing hosts (e.g. Vercel)
Add no-cache headers when enforcing CORS. If multiple origins are allowed in `JSS_ALLOWED_ORIGINS` some requests may result in 304 - not-modified when different origin is required for the current request.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
