### PR TITLE
[react] Disable DL server component variant generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Our versioning strategy is as follows:
     - `useSearch` hook for paginated search queries with automatic state management, request cancellation, request status tracking.
     - `useInfiniteSearch` hook for infinite scroll/search patterns with `loadMore` functionality, request cancellation, request status tracking.
 
+## 1.3.1
+
+### 🧹 Chores
+
+* `[react]` Disable variant generation mode for server components in Design Studio ([#320](https://github.com/Sitecore/content-sdk/pull/320))
+
+
 ## 1.3.0
 
 ### 🎉 New Features & Improvements

--- a/packages/react/src/components/DesignLibrary/DesignLibraryClientEvents.test.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryClientEvents.test.tsx
@@ -176,6 +176,35 @@ describe('<DesignLibraryClientEvents />', () => {
       });
     });
 
+    // TODO: Remove this test when server component variant generation is supported
+    it('should add server component preview handler on mount', () => {
+      renderWithSitecore({
+        designLibraryStatus: DesignLibraryStatus.READY,
+        component: testEditedComponent,
+      });
+
+      expect(addServerComponentPreviewHandlerSpy).to.have.been.called;
+    });
+
+    // TODO: Remove this test when server component variant generation is supported
+    it('should call console error when preview component event is received', async () => {
+      const consoleErrorStub = sandbox.stub(console, 'error');
+
+      renderWithSitecore({
+        designLibraryStatus: DesignLibraryStatus.READY,
+        component: testEditedComponent,
+      });
+
+      const previewCallback = addServerComponentPreviewHandlerSpy.getCall(0).args[0];
+      const eventArgs = { data: { a: 'b' } };
+
+      previewCallback(eventArgs);
+      expect(consoleErrorStub).to.have.been.calledOnce;
+      expect(consoleErrorStub).to.have.been.calledWith(
+        'Component Library variant generation for server components is temporarily disabled.'
+      );
+    });
+
     it('should clean up event handlers on unmount', async () => {
       const unsubUpdate = sinon.stub();
       addComponentUpdateHandlerSpy.returns(unsubUpdate);

--- a/packages/react/src/components/DesignLibrary/DesignLibraryClientEvents.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryClientEvents.tsx
@@ -49,8 +49,16 @@ export const DesignLibraryPreviewEvents = ({
       _updateServerComponentAction({ uid: updated.uid!, updatedComponent: updated });
     });
 
+    // eslint-disable-next-line no-unused-vars
+    const unsubPreview = addServerComponentPreviewHandler((_eventArgs) => {
+      console.error(
+        'Component Library variant generation for server components is temporarily disabled.'
+      );
+    });
+
     return () => {
       unsubUpdate && unsubUpdate();
+      unsubPreview && unsubPreview();
     };
   }, [component, designLibraryStatus]);
 

--- a/packages/react/src/components/DesignLibrary/DesignLibraryServer.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryServer.tsx
@@ -63,7 +63,9 @@ export const DesignLibraryServer = async ({
 
   const isVariantGeneration = page.mode.designLibrary?.isVariantGeneration;
 
-  if (isVariantGeneration) {
+  // Temporarily disable server side variant generation due to potential security vulerability
+  // eslint-disable-next-line no-constant-condition
+  if (isVariantGeneration && false) {
     return (
       <DesignLibraryServerVariantGeneration
         page={page}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR temporarily disables Design Library server component variant generation due to security vulnerability concerns.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore
