### PR TITLE
[Chore] Release 1.3.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/cli",
-  "version": "1.3.1-canary.2",
+  "version": "1.3.1",
   "description": "Sitecore Content SDK CLI",
   "main": "dist/cjs/cli.js",
   "module": "dist/esm/cli.js",
@@ -34,7 +34,7 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "1.3.1-canary.2",
+    "@sitecore-content-sdk/core": "1.3.1",
     "chokidar": "^4.0.3",
     "dotenv": "^16.5.0",
     "dotenv-expand": "^12.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/core",
-  "version": "1.3.1-canary.2",
+  "version": "1.3.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/packages/create-content-sdk-app/package.json
+++ b/packages/create-content-sdk-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-content-sdk-app",
-  "version": "1.3.1-canary.2",
+  "version": "1.3.1",
   "description": "Sitecore Content SDK initializer",
   "bin": "./dist/index.js",
   "scripts": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/nextjs",
-  "version": "1.3.1-canary.2",
+  "version": "1.3.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -91,8 +91,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.27.2",
-    "@sitecore-content-sdk/core": "1.3.1-canary.2",
-    "@sitecore-content-sdk/react": "1.3.1-canary.2",
+    "@sitecore-content-sdk/core": "1.3.1",
+    "@sitecore-content-sdk/react": "1.3.1",
     "recast": "^0.23.11",
     "regex-parser": "^2.3.1",
     "sync-disk-cache": "^2.1.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/react",
-  "version": "1.3.1-canary.2",
+  "version": "1.3.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -76,8 +76,8 @@
     "react-dom": "^19.2.1"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "1.3.1-canary.2",
-    "@sitecore-content-sdk/search": "0.1.1-canary.2",
+    "@sitecore-content-sdk/core": "1.3.1",
+    "@sitecore-content-sdk/search": "0.1.1",
     "fast-deep-equal": "^3.1.3"
   },
   "description": "",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "@sitecore-content-sdk/core": "1.3.1",
-    "@sitecore-content-sdk/search": "0.1.1",
+    "@sitecore-content-sdk/search": "0.1.0",
     "fast-deep-equal": "^3.1.3"
   },
   "description": "",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/search",
-  "version": "0.1.1-canary.2",
+  "version": "0.1.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -36,7 +36,7 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "1.3.1-canary.2"
+    "@sitecore-content-sdk/core": "1.3.1"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/search",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3003,7 +3003,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/cli@workspace:packages/cli"
   dependencies:
-    "@sitecore-content-sdk/core": 1.3.1-canary.2
+    "@sitecore-content-sdk/core": 1.3.1
     "@stylistic/eslint-plugin": ^5.2.2
     "@types/chai": ^5.2.2
     "@types/inquirer": ^9.0.9
@@ -3042,7 +3042,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/core@1.3.1-canary.2, @sitecore-content-sdk/core@workspace:packages/core":
+"@sitecore-content-sdk/core@1.3.1, @sitecore-content-sdk/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/core@workspace:packages/core"
   dependencies:
@@ -3101,8 +3101,8 @@ __metadata:
     "@babel/parser": ^7.27.2
     "@sitecore-cloudsdk/core": ^0.5.1
     "@sitecore-cloudsdk/personalize": ^0.5.1
-    "@sitecore-content-sdk/core": 1.3.1-canary.2
-    "@sitecore-content-sdk/react": 1.3.1-canary.2
+    "@sitecore-content-sdk/core": 1.3.1
+    "@sitecore-content-sdk/react": 1.3.1
     "@stylistic/eslint-plugin": ^5.2.2
     "@testing-library/dom": ^10.4.0
     "@testing-library/react": ^16.3.0
@@ -3160,12 +3160,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/react@1.3.1-canary.2, @sitecore-content-sdk/react@workspace:packages/react":
+"@sitecore-content-sdk/react@1.3.1, @sitecore-content-sdk/react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/react@workspace:packages/react"
   dependencies:
-    "@sitecore-content-sdk/core": 1.3.1-canary.2
-    "@sitecore-content-sdk/search": 0.1.1-canary.2
+    "@sitecore-content-sdk/core": 1.3.1
+    "@sitecore-content-sdk/search": 0.1.1
     "@sitecore-feaas/clientside": ^0.6.0
     "@stylistic/eslint-plugin": ^5.2.2
     "@testing-library/dom": ^10.4.0
@@ -3211,11 +3211,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/search@0.1.1-canary.2, @sitecore-content-sdk/search@workspace:packages/search":
+"@sitecore-content-sdk/search@0.1.1, @sitecore-content-sdk/search@workspace:packages/search":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/search@workspace:packages/search"
   dependencies:
-    "@sitecore-content-sdk/core": 1.3.1-canary.2
+    "@sitecore-content-sdk/core": 1.3.1
     "@types/chai": ^5.2.3
     "@types/mocha": ^10.0.10
     chai: ^6.2.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3165,7 +3165,7 @@ __metadata:
   resolution: "@sitecore-content-sdk/react@workspace:packages/react"
   dependencies:
     "@sitecore-content-sdk/core": 1.3.1
-    "@sitecore-content-sdk/search": 0.1.1
+    "@sitecore-content-sdk/search": 0.1.0
     "@sitecore-feaas/clientside": ^0.6.0
     "@stylistic/eslint-plugin": ^5.2.2
     "@testing-library/dom": ^10.4.0
@@ -3211,7 +3211,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/search@0.1.1, @sitecore-content-sdk/search@workspace:packages/search":
+"@sitecore-content-sdk/search@0.1.0, @sitecore-content-sdk/search@workspace:packages/search":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/search@workspace:packages/search"
   dependencies:


### PR DESCRIPTION
This is a hotfix release to fix the latest Next.JS security vulnerability:
https://nextjs.org/blog/security-update-2025-12-11