### PR TITLE
[create-content-sdk-app][nextjs] Fix middleware initialization errors when API configuration is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+
+* `[nextjs]` `[template/nextjs]` `[template/nextjs-app-router]` Fix middleware initialization errors when API configuration is missing ([#XXX](https://github.com/Sitecore/content-sdk/pull/XXX))
+
 * Search integration ([#295](https://github.com/Sitecore/content-sdk/pull/295))
   * `[search]` New `@sitecore-content-sdk/search` package providing search functionality
     - `SearchService` class for performing search queries with support for pagination, sorting, request cancellation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
-### 🐛 Bug Fixes
-
-* `[nextjs]` `[template/nextjs]` `[template/nextjs-app-router]` Fix middleware initialization errors when API configuration is missing ([#325](https://github.com/Sitecore/content-sdk/pull/325))
-
 ### 🎉 New Features & Improvements
 
 * Search integration ([#295](https://github.com/Sitecore/content-sdk/pull/295))
@@ -29,6 +25,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[nextjs]` Add "use client" directive to import-map.ts for React hooks compatibility ([#326](https://github.com/Sitecore/content-sdk/pull/326))
+* `[nextjs]` `[template/nextjs]` `[template/nextjs-app-router]` Fix middleware initialization errors when API configuration is missing ([#325](https://github.com/Sitecore/content-sdk/pull/325))
 
 ## 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
-* `[nextjs]` `[template/nextjs]` `[template/nextjs-app-router]` Fix middleware initialization errors when API configuration is missing ([#XXX](https://github.com/Sitecore/content-sdk/pull/XXX))
+* `[nextjs]` `[template/nextjs]` `[template/nextjs-app-router]` Fix middleware initialization errors when API configuration is missing ([#325](https://github.com/Sitecore/content-sdk/pull/325))
 
 * Search integration ([#295](https://github.com/Sitecore/content-sdk/pull/295))
   * `[search]` New `@sitecore-content-sdk/search` package providing search functionality

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/middleware.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/middleware.ts
@@ -10,75 +10,78 @@ import sites from '.sitecore/sites.json';
 import scConfig from 'sitecore.config';
 import { routing } from './i18n/routing';
 
-const locale = new LocaleMiddleware({
-  /**
-   * List of sites for site resolver to work with
-   */
-  sites,
-  /**
-   * List of all supported locales configured in routing.ts
-   */
-  locales: routing.locales.slice(),
-  // This function determines if the middleware should be turned off on per-request basis.
-  // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to disable more.
-  // This is an important performance consideration since Next.js Edge middleware runs on every request.
-  // in multilanguage scenarios, we need locale middleware to always run first to ensure locale is set and used correctly by the rest of the middlewares
-  skip: () => false,
-});
-
-const multisite = new AppRouterMultisiteMiddleware({
-  /**
-   * List of sites for site resolver to work with
-   */
-  sites,
-  ...scConfig.multisite,
-  // This function determines if the middleware should be turned off on per-request basis.
-  // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to disable more.
-  // This is an important performance consideration since Next.js Edge middleware runs on every request.
-  skip: () => false,
-});
-
-const redirects = new RedirectsMiddleware({
-  /**
-   * List of sites for site resolver to work with
-   */
-  sites,
-  ...scConfig.api.edge,
-  ...scConfig.api.local,
-  ...scConfig.redirects,
-  // This function determines if the middleware should be turned off on per-request basis.
-  // Certain paths are ignored by default (e.g. Next.js API routes), but you may wish to disable more.
-  // By default it is disabled while in development mode.
-  // This is an important performance consideration since Next.js Edge middleware runs on every request.
-  skip: () => false,
-});
-
-const personalize = new PersonalizeMiddleware({
-  /**
-   * List of sites for site resolver to work with
-   */
-  sites,
-  ...scConfig.api.edge,
-  ...scConfig.personalize,
-  // This function determines if the middleware should be turned off on per-request basis.
-  // Certain paths are ignored by default (e.g. Next.js API routes), but you may wish to disable more.
-  // By default it is disabled while in development mode.
-  // This is an important performance consideration since Next.js Edge middleware runs on every request.
-  // NOTE: Personalize requires Edge configuration and cannot work with local containers.
-  // The middleware will disable itself if Edge config is not present.
-  skip: () => false,
-  // This is an example of how to provide geo data for personalization.
-  // The provided callback will be called on each request to extract geo data.
-  // extractGeoDataCb: () => {
-  //   return {
-  //     city: 'Athens',
-  //     country: 'Greece',
-  //     region: 'Attica',
-  //   };
-  // },
-});
-
 export function middleware(req: NextRequest, ev: NextFetchEvent) {
+  // LocaleMiddleware and AppRouterMultisiteMiddleware must always run for App Router routing
+  const locale = new LocaleMiddleware({
+    /**
+     * List of sites for site resolver to work with
+     */
+    sites,
+    /**
+     * List of all supported locales configured in routing.ts
+     */
+    locales: routing.locales.slice(),
+    // This function determines if the middleware should be turned off on per-request basis.
+    // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to disable more.
+    // This is an important performance consideration since Next.js Edge middleware runs on every request.
+    // in multilanguage scenarios, we need locale middleware to always run first to ensure locale is set and used correctly by the rest of the middlewares
+    skip: () => false,
+  });
+
+  const multisite = new AppRouterMultisiteMiddleware({
+    /**
+     * List of sites for site resolver to work with
+     */
+    sites,
+    ...scConfig.multisite,
+    // This function determines if the middleware should be turned off on per-request basis.
+    // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to disable more.
+    // This is an important performance consideration since Next.js Edge middleware runs on every request.
+    skip: () => false,
+  });
+
+  // Instantiate middlewares - they will use Edge config if available, otherwise fall back to local config
+  // Each middleware will skip processing if required API configuration is not available
+  const redirects = new RedirectsMiddleware({
+    /**
+     * List of sites for site resolver to work with
+     */
+    sites,
+    ...scConfig.api.edge,
+    ...scConfig.api.local,
+    ...scConfig.redirects,
+    // This function determines if the middleware should be turned off on per-request basis.
+    // Certain paths are ignored by default (e.g. Next.js API routes), but you may wish to disable more.
+    // By default it is disabled while in development mode.
+    // This is an important performance consideration since Next.js Edge middleware runs on every request.
+    skip: () => false,
+  });
+
+  const personalize = new PersonalizeMiddleware({
+    /**
+     * List of sites for site resolver to work with
+     */
+    sites,
+    ...scConfig.api.edge,
+    ...scConfig.personalize,
+    // This function determines if the middleware should be turned off on per-request basis.
+    // Certain paths are ignored by default (e.g. Next.js API routes), but you may wish to disable more.
+    // By default it is disabled while in development mode.
+    // This is an important performance consideration since Next.js Edge middleware runs on every request.
+    // NOTE: Personalize requires Edge configuration and cannot work with local containers.
+    // The middleware will disable itself if Edge config is not present.
+    skip: () => false,
+    // This is an example of how to provide geo data for personalization.
+    // The provided callback will be called on each request to extract geo data.
+    // extractGeoDataCb: () => {
+    //   return {
+    //     city: 'Athens',
+    //     country: 'Greece',
+    //     region: 'Attica',
+    //   };
+    // },
+  });
+
   return defineMiddleware(locale, multisite, redirects, personalize).exec(req, ev);
 }
 

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/middleware.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/middleware.ts
@@ -1,4 +1,4 @@
-import { type NextRequest, type NextFetchEvent, NextResponse } from 'next/server';
+import { type NextRequest, type NextFetchEvent } from 'next/server';
 import {
   defineMiddleware,
   MultisiteMiddleware,
@@ -9,13 +9,8 @@ import sites from '.sitecore/sites.json';
 import scConfig from 'sitecore.config';
 
 export function middleware(req: NextRequest, ev: NextFetchEvent) {
-  // Skip middlewares only if neither Edge nor local API configuration is available.
-  // Middlewares can work with either Edge (contextId) or local (apiHost/apiKey) configuration.
-  if (!scConfig.api?.edge?.contextId && !scConfig.api?.local?.apiHost) {
-    return NextResponse.next();
-  }
-
   // Instantiate middlewares - they will use Edge config if available, otherwise fall back to local config
+  // Each middleware will skip processing if required API configuration is not available
   const multisite = new MultisiteMiddleware({
     /**
      * List of sites for site resolver to work with

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -771,7 +771,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
     handle: (req: NextRequest, res: NextResponse) => Promise<NextResponse>;
     protected normalizeUrl(url: NextURL): NextURL;
     // (undocumented)
-    protected redirectsService: RedirectsService;
+    protected redirectsService: RedirectsService | null;
 }
 
 // @public

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -764,6 +764,8 @@ export class RedirectsMiddleware extends MiddlewareBase {
     // (undocumented)
     protected config: RedirectsMiddlewareConfig;
     protected createRedirectResponse(url: NextURL | string, res: Response | undefined, status: number, statusText: string): NextResponse;
+    // (undocumented)
+    protected disabled(req: NextRequest, res: NextResponse): boolean | undefined;
     protected dispatchRedirect(target: NextURL | string, type: string, req: NextRequest, res: NextResponse, isExternal?: boolean): NextResponse;
     // Warning: (ae-forgotten-export) The symbol "RedirectResult" needs to be exported by the entry point api-surface.d.ts
     protected getExistsRedirect(req: NextRequest, siteName: string): Promise<RedirectResult | undefined>;
@@ -929,7 +931,7 @@ export * from "@sitecore-content-sdk/react/search";
 
 // Warnings were encountered during analysis:
 //
-// src/middleware/personalize-middleware.ts:299:7 - (ae-forgotten-export) The symbol "PersonalizeGeoData" needs to be exported by the entry point api-surface.d.ts
+// src/middleware/personalize-middleware.ts:302:7 - (ae-forgotten-export) The symbol "PersonalizeGeoData" needs to be exported by the entry point api-surface.d.ts
 // src/services/component-props-service.ts:61:5 - (ae-forgotten-export) The symbol "NextContext" needs to be exported by the entry point api-surface.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/nextjs/src/middleware/personalize-middleware.ts
@@ -100,13 +100,17 @@ export class PersonalizeMiddleware extends MiddlewareBase {
       });
   }
 
-  handle = async (req: NextRequest, res: NextResponse): Promise<NextResponse> => {
-    // Skip if service wasn't initialized (no edge config)
+  protected disabled(req: NextRequest, res: NextResponse): boolean | undefined {
+    // Check if API config is missing - if so, disable the middleware
     if (!this.personalizeService) {
       debug.personalize('skipped (personalize service not configured - edge config required)');
-      return res;
+      return true;
     }
+    // ignore files
+    return req.nextUrl.pathname.includes('.') || super.disabled(req, res);
+  }
 
+  handle = async (req: NextRequest, res: NextResponse): Promise<NextResponse> => {
     if (!this.config.enabled) {
       debug.personalize('skipped (personalize middleware is disabled globally)');
       return res;
@@ -253,11 +257,6 @@ export class PersonalizeMiddleware extends MiddlewareBase {
       referrer: req.headers.get('referer') || req.referrer,
       utm,
     };
-  }
-
-  protected disabled(req: NextRequest, res: NextResponse): boolean | undefined {
-    // ignore files
-    return req.nextUrl.pathname.includes('.') || super.disabled(req, res);
   }
 
   protected async initPersonalizeServer({

--- a/packages/nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/nextjs/src/middleware/personalize-middleware.ts
@@ -149,6 +149,10 @@ export class PersonalizeMiddleware extends MiddlewareBase {
       const site = this.getSite(req, res);
 
       // Get personalization info from Experience Edge
+      // personalizeService is guaranteed to be non-null here because disabled() check passed
+      if (!this.personalizeService) {
+        return res;
+      }
       const personalizeInfo = await this.personalizeService.getPersonalizeInfo(
         pathname,
         language,

--- a/packages/nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/nextjs/src/middleware/personalize-middleware.ts
@@ -100,16 +100,6 @@ export class PersonalizeMiddleware extends MiddlewareBase {
       });
   }
 
-  protected disabled(req: NextRequest, res: NextResponse): boolean | undefined {
-    // Check if API config is missing - if so, disable the middleware
-    if (!this.personalizeService) {
-      debug.personalize('skipped (personalize service not configured - edge config required)');
-      return true;
-    }
-    // ignore files
-    return req.nextUrl.pathname.includes('.') || super.disabled(req, res);
-  }
-
   handle = async (req: NextRequest, res: NextResponse): Promise<NextResponse> => {
     if (!this.config.enabled) {
       debug.personalize('skipped (personalize middleware is disabled globally)');
@@ -244,6 +234,16 @@ export class PersonalizeMiddleware extends MiddlewareBase {
       return res;
     }
   };
+
+  protected disabled(req: NextRequest, res: NextResponse): boolean | undefined {
+    // Check if API config is missing - if so, disable the middleware
+    if (!this.personalizeService) {
+      debug.personalize('skipped (personalize service not configured - edge config required)');
+      return true;
+    }
+    // ignore files
+    return req.nextUrl.pathname.includes('.') || super.disabled(req, res);
+  }
 
   protected getExperienceParams(req: NextRequest): ExperienceParams {
     const extraParams = this.config.getExtraUtmParams ? this.config.getExtraUtmParams(req) : {};

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -202,7 +202,8 @@ describe('RedirectsMiddleware', () => {
 
     middleware['siteResolver'] = siteResolver;
 
-    const fetchRedirects = (middleware['redirectsService']['fetchRedirects'] =
+    // In test helper, we always provide API config, so redirectsService should never be null
+    const fetchRedirects = (middleware['redirectsService']!['fetchRedirects'] =
       props.fetchRedirectsStub ||
       sandbox.stub().returns(Promise.resolve(Object.keys(props).length ? redirectMaps : [])));
 
@@ -2694,6 +2695,8 @@ describe('RedirectsMiddleware', () => {
       } as any); // Type assertion: Edge properties are optional at runtime
 
       expect(middleware1).to.not.be.undefined;
+      // Should be null since local config is incomplete (missing apiKey)
+      expect(middleware1['redirectsService']).to.be.null;
 
       // Only apiKey, missing apiHost
       const middleware2 = new RedirectsMiddleware({
@@ -2705,6 +2708,103 @@ describe('RedirectsMiddleware', () => {
       } as any); // Type assertion: Edge properties are optional at runtime
 
       expect(middleware2).to.not.be.undefined;
+      // Should be null since local config is incomplete (missing apiHost)
+      expect(middleware2['redirectsService']).to.be.null;
+    });
+  });
+
+  describe('configuration - missing API config', () => {
+    it('gracefully disables when no API config is provided', () => {
+      // Create middleware without any API config (no Edge, no Local)
+      const middleware = new RedirectsMiddleware({
+        enabled: true,
+        sites: [],
+        locales: ['en'],
+        // No contextId, clientContextId, apiHost, or apiKey
+      } as any); // Type assertion: API properties are optional at runtime
+
+      // Verify middleware was created but redirectsService is null
+      expect(middleware).to.not.be.undefined;
+      expect(middleware['redirectsService']).to.be.null;
+    });
+
+    it('works with only contextId (no clientContextId, no local)', () => {
+      const middleware = new RedirectsMiddleware({
+        enabled: true,
+        // Only contextId, but no clientContextId and no local config
+        contextId: 'edge-context-id',
+        edgeUrl: 'https://edge.url',
+        sites: [],
+        locales: ['en'],
+      } as any);
+
+      // Should work with contextId only (Edge config)
+      expect(middleware).to.not.be.undefined;
+      expect(middleware['redirectsService']).to.not.be.null;
+    });
+
+    it('works with only clientContextId (no contextId, no local)', () => {
+      const middleware = new RedirectsMiddleware({
+        enabled: true,
+        // Only clientContextId, but no contextId and no local config
+        clientContextId: 'edge-client-id',
+        edgeUrl: 'https://edge.url',
+        sites: [],
+        locales: ['en'],
+      } as any);
+
+      // Should work with clientContextId only (Edge config)
+      expect(middleware).to.not.be.undefined;
+      expect(middleware['redirectsService']).to.not.be.null;
+    });
+
+    it('skips execution when redirectsService is null', async () => {
+      const req = createRequest();
+      const res = createResponse();
+
+      // Create middleware without any API config
+      const middleware = new RedirectsMiddleware({
+        enabled: true,
+        sites: [],
+        locales: ['en'],
+        // No API config
+      } as any);
+
+      const finalRes = await middleware.handle(req, res);
+
+      // Should skip execution and return response unchanged
+      validateDebugLog('skipped (redirects service not configured - API config required)');
+      expect(finalRes).to.deep.equal(res);
+    });
+
+    it('works normally when Edge config is provided', () => {
+      const middleware = new RedirectsMiddleware({
+        enabled: true,
+        contextId: 'edge-context-id',
+        clientContextId: 'edge-client-id',
+        edgeUrl: 'https://edge.url',
+        sites: [],
+        locales: ['en'],
+      });
+
+      // Verify middleware was created and redirectsService is initialized
+      expect(middleware).to.not.be.undefined;
+      expect(middleware['redirectsService']).to.not.be.null;
+    });
+
+    it('works normally when local config is provided', () => {
+      const middleware = new RedirectsMiddleware({
+        enabled: true,
+        apiHost: 'https://local.host',
+        apiKey: 'local-api-key',
+        path: '/api/graphql',
+        sites: [],
+        locales: ['en'],
+      } as any);
+
+      // Verify middleware was created and redirectsService is initialized
+      expect(middleware).to.not.be.undefined;
+      expect(middleware['redirectsService']).to.not.be.null;
     });
   });
 });

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -95,15 +95,6 @@ export class RedirectsMiddleware extends MiddlewareBase {
       });
   }
 
-  protected disabled(req: NextRequest, res: NextResponse): boolean | undefined {
-    // Check if API config is missing - if so, disable the middleware
-    if (!this.redirectsService) {
-      debug.redirects('skipped (redirects service not configured - API config required)');
-      return true;
-    }
-    return super.disabled(req, res);
-  }
-
   handle = async (req: NextRequest, res: NextResponse): Promise<NextResponse> => {
     if (!this.config.enabled) {
       debug.redirects('skipped (redirects middleware is disabled globally)');
@@ -260,6 +251,15 @@ export class RedirectsMiddleware extends MiddlewareBase {
       return res;
     }
   };
+
+  protected disabled(req: NextRequest, res: NextResponse): boolean | undefined {
+    // Check if API config is missing - if so, disable the middleware
+    if (!this.redirectsService) {
+      debug.redirects('skipped (redirects service not configured - API config required)');
+      return true;
+    }
+    return super.disabled(req, res);
+  }
 
   /**
    * Method returns RedirectInfo when matches

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -95,13 +95,16 @@ export class RedirectsMiddleware extends MiddlewareBase {
       });
   }
 
-  handle = async (req: NextRequest, res: NextResponse): Promise<NextResponse> => {
-    // Skip if service wasn't initialized (no API config)
+  protected disabled(req: NextRequest, res: NextResponse): boolean | undefined {
+    // Check if API config is missing - if so, disable the middleware
     if (!this.redirectsService) {
       debug.redirects('skipped (redirects service not configured - API config required)');
-      return res;
+      return true;
     }
+    return super.disabled(req, res);
+  }
 
+  handle = async (req: NextRequest, res: NextResponse): Promise<NextResponse> => {
     if (!this.config.enabled) {
       debug.redirects('skipped (redirects middleware is disabled globally)');
       return res;

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -42,7 +42,7 @@ export type RedirectsMiddlewareConfig = Omit<RedirectsServiceConfig, 'fetch' | '
  * @public
  */
 export class RedirectsMiddleware extends MiddlewareBase {
-  protected redirectsService: RedirectsService;
+  protected redirectsService: RedirectsService | null;
   private locales: string[];
 
   /**
@@ -50,6 +50,22 @@ export class RedirectsMiddleware extends MiddlewareBase {
    */
   constructor(protected config: RedirectsMiddlewareConfig) {
     super(config);
+    this.locales = config.locales;
+
+    // Validate API config is present - redirects requires either Edge or local API configuration
+    const hasEdgeConfig = !!(this.config.contextId || this.config.clientContextId);
+    const hasLocalConfig = !!(this.config.apiHost && this.config.apiKey);
+
+    if (!hasEdgeConfig && !hasLocalConfig) {
+      console.warn(
+        '[RedirectsMiddleware] Redirects middleware requires either Edge configuration (contextId/clientContextId) or local API configuration (apiHost/apiKey). ' +
+          'Redirects features will be disabled. This is expected when API configuration is not available.'
+      );
+      // Set to null to indicate service is disabled
+      this.redirectsService = null;
+      return;
+    }
+
     const graphQLOptions = {
       api: {
         edge: {
@@ -77,10 +93,15 @@ export class RedirectsMiddleware extends MiddlewareBase {
         clientFactory: this.getClientFactory(graphQLOptions),
         fetch: fetch,
       });
-    this.locales = config.locales;
   }
 
   handle = async (req: NextRequest, res: NextResponse): Promise<NextResponse> => {
+    // Skip if service wasn't initialized (no API config)
+    if (!this.redirectsService) {
+      debug.redirects('skipped (redirects service not configured - API config required)');
+      return res;
+    }
+
     if (!this.config.enabled) {
       debug.redirects('skipped (redirects middleware is disabled globally)');
       return res;
@@ -248,6 +269,10 @@ export class RedirectsMiddleware extends MiddlewareBase {
     req: NextRequest,
     siteName: string
   ): Promise<RedirectResult | undefined> {
+    if (!this.redirectsService) {
+      return undefined;
+    }
+
     const { pathname: incomingURL, search: incomingQS = '' } = this.normalizeUrl(
       req.nextUrl.clone()
     );


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
The `RedirectsMiddleware` constructor was throwing errors when no Edge or local API configuration was available, causing app startup failures. Updated RedirectsMiddleware to gracefully handle missing API configuration by setting the service to null and skipping processing when configuration is unavailable, similar to how `PersonalizeMiddleware` already handles this scenario. Both Pages Router and App Router templates were updated to always instantiate all middleware, with each middleware responsible for handling missing configuration internally.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
