### PR TITLE
[nextjs] Add "use client" directive to import-map.ts for React hooks compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ Our versioning strategy is as follows:
     - `useInfiniteSearch` hook for infinite scroll/search patterns with `loadMore` functionality, request cancellation, request status tracking.
 
 ### 🐛 Bug Fixes
-* [nextjs] Add "use client" directive to import-map.ts for React hooks compatibility ([#326](https://github.com/Sitecore/content-sdk/pull/326))
+
+* `[nextjs]` Add "use client" directive to import-map.ts for React hooks compatibility ([#326](https://github.com/Sitecore/content-sdk/pull/326))
 
 ## 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🎉 New Features & Improvements
+
 * Search integration ([#295](https://github.com/Sitecore/content-sdk/pull/295))
   * `[search]` New `@sitecore-content-sdk/search` package providing search functionality
     - `SearchService` class for performing search queries with support for pagination, sorting, request cancellation.
@@ -19,6 +21,9 @@ Our versioning strategy is as follows:
   * `[react]` Added React hooks for search functionality
     - `useSearch` hook for paginated search queries with automatic state management, request cancellation, request status tracking.
     - `useInfiniteSearch` hook for infinite scroll/search patterns with `loadMore` functionality, request cancellation, request status tracking.
+
+### 🐛 Bug Fixes
+* [nextjs] Add "use client" directive to import-map.ts for React hooks compatibility ([#326](https://github.com/Sitecore/content-sdk/pull/326))
 
 ## 1.3.1
 

--- a/packages/nextjs/src/editing/codegen/import-map.test.ts
+++ b/packages/nextjs/src/editing/codegen/import-map.test.ts
@@ -128,4 +128,19 @@ describe('Import Map Utils', () => {
       expect(result).to.deep.equal(generatedImportEntries);
     });
   });
+
+  describe('Module directives', () => {
+    it('should have "use client" directive for React hooks compatibility', () => {
+      // Read the source file to verify it starts with "use client"
+      const fs = require('fs');
+      const path = require('path');
+      const filePath = path.join(__dirname, 'import-map.ts');
+      const fileContent = fs.readFileSync(filePath, 'utf-8');
+
+      // Check if the file starts with 'use client' directive (allowing for whitespace)
+      const hasUseClientDirective = /^\s*['"]use client['"];/.test(fileContent);
+
+      expect(hasUseClientDirective).to.equal(true);
+    });
+  });
 });

--- a/packages/nextjs/src/editing/codegen/import-map.ts
+++ b/packages/nextjs/src/editing/codegen/import-map.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   Children,
   Fragment,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Make import map component a client component since it uses the React hooks like useActionState, useCallback, useContext, and useEffect which only work in Client Components.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
