### PR TITLE
[nextjs] Fix server transfer redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Our versioning strategy is as follows:
 
 * `[nextjs]` Add "use client" directive to import-map.ts for React hooks compatibility ([#326](https://github.com/Sitecore/content-sdk/pull/326))
 * `[nextjs]` `[template/nextjs]` `[template/nextjs-app-router]` Fix middleware initialization errors when API configuration is missing ([#325](https://github.com/Sitecore/content-sdk/pull/325))
+* `[nextjs]` Fixes Server Transfer (rewrite) redirects ([#329](https://github.com/Sitecore/content-sdk/pull/329))
 
 ## 1.3.1
 

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -626,9 +626,9 @@ describe('RedirectsMiddleware', () => {
           res
         );
 
-        // rewrite path -> expect our custom rewrite header
+        // rewrite path -> expect our custom rewrite header (pathname only, not full URL)
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: { 'x-sc-rewrite': 'http://localhost:3000/found' },
+          headers: { 'x-sc-rewrite': '/found' },
           redirected: undefined,
           status: 200,
           url,
@@ -679,7 +679,7 @@ describe('RedirectsMiddleware', () => {
         );
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: { 'x-sc-rewrite': 'http://localhost:3000/found?abc=def' },
+          headers: { 'x-sc-rewrite': '/found?abc=def' },
           redirected: undefined,
           status: 200,
           url,
@@ -3403,7 +3403,6 @@ describe('RedirectsMiddleware', () => {
           status: 200,
         });
 
-        // Set locale header to indicate App Router
         res.headers.set(LOCALE_HEADER_NAME, 'en');
 
         setupRewriteStub(200, res);
@@ -3456,7 +3455,6 @@ describe('RedirectsMiddleware', () => {
           status: 200,
         });
 
-        // Set locale header to indicate App Router
         res.headers.set(LOCALE_HEADER_NAME, 'en');
 
         setupRewriteStub(200, res);
@@ -3467,7 +3465,7 @@ describe('RedirectsMiddleware', () => {
               locales: ['en', 'da-DK'],
             },
             pattern: '/source-page',
-            target: '/da-DK/target-page', // Explicit locale in target
+            target: '/da-DK/target-page',
             redirectType: REDIRECT_TYPE_SERVER_TRANSFER,
             isQueryStringPreserved: false,
             isLanguagePreserved: false,
@@ -3481,7 +3479,6 @@ describe('RedirectsMiddleware', () => {
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.status).to.equal(res.status);
 
-        // Should use the explicit locale from target, not the fallback
         const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
         expect(rewriteHeader).to.include('/da-DK/');
       });
@@ -3511,10 +3508,8 @@ describe('RedirectsMiddleware', () => {
           status: 200,
         });
 
-        // Set locale header to indicate App Router
         res.headers.set(LOCALE_HEADER_NAME, 'en');
 
-        // Simulate MultisiteMiddleware having already added site prefix
         res.headers.set(REWRITE_HEADER_NAME, '/my-site/en/source-page');
 
         setupRewriteStub(200, res);
@@ -3539,7 +3534,6 @@ describe('RedirectsMiddleware', () => {
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.status).to.equal(res.status);
 
-        // The rewrite should include the site prefix from the incoming x-sc-rewrite header
         const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
         expect(rewriteHeader).to.include('/my-site/');
         expect(rewriteHeader).to.include('/en/');
@@ -3569,10 +3563,8 @@ describe('RedirectsMiddleware', () => {
           status: 200,
         });
 
-        // Set locale header to indicate App Router
         res.headers.set(LOCALE_HEADER_NAME, 'en');
 
-        // Simulate LocaleMiddleware having run (no site prefix, just locale)
         res.headers.set(REWRITE_HEADER_NAME, '/en/source-page');
 
         setupRewriteStub(200, res);
@@ -3597,7 +3589,6 @@ describe('RedirectsMiddleware', () => {
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.status).to.equal(res.status);
 
-        // Should work without site prefix (locale at position 0 means no site prefix)
         const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
         expect(rewriteHeader).to.include('/en/');
         expect(rewriteHeader).to.include('/target-page');
@@ -3627,10 +3618,8 @@ describe('RedirectsMiddleware', () => {
           status: 200,
         });
 
-        // Set locale header to indicate App Router
         res.headers.set(LOCALE_HEADER_NAME, 'en');
 
-        // Simulate MultisiteMiddleware having already added site prefix
         res.headers.set(REWRITE_HEADER_NAME, '/my-site/en/source-page');
 
         setupRewriteStub(200, res);
@@ -3655,7 +3644,6 @@ describe('RedirectsMiddleware', () => {
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.status).to.equal(res.status);
 
-        // Should include site prefix, locale, target, and query string
         const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
         expect(rewriteHeader).to.include('/my-site/');
         expect(rewriteHeader).to.include('/en/');

--- a/packages/nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.test.ts
@@ -1,4 +1,4 @@
-﻿/* eslint-disable react-hooks/rules-of-hooks */
+/* eslint-disable react-hooks/rules-of-hooks */
 /* eslint-disable no-unused-expressions */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable dot-notation */
@@ -3375,6 +3375,292 @@ describe('RedirectsMiddleware', () => {
       // Verify middleware was created and redirectsService is initialized
       expect(middleware).to.not.be.undefined;
       expect(middleware['redirectsService']).to.not.be.null;
+    });
+  });
+
+  describe('Server Transfer', () => {
+    describe('App Router locale fallback', () => {
+      it('[app router] should include locale in pathname even when isLanguagePreserved is false', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/en/target-page',
+          pathname: '/en/target-page',
+          origin: 'http://localhost:3000',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/source-page',
+              href: 'http://localhost:3000/source-page',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 200,
+        });
+
+        // Set locale header to indicate App Router
+        res.headers.set(LOCALE_HEADER_NAME, 'en');
+
+        setupRewriteStub(200, res);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            redirectsMiddlewareConfig: {
+              locales: ['en', 'da-DK'],
+            },
+            pattern: '/source-page',
+            target: '/target-page',
+            redirectType: REDIRECT_TYPE_SERVER_TRANSFER,
+            isQueryStringPreserved: false,
+            isLanguagePreserved: false, // Not preserving language explicitly
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(res.status);
+
+        // App Router should have locale in the rewrite path even when isLanguagePreserved is false
+        const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
+        expect(rewriteHeader).to.include('/en/');
+      });
+
+      it('[app router] should use explicit locale from target when provided', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/da-DK/target-page',
+          pathname: '/da-DK/target-page',
+          origin: 'http://localhost:3000',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/source-page',
+              href: 'http://localhost:3000/source-page',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 200,
+        });
+
+        // Set locale header to indicate App Router
+        res.headers.set(LOCALE_HEADER_NAME, 'en');
+
+        setupRewriteStub(200, res);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            redirectsMiddlewareConfig: {
+              locales: ['en', 'da-DK'],
+            },
+            pattern: '/source-page',
+            target: '/da-DK/target-page', // Explicit locale in target
+            redirectType: REDIRECT_TYPE_SERVER_TRANSFER,
+            isQueryStringPreserved: false,
+            isLanguagePreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(res.status);
+
+        // Should use the explicit locale from target, not the fallback
+        const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
+        expect(rewriteHeader).to.include('/da-DK/');
+      });
+    });
+
+    describe('Site prefix preservation', () => {
+      it('[app router] should preserve site prefix from MultisiteMiddleware in Server Transfer rewrite', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/my-site/en/target-page',
+          pathname: '/my-site/en/target-page',
+          origin: 'http://localhost:3000',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/source-page',
+              href: 'http://localhost:3000/source-page',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 200,
+        });
+
+        // Set locale header to indicate App Router
+        res.headers.set(LOCALE_HEADER_NAME, 'en');
+
+        // Simulate MultisiteMiddleware having already added site prefix
+        res.headers.set(REWRITE_HEADER_NAME, '/my-site/en/source-page');
+
+        setupRewriteStub(200, res);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            redirectsMiddlewareConfig: {
+              locales: ['en', 'da-DK'],
+            },
+            pattern: '/source-page',
+            target: '/target-page',
+            redirectType: REDIRECT_TYPE_SERVER_TRANSFER,
+            isQueryStringPreserved: false,
+            isLanguagePreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(res.status);
+
+        // The rewrite should include the site prefix from the incoming x-sc-rewrite header
+        const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
+        expect(rewriteHeader).to.include('/my-site/');
+        expect(rewriteHeader).to.include('/en/');
+        expect(rewriteHeader).to.include('/target-page');
+      });
+
+      it('[app router] should work without site prefix when MultisiteMiddleware has not run', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/en/target-page',
+          pathname: '/en/target-page',
+          origin: 'http://localhost:3000',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/source-page',
+              href: 'http://localhost:3000/source-page',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 200,
+        });
+
+        // Set locale header to indicate App Router
+        res.headers.set(LOCALE_HEADER_NAME, 'en');
+
+        // Simulate LocaleMiddleware having run (no site prefix, just locale)
+        res.headers.set(REWRITE_HEADER_NAME, '/en/source-page');
+
+        setupRewriteStub(200, res);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            redirectsMiddlewareConfig: {
+              locales: ['en', 'da-DK'],
+            },
+            pattern: '/source-page',
+            target: '/target-page',
+            redirectType: REDIRECT_TYPE_SERVER_TRANSFER,
+            isQueryStringPreserved: false,
+            isLanguagePreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(res.status);
+
+        // Should work without site prefix (locale at position 0 means no site prefix)
+        const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
+        expect(rewriteHeader).to.include('/en/');
+        expect(rewriteHeader).to.include('/target-page');
+      });
+
+      it('[app router] should preserve site prefix with query string', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/my-site/en/target-page?foo=bar',
+          pathname: '/my-site/en/target-page',
+          origin: 'http://localhost:3000',
+          search: '?foo=bar',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/source-page',
+              href: 'http://localhost:3000/source-page?foo=bar',
+              origin: 'http://localhost:3000',
+              search: '?foo=bar',
+              clone: cloneUrl,
+            },
+          },
+          status: 200,
+        });
+
+        // Set locale header to indicate App Router
+        res.headers.set(LOCALE_HEADER_NAME, 'en');
+
+        // Simulate MultisiteMiddleware having already added site prefix
+        res.headers.set(REWRITE_HEADER_NAME, '/my-site/en/source-page');
+
+        setupRewriteStub(200, res);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            redirectsMiddlewareConfig: {
+              locales: ['en', 'da-DK'],
+            },
+            pattern: '/source-page',
+            target: '/target-page',
+            redirectType: REDIRECT_TYPE_SERVER_TRANSFER,
+            isQueryStringPreserved: true,
+            isLanguagePreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(res.status);
+
+        // Should include site prefix, locale, target, and query string
+        const rewriteHeader = finalRes.headers.get(REWRITE_HEADER_NAME);
+        expect(rewriteHeader).to.include('/my-site/');
+        expect(rewriteHeader).to.include('/en/');
+        expect(rewriteHeader).to.include('/target-page');
+      });
     });
   });
 });

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -208,11 +208,8 @@ export class RedirectsMiddleware extends MiddlewareBase {
           // for pages router i18n implementation, apply default locale as backup
           url.locale = targetLocale || req.nextUrl.defaultLocale || 'en';
         } else {
-          // In App Router, locale must be in the pathname for proper routing
-          // Use the target locale if specified, otherwise preserve the current language
-          // This ensures Server Transfer (rewrite) works correctly since the route structure requires locale
-          const localeToUse = targetLocale || language;
-          url.pathname = `/${localeToUse}${url.pathname}`;
+          // In App Router, we need to set the locale in the pathname, if present
+          if (targetLocale) url.pathname = `/${targetLocale}${url.pathname}`;
         }
 
         /** return Response redirect with http code of redirect type */
@@ -434,6 +431,19 @@ export class RedirectsMiddleware extends MiddlewareBase {
         // rewrite expects a path string; for NextURL extract pathname + search
         let rewritePath =
           typeof target === 'string' ? target : `${target.pathname}${target.search || ''}`;
+
+        // For App Router Server Transfer, ensure locale is in the path
+        // This is needed because the route structure requires [locale] segment
+        if (this.isAppRouter(res) && !isExternal) {
+          const pathParts = rewritePath.split('/').filter(Boolean);
+          const firstSegment = pathParts[0];
+          // Check if path doesn't start with a locale
+          if (!this.locales.includes(firstSegment)) {
+            // Add current language as locale prefix
+            const language = this.getLanguage(req, res);
+            rewritePath = `/${language}${rewritePath}`;
+          }
+        }
 
         // Check if it has a site prefix
         // If so, preserve it for the redirect target to maintain proper routing

--- a/packages/nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/nextjs/src/middleware/redirects-middleware.ts
@@ -1,4 +1,4 @@
-﻿import { debug } from '@sitecore-content-sdk/core';
+import { debug } from '@sitecore-content-sdk/core';
 import {
   RedirectsService,
   RedirectsServiceConfig,
@@ -208,8 +208,11 @@ export class RedirectsMiddleware extends MiddlewareBase {
           // for pages router i18n implementation, apply default locale as backup
           url.locale = targetLocale || req.nextUrl.defaultLocale || 'en';
         } else {
-          // In App Router, we need to set the locale in the pathname, if present
-          if (targetLocale) url.pathname = `/${targetLocale}${url.pathname}`;
+          // In App Router, locale must be in the pathname for proper routing
+          // Use the target locale if specified, otherwise preserve the current language
+          // This ensures Server Transfer (rewrite) works correctly since the route structure requires locale
+          const localeToUse = targetLocale || language;
+          url.pathname = `/${localeToUse}${url.pathname}`;
         }
 
         /** return Response redirect with http code of redirect type */
@@ -427,14 +430,32 @@ export class RedirectsMiddleware extends MiddlewareBase {
         return this.createRedirectResponse(target, res, 301, 'Moved Permanently');
       case REDIRECT_TYPE_302:
         return this.createRedirectResponse(target, res, 302, 'Found');
-      case REDIRECT_TYPE_SERVER_TRANSFER:
-        // rewrite expects a string; unwrap NextURL if needed
-        return this.rewrite(
-          typeof target === 'string' ? target : target.href,
-          req,
-          res,
-          isExternal
-        );
+      case REDIRECT_TYPE_SERVER_TRANSFER: {
+        // rewrite expects a path string; for NextURL extract pathname + search
+        let rewritePath =
+          typeof target === 'string' ? target : `${target.pathname}${target.search || ''}`;
+
+        // Check if it has a site prefix
+        // If so, preserve it for the redirect target to maintain proper routing
+        const incomingRewrite = res?.headers.get(REWRITE_HEADER_NAME);
+        if (incomingRewrite && !isExternal) {
+          // Extract locale from target path
+          const targetPathParts = rewritePath.split('/').filter(Boolean);
+          const targetLocale = targetPathParts[0];
+
+          // Find locale position in incoming rewrite to extract site prefix
+          if (targetLocale) {
+            const localePattern = `/${targetLocale}/`;
+            const localeIndex = incomingRewrite.indexOf(localePattern);
+            if (localeIndex > 0) {
+              const sitePrefix = incomingRewrite.substring(0, localeIndex);
+              rewritePath = `${sitePrefix}${rewritePath}`;
+            }
+          }
+        }
+
+        return this.rewrite(rewritePath, req, res, isExternal);
+      }
       default:
         return res;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- Extract `pathname + search` instead of full `href` when creating Server Transfer rewrites
- Add locale fallback for App Router (matches Pages Router behavior)
- Preserve site prefix from MultisiteMiddleware in Server Transfer rewrites

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
