### PR TITLE
[nextjs] Sitecore Content SDK does not support X-Forwarded-Host, causing incorrect hostname resolution behind proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Our versioning strategy is as follows:
 
 * `[nextjs]` Add "use client" directive to import-map.ts for React hooks compatibility ([#326](https://github.com/Sitecore/content-sdk/pull/326))
 * `[nextjs]` `[template/nextjs]` `[template/nextjs-app-router]` Fix middleware initialization errors when API configuration is missing ([#325](https://github.com/Sitecore/content-sdk/pull/325))
+* `[nextjs]` Sitecore Content SDK does not support X-Forwarded-Host, causing incorrect hostname resolution behind proxies ([#330](https://github.com/Sitecore/content-sdk/pull/330))
 
 ## 1.3.1
 

--- a/packages/nextjs/global.d.ts
+++ b/packages/nextjs/global.d.ts
@@ -19,3 +19,9 @@ declare namespace NodeJS {
     HTMLElement: HTMLElement;
   }
 }
+
+declare module 'http' {
+  interface IncomingHttpHeaders {
+    'x-forwarded-host'?: string | undefined;
+  }
+}

--- a/packages/nextjs/src/editing/utils.test.ts
+++ b/packages/nextjs/src/editing/utils.test.ts
@@ -862,6 +862,33 @@ describe('editing/utils', () => {
 
       expect(result).to.equal('http://localhost:3000');
     });
+
+    it('should prioritize x-forwarded-host over host header (NextApiRequest)', () => {
+      const req = {
+        headers: {
+          'x-forwarded-host': 'forwarded.com',
+          host: 'localhost:3000',
+        },
+      } as NextApiRequest;
+
+      const result = resolveServerUrl(req);
+
+      expect(result).to.equal('http://forwarded.com');
+    });
+
+    it('should use x-forwarded-host header when present (NextRequest)', () => {
+      const headers = new Headers();
+      headers.set('x-forwarded-host', 'proxy.example.com');
+      headers.set('host', 'internal-host.local');
+
+      const req = {
+        headers,
+      } as NextRequest;
+
+      const result = resolveServerUrl(req);
+
+      expect(result).to.equal('http://proxy.example.com');
+    });
   });
 
   describe('getCSPHeader', () => {

--- a/packages/nextjs/src/editing/utils.ts
+++ b/packages/nextjs/src/editing/utils.ts
@@ -294,8 +294,9 @@ export const resolveServerUrl = (req: NextApiRequest | NextRequest) => {
   // to preserve auth headers, use https if we're in our 3 main hosting options
   const useHttps = (process.env.VERCEL || process.env.NETLIFY) !== undefined;
   const host = (req.headers as Headers).get
-    ? (req.headers as Headers).get('host')
-    : (req as NextApiRequest).headers.host;
+    ? (req.headers as Headers).get('x-forwarded-host') || (req.headers as Headers).get('host')
+    : (req as NextApiRequest).headers['x-forwarded-host'] || (req as NextApiRequest).headers.host;
+
   // use https for requests with auth but also support unsecured http rendering hosts
   return `${useHttps ? 'https' : 'http'}://${host}`;
 };

--- a/packages/nextjs/src/middleware/middleware.test.ts
+++ b/packages/nextjs/src/middleware/middleware.test.ts
@@ -320,6 +320,18 @@ describe('MiddlewareBase', () => {
 
       expect(middleware['getHostHeader'](req)).to.equal('bar.net');
     });
+
+    it('should return x-forwarded-host header when present', () => {
+      const middleware = new SampleMiddleware({ sites: [] });
+      const req = createReq({
+        headerValues: {
+          'x-forwarded-host': 'proxy.forwarded.com',
+          host: 'localhost:3000',
+        },
+      });
+
+      expect(middleware['getHostHeader'](req)).to.equal('proxy.forwarded.com');
+    });
   });
 
   describe('getLanguage', () => {

--- a/packages/nextjs/src/middleware/middleware.ts
+++ b/packages/nextjs/src/middleware/middleware.ts
@@ -164,7 +164,7 @@ export abstract class MiddlewareBase extends Middleware {
    * @param {NextRequest} req request
    */
   protected getHostHeader(req: NextRequest) {
-    return req.headers.get('host')?.split(':')[0];
+    return req.headers.get('x-forwarded-host') || req.headers.get('host')?.split(':')[0];
   }
 
   /**

--- a/packages/nextjs/src/middleware/robots-middleware.test.ts
+++ b/packages/nextjs/src/middleware/robots-middleware.test.ts
@@ -111,4 +111,15 @@ describe('RobotsMiddleware', () => {
     expect(res.status).to.have.been.calledWith(200);
     expect(res.send).to.have.been.calledWith('User-agent: *\nDisallow: /');
   });
+
+  it('should use x-forwarded-host header when present', async () => {
+    req.headers = {
+      'x-forwarded-host': 'proxy.forwarded.com',
+      host: 'localhost:3000',
+    };
+
+    await middleware.getHandler()(req as NextApiRequest, res as NextApiResponse);
+
+    expect(siteResolverStub.getByHost).to.have.been.calledWith('proxy.forwarded.com');
+  });
 });

--- a/packages/nextjs/src/middleware/robots-middleware.ts
+++ b/packages/nextjs/src/middleware/robots-middleware.ts
@@ -22,7 +22,8 @@ export class RobotsMiddleware {
   private async handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
     res.setHeader('Content-Type', 'text/plain');
 
-    const hostName = req.headers.host?.split(':')[0] || 'localhost';
+    const hostName =
+      req.headers['x-forwarded-host'] || req.headers.host?.split(':')[0] || 'localhost';
     const site = this.siteResolver.getByHost(hostName);
 
     try {

--- a/packages/nextjs/src/middleware/sitemap-middleware.test.ts
+++ b/packages/nextjs/src/middleware/sitemap-middleware.test.ts
@@ -141,6 +141,33 @@ describe('SitemapMiddleware', () => {
       });
     });
 
+    it('should use x-forwarded-host header when present', async () => {
+      req.headers = {
+        'x-forwarded-host': 'example.com',
+        host: 'localhost:3000',
+      };
+
+      await middleware.getHandler()(req as NextApiRequest, res as NextApiResponse);
+
+      expect(siteResolverStub.getByHost).to.have.been.calledWith('example.com');
+    });
+
+    it('should use empty string when both x-forwarded-host and host headers are missing', async () => {
+      req.headers = {};
+      const xmlContent = '<sitemapindex>...</sitemapindex>';
+
+      siteResolverStub.getByHost.withArgs('').returns(sites[1]);
+
+      sitecoreClientStub.getSiteMap.resolves(xmlContent);
+
+      await middleware.getHandler()(req as NextApiRequest, res as NextApiResponse);
+
+      expect(sitecoreClientStub.getSiteMap.firstCall.args[0]).to.deep.include({
+        reqHost: '',
+        reqProtocol: 'https',
+      });
+    });
+
     it('should redirect to 404 when REDIRECT_404 error is thrown', async () => {
       const error = new Error('REDIRECT_404');
 

--- a/packages/nextjs/src/middleware/sitemap-middleware.ts
+++ b/packages/nextjs/src/middleware/sitemap-middleware.ts
@@ -22,7 +22,7 @@ export class SitemapMiddleware {
 
   private async handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
     const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
-    const reqHost = req.headers.host || '';
+    const reqHost = req.headers['x-forwarded-host'] || req.headers.host || '';
     const reqProtocol = req.headers['x-forwarded-proto'] || 'https';
     const site = this.siteResolver.getByHost(reqHost);
 

--- a/packages/nextjs/src/route-handler/robots-route-handler.test.ts
+++ b/packages/nextjs/src/route-handler/robots-route-handler.test.ts
@@ -114,6 +114,21 @@ describe('createRobotsRouteHandler', () => {
     expect(res.body).to.equal('User-agent: *\nDisallow: /');
   });
 
+  it('should use x-forwarded-host header when present', async () => {
+    const req = {
+      headers: new Headers({
+        'x-forwarded-host': 'example.com',
+        host: 'localhost:3000',
+      }),
+    };
+
+    sitecoreClientStub.getRobots.resolves('User-agent: *\nDisallow: /');
+
+    await handler.GET(req as NextRequest);
+
+    expect(sitecoreClientStub.getRobots).to.have.been.calledWith('test-site');
+  });
+
   it('should cache the response for default revalidate time', async () => {
     sitecoreClientStub.getRobots.resolves('User-agent: *\nDisallow: /');
 

--- a/packages/nextjs/src/route-handler/robots-route-handler.ts
+++ b/packages/nextjs/src/route-handler/robots-route-handler.ts
@@ -47,7 +47,10 @@ export const createRobotsRouteHandler = (options: RouteHandlerOptions) => {
     try {
       const startTimestamp = Date.now();
 
-      const hostName = req.headers.get('host')?.split(':')[0] || 'localhost';
+      const hostName =
+        req.headers.get('x-forwarded-host') ||
+        req.headers.get('host')?.split(':')[0] ||
+        'localhost';
       const site = siteResolver.getByHost(hostName);
 
       debug.robots('robots route handler start: %o', {

--- a/packages/nextjs/src/route-handler/sitemap-route-handler.test.ts
+++ b/packages/nextjs/src/route-handler/sitemap-route-handler.test.ts
@@ -127,6 +127,48 @@ describe('createSitemapRouteHandler', () => {
       expect(res.body).to.equal(xmlContent);
     });
 
+    it('should use x-forwarded-host header when present', async () => {
+      const reqWithForwardedHost = {
+        ...req,
+        headers: new Headers({
+          'x-forwarded-host': 'example.com',
+          host: 'localhost:3000',
+        }),
+      };
+      const siteName = sites[0].name;
+
+      await handler.GET(reqWithForwardedHost);
+
+      expect(sitecoreClientStub.getSiteMap).to.have.been.calledWithMatch({
+        reqHost: 'example.com',
+        reqProtocol: 'https',
+        siteName: siteName,
+      });
+    });
+
+    it('should use empty string when both x-forwarded-host and host headers are missing', async () => {
+      const reqWithoutHeaders = {
+        ...req,
+        headers: new Headers({
+          'x-forwarded-proto': 'https',
+        }),
+        nextUrl: {
+          pathname: '/sitemap.xml',
+        } as any,
+      };
+      const xmlContent = '<sitemapindex>...</sitemapindex>';
+
+      sitecoreClientStub.getSiteMap.resolves(xmlContent);
+
+      const res = await handler.GET(reqWithoutHeaders);
+
+      expect(sitecoreClientStub.getSiteMap.firstCall.args[0]).to.deep.include({
+        reqHost: '',
+        reqProtocol: 'https',
+      });
+      expect(res.body).to.equal(xmlContent);
+    });
+
     it('should cache the response for default revalidate time', async () => {
       const xmlContent = '<sitemapindex>...</sitemapindex>';
 

--- a/packages/nextjs/src/route-handler/sitemap-route-handler.ts
+++ b/packages/nextjs/src/route-handler/sitemap-route-handler.ts
@@ -1,8 +1,8 @@
-import { SitecoreClient, SitemapXmlOptions } from "@sitecore-content-sdk/core/client";
-import { SiteInfo, SiteResolver } from "@sitecore-content-sdk/core/site";
-import { debug } from "@sitecore-content-sdk/core";
-import { NextRequest } from "next/server";
-import { unstable_cache } from "next/cache";
+import { SitecoreClient, SitemapXmlOptions } from '@sitecore-content-sdk/core/client';
+import { SiteInfo, SiteResolver } from '@sitecore-content-sdk/core/site';
+import { debug } from '@sitecore-content-sdk/core';
+import { NextRequest } from 'next/server';
+import { unstable_cache } from 'next/cache';
 
 type RouteHandlerOptions = {
   /**
@@ -34,7 +34,7 @@ export function createSitemapRouteHandler(options: RouteHandlerOptions) {
 
   const getOptions = (req: NextRequest): SitemapXmlOptions => {
     const id = req.nextUrl.pathname.match(/^\/sitemap-(\d+)\.xml$/i)?.[1] || '';
-    const reqHost = req.headers.get('host') || '';
+    const reqHost = req.headers.get('x-forwarded-host') || req.headers.get('host') || '';
     const reqProtocol = req.headers.get('x-forwarded-proto') || 'https';
     const site = siteResolver.getByHost(reqHost);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)
   Created a Nginx proxy and used the app through it

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
