### PR TITLE
[nextjs] Preserve `basePath` when doing redirects in redirects-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Our versioning strategy is as follows:
 * `[nextjs]` Sitecore Content SDK does not support X-Forwarded-Host, causing incorrect hostname resolution behind proxies ([#330](https://github.com/Sitecore/content-sdk/pull/330))
 * `[core]` `[search]` `[analytics]` Pass Sitecore Context ID only in headers ([#336](https://github.com/Sitecore/content-sdk/pull/336))
 * `[nextjs]` `[react]` Fix fields becoming uneditable in Pages when running Editing Host in dev mode ([#339](https://github.com/Sitecore/content-sdk/pull/339))
+* `[nextjs]` Preserve `basePath` when doing redirects in redirects-middleware ([#344](https://github.com/Sitecore/content-sdk/pull/344))
 
 ## 1.3.1
 

--- a/packages/nextjs/src/proxy/redirects-proxy.test.ts
+++ b/packages/nextjs/src/proxy/redirects-proxy.test.ts
@@ -662,6 +662,41 @@ describe('RedirectsProxy', () => {
       expect(finalRes).to.deep.equal(redirectRes);
     });
 
+    it('should preserve basePath if configured ', async () => {
+      const req = createRequest({
+        nextUrl: {
+          pathname: '/old-page',
+          search: '?param1=value1&param2=value2',
+          basePath: '/test',
+        },
+      });
+      const res = createResponse();
+
+      const redirectRes = createResponse({
+        redirected: true,
+        status: 302,
+        url: 'http://localhost:3000/test/new-page',
+      });
+      nextRedirectStub.returns(redirectRes);
+
+      const { proxy } = createProxy({
+        pattern: '/old-page',
+        target: '/new-page',
+        redirectType: REDIRECT_TYPE_301,
+        isQueryStringPreserved: true,
+      });
+
+      const finalRes = await proxy.handle(req, res);
+
+      expect(nextRedirectStub.calledOnce).to.be.true;
+      const redirectUrl = nextRedirectStub.getCall(0).args[0];
+      expect(redirectUrl).to.include('/new-page');
+      expect(redirectUrl).to.include('param1=value1');
+      expect(redirectUrl).to.include('param2=value2');
+
+      expect(finalRes).to.deep.equal(redirectRes);
+    });
+
     it('should handle absolute URL targets', async () => {
       const req = createRequest({
         nextUrl: {

--- a/packages/nextjs/src/proxy/redirects-proxy.ts
+++ b/packages/nextjs/src/proxy/redirects-proxy.ts
@@ -205,9 +205,12 @@ export class RedirectsProxy extends ProxyBase {
           url.origin
         );
 
+        const basePath = url.basePath; // setting NextUrl.href overrides basePath, so we need to store it
         url.href = prepareNewURL.href;
         url.pathname = prepareNewURL.pathname;
         url.search = prepareNewURL.search;
+        url.basePath = basePath;
+
         if (!isAppRouterRequest) {
           // for pages router i18n implementation, apply default locale as backup
           url.locale = targetLocale || req.nextUrl.defaultLocale || 'en';
@@ -403,9 +406,11 @@ export class RedirectsProxy extends ProxyBase {
 
     const newUrl = new URL(`${url.pathname.toLowerCase()}?${newQueryString}`, url.origin);
 
+    const basePath = url.basePath; // setting NextUrl.href overrides basePath, so we need to store it
     url.search = newUrl.search;
     url.pathname = newUrl.pathname.toLocaleLowerCase();
     url.href = newUrl.href;
+    url.basePath = basePath;
 
     return url;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When `basePath` is configured in NextJs config make sure that it is preserved when doing redirects in redirects-proxy. 
Example:
 - `basePath` is configured in next.config: `basePath: '/base-path',`
 - we have the following redirect map configured in Sitecore AI: `/old-page` -> `/new-page`
 - Navigating 'https://my-site.com/base-path/old-page' should redirect to 'https://my-site.com/base-path/new-page'

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - all redirects with configured NextJs `basePath` should work properly; test with both client side and server side navigation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
