### PR TITLE
[nextjs] [Pages Router] Adjust static path generation when multisite is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Our versioning strategy is as follows:
     - `useInfiniteSearch` hook for infinite scroll/search patterns with `loadMore` functionality, request cancellation, request status tracking.
   * `[analytics]` `[core]` `[create-content-sdk-app]` `[nextjs]` `[react]` Reorganize Analytics packages ([#340](https://github.com/Sitecore/content-sdk/pull/340))([#341](https://github.com/Sitecore/content-sdk/pull/341))
 
+* `[nextjs]` `[Pages Router]` Adjust static path generation when multisite is disabled ([#345](https://github.com/Sitecore/content-sdk/pull/345))
+
 ### 🛠 Breaking Changes
 
 * `[nextjs]` `[create-content-sdk-app]` Upgrade to Next.js 16 ([#334](https://github.com/Sitecore/content-sdk/pull/334))

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -58,7 +58,9 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
     try {
       paths = await client.getPagePaths(
         sites.map((site: SiteInfo) => site.name),
-        context?.locales || []
+        context?.locales || [],
+        undefined,
+        scConfig.multisite.enabled
       );
     } catch (error) {
       console.log('Error occurred while fetching static paths');

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -58,9 +58,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
     try {
       paths = await client.getPagePaths(
         sites.map((site: SiteInfo) => site.name),
-        context?.locales || [],
-        undefined,
-        scConfig.multisite.enabled
+        context?.locales || []
       );
     } catch (error) {
       console.log('Error occurred while fetching static paths');

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -824,7 +824,7 @@ export { RouteData }
 
 // @public
 export class SitecoreClient extends SitecoreClient_2 {
-    constructor(initOptions: SitecoreClientInit);
+    constructor(initOptions: SitecoreNextjsClientInit);
     // (undocumented)
     protected componentPropsService: ComponentPropsService;
     // Warning: (ae-forgotten-export) The symbol "StaticParams" needs to be exported by the entry point api-surface.d.ts
@@ -835,11 +835,13 @@ export class SitecoreClient extends SitecoreClient_2 {
     getDesignLibraryData(designLibData: PreviewData, fetchOptions?: FetchOptions): Promise<Page>;
     // (undocumented)
     getPage(path: string | string[], pageOptions: PageOptions, options?: FetchOptions): Promise<Page | null>;
-    getPagePaths(sites: string[], languages?: string[], fetchOptions?: FetchOptions, multisiteEnabled?: boolean): Promise<StaticPath[]>;
+    getPagePaths(sites: string[], languages?: string[], fetchOptions?: FetchOptions): Promise<StaticPath[]>;
     getPreview(previewData: PreviewData, fetchOptions?: FetchOptions): Promise<Page | null>;
     getSiteNameFromPath(path: string | string[]): string;
+    // Warning: (ae-forgotten-export) The symbol "SitecoreNextjsClientInit" needs to be exported by the entry point api-surface.d.ts
+    //
     // (undocumented)
-    protected initOptions: SitecoreClientInit;
+    protected initOptions: SitecoreNextjsClientInit;
     parsePath(path: string | string[]): string;
 }
 

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -835,6 +835,7 @@ export class SitecoreClient extends SitecoreClient_2 {
     getDesignLibraryData(designLibData: PreviewData, fetchOptions?: FetchOptions): Promise<Page>;
     // (undocumented)
     getPage(path: string | string[], pageOptions: PageOptions, options?: FetchOptions): Promise<Page | null>;
+    getPagePaths(sites: string[], languages?: string[], fetchOptions?: FetchOptions, multisiteEnabled?: boolean): Promise<StaticPath[]>;
     getPreview(previewData: PreviewData, fetchOptions?: FetchOptions): Promise<Page | null>;
     getSiteNameFromPath(path: string | string[]): string;
     // (undocumented)

--- a/packages/nextjs/src/client/sitecore-nextjs-client.test.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.test.ts
@@ -322,4 +322,59 @@ describe('SitecoreClient', () => {
       ]);
     });
   });
+
+  describe('getPagePaths', () => {
+    it('should return static paths with site prefixes - multisite enabled by default', async () => {
+      const paths = [
+        { params: { path: ['_site_site-one', 'home'] }, locale: 'en' },
+        { params: { path: ['_site_site-one', 'about'] }, locale: 'en' },
+        { params: { path: ['_site_site-two', 'home'] }, locale: 'de-DE' },
+      ];
+
+      sitePathServiceStub.fetchSiteRoutes.resolves(paths);
+
+      const result = await sitecoreClient.getPagePaths(['site-one', 'site-two'], ['en', 'de-DE']);
+
+      expect(result).to.deep.equal(paths);
+    });
+
+    it('should return static paths with site prefixes when multisite enabled', async () => {
+      const paths = [
+        { params: { path: ['_site_site-one', 'home'] }, locale: 'en' },
+        { params: { path: ['_site_site-one', 'about'] }, locale: 'en' },
+        { params: { path: ['_site_site-two', 'home'] }, locale: 'de-DE' },
+      ];
+
+      sitePathServiceStub.fetchSiteRoutes.resolves(paths);
+
+      const result = await sitecoreClient.getPagePaths(
+        ['site-one', 'site-two'],
+        ['en', 'de-DE'],
+        undefined,
+        true
+      );
+
+      expect(result).to.deep.equal(paths);
+    });
+
+    it('should return static paths without site prefixes when multisite is disabled', async () => {
+      const paths = [
+        { params: { path: ['_site_site-one', 'home'] }, locale: 'en' },
+        { params: { path: ['_site_site-one', 'about'] }, locale: 'en' },
+        { params: { path: ['_site_site-two', 'home'] }, locale: 'de-DE' },
+      ];
+
+      const expectedPaths = [
+        { params: { path: ['home'] }, locale: 'en' },
+        { params: { path: ['about'] }, locale: 'en' },
+        { params: { path: ['home'] }, locale: 'de-DE' },
+      ];
+
+      sitePathServiceStub.fetchSiteRoutes.resolves(structuredClone(paths));
+
+      const result = await sitecoreClient.getPagePaths(['site-one'], ['en'], undefined, false);
+
+      expect(result).to.deep.equal(expectedPaths);
+    });
+  });
 });

--- a/packages/nextjs/src/client/sitecore-nextjs-client.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.ts
@@ -25,6 +25,13 @@ import {
 } from '@sitecore-content-sdk/core/personalize';
 import { ComponentMap } from '@sitecore-content-sdk/react';
 import { StaticParams } from './models';
+import { SitecoreConfig } from '../config';
+
+/**
+ * Init options for Sitecore Client that allows you to override services too
+ * @public
+ */
+export type SitecoreNextjsClientInit = SitecoreClientInit & Pick<SitecoreConfig, 'multisite'>;
 
 /**
  * The SitecoreNextjsClient class extends the SitecoreClient class to provide additional functionality for Next.js.
@@ -32,7 +39,7 @@ import { StaticParams } from './models';
  */
 export class SitecoreNextjsClient extends SitecoreClient {
   protected componentPropsService: ComponentPropsService;
-  constructor(protected initOptions: SitecoreClientInit) {
+  constructor(protected initOptions: SitecoreNextjsClientInit) {
     super(initOptions);
     this.componentPropsService = this.getComponentPropsService();
   }
@@ -149,18 +156,16 @@ export class SitecoreNextjsClient extends SitecoreClient {
    * @param {string[]} sites - An array of site names to fetch routes for.
    * @param {string[]} [languages] - An optional array of language codes to generate paths for.
    * @param {FetchOptions} [fetchOptions] - Additional fetch options.
-   * @param {boolean} [multisiteEnabled] - Indicates if multisite support is enabled.
    * @returns {Promise<StaticPath[]>} A promise that resolves to an array of static paths.
    */
   async getPagePaths(
     sites: string[],
     languages?: string[],
-    fetchOptions?: FetchOptions,
-    multisiteEnabled: boolean = true
+    fetchOptions?: FetchOptions
   ): Promise<StaticPath[]> {
     const staticPaths = await super.getPagePaths(sites, languages, fetchOptions);
 
-    if (!multisiteEnabled) {
+    if (!this.initOptions.multisite?.enabled) {
       // remove _site_ segments when multisite is disabled
       staticPaths.map((path) => {
         path.params.path = normalizeSiteRewrite(path.params.path.join('/')).split('/');

--- a/packages/nextjs/src/client/sitecore-nextjs-client.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.ts
@@ -1,3 +1,4 @@
+import { StaticPath } from '@sitecore-content-sdk/core';
 import {
   FetchOptions,
   Page,
@@ -125,7 +126,7 @@ export class SitecoreNextjsClient extends SitecoreClient {
     languages?: string[],
     fetchOptions?: FetchOptions
   ): Promise<StaticParams[]> {
-    const staticPaths = await this.getPagePaths(sites, languages, fetchOptions);
+    const staticPaths = await super.getPagePaths(sites, languages, fetchOptions);
 
     const params = new Array<StaticParams>();
 
@@ -141,6 +142,32 @@ export class SitecoreNextjsClient extends SitecoreClient {
     });
 
     return params;
+  }
+
+  /**
+   * Retrieves the static paths for pages based on the given languages.
+   * @param {string[]} sites - An array of site names to fetch routes for.
+   * @param {string[]} [languages] - An optional array of language codes to generate paths for.
+   * @param {FetchOptions} [fetchOptions] - Additional fetch options.
+   * @param {boolean} [multisiteEnabled] - Indicates if multisite support is enabled.
+   * @returns {Promise<StaticPath[]>} A promise that resolves to an array of static paths.
+   */
+  async getPagePaths(
+    sites: string[],
+    languages?: string[],
+    fetchOptions?: FetchOptions,
+    multisiteEnabled: boolean = true
+  ): Promise<StaticPath[]> {
+    const staticPaths = await super.getPagePaths(sites, languages, fetchOptions);
+
+    if (!multisiteEnabled) {
+      // remove _site_ segments when multisite is disabled
+      staticPaths.map((path) => {
+        path.params.path = normalizeSiteRewrite(path.params.path.join('/')).split('/');
+      });
+    }
+
+    return staticPaths;
   }
 
   /**


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When multisite is disabled in `sitecore.config` MultisiteProxy does not run and does not rewrite paths by adding site segment ( `/_site_my-site/...`), while the same setting does not affect the behavior of `getPagePaths` - paths are generated with the site segment. 
This PR adjusts `getPagePaths` to eliminate this discrepancy.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - in Pages Router app explicitly disable multisite; run in prod mode; verify that generated paths are without site prefix, personalize and redirects should work as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
