### PR TITLE
[Chore] 1.5.0 canary for dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,14 +45,30 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[nextjs]` Sitecore Content SDK does not support X-Forwarded-Host, causing incorrect hostname resolution behind proxies ([#330](https://github.com/Sitecore/content-sdk/pull/330))
+* `[core]` `[search]` `[analytics]` Pass Sitecore Context ID only in headers ([#336](https://github.com/Sitecore/content-sdk/pull/336))
+
+### 1.4.0
+
+### 🎉 New Features & Improvements
+
+* `[nextjs]` `[AI Component Generation]` Enable CLI command to add a new component ([#346](https://github.com/Sitecore/content-sdk/pull/346))
+
+### 🐛 Bug Fixes
+
 * `[nextjs]` `[App Router]` Form component throws a Server component error ([#333](https://github.com/Sitecore/content-sdk/pull/333))
 * `[nextjs]` Add "use client" directive to import-map.ts for React hooks compatibility ([#326](https://github.com/Sitecore/content-sdk/pull/326))
 * `[nextjs]` `[template/nextjs]` `[template/nextjs-app-router]` Fix middleware initialization errors when API configuration is missing ([#325](https://github.com/Sitecore/content-sdk/pull/325))
 * `[nextjs]` Fixes Server Transfer (rewrite) redirects ([#329](https://github.com/Sitecore/content-sdk/pull/329))
-* `[nextjs]` Sitecore Content SDK does not support X-Forwarded-Host, causing incorrect hostname resolution behind proxies ([#330](https://github.com/Sitecore/content-sdk/pull/330))
-* `[core]` `[search]` `[analytics]` Pass Sitecore Context ID only in headers ([#336](https://github.com/Sitecore/content-sdk/pull/336))
-* `[nextjs]` `[react]` Fix fields becoming uneditable in Pages when running Editing Host in dev mode ([#339](https://github.com/Sitecore/content-sdk/pull/339))
 * `[nextjs]` Preserve `basePath` when doing redirects in redirects-middleware ([#344](https://github.com/Sitecore/content-sdk/pull/344))
+* `[nextjs]` `[react]` Fix fields becoming uneditable in Pages when running Editing Host in dev mode ([#339](https://github.com/Sitecore/content-sdk/pull/339))
+* `[nextjs]` `[Pages Router]` Adjust static path generation when multisite is disabled ([#345](https://github.com/Sitecore/content-sdk/pull/345))
+
+## 1.3.2
+
+### ✨ Chores
+
+* Apply caret (`^`) verisoning to content-sdk packages, ensuring the latest patch versions are used by them.
 
 ## 1.3.1
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,8 @@
 {
   "lerna": "3.22.1",
   "packages": ["packages/*", "samples/*"],
-  "version": "1.4.0-canary.24",
+  "version": "independent",
   "npmClient": "yarn",
   "useWorkspaces": true
 }
+

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -73,5 +73,5 @@
     "prepublishOnly": "npm run build",
     "test": "jest --config jest.config.ts"
   },
-  "version": "1.4.0-canary.24"
+  "version": "1.5.0-canary.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/cli",
-  "version": "1.4.0-canary.24",
+  "version": "1.5.0-canary.0",
   "description": "Sitecore Content SDK CLI",
   "main": "dist/cjs/cli.js",
   "module": "dist/esm/cli.js",
@@ -34,7 +34,7 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "1.4.0-canary.24",
+    "@sitecore-content-sdk/core": "1.5.0-canary.0",
     "chokidar": "^4.0.3",
     "dotenv": "^16.5.0",
     "dotenv-expand": "^12.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/core",
-  "version": "1.4.0-canary.24",
+  "version": "1.5.0-canary.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/packages/create-content-sdk-app/package.json
+++ b/packages/create-content-sdk-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-content-sdk-app",
-  "version": "1.4.0-canary.24",
+  "version": "1.5.0-canary.0",
   "description": "Sitecore Content SDK initializer",
   "bin": "./dist/index.js",
   "scripts": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/analytics-core": "1.4.0-canary.24",
+    "@sitecore-content-sdk/analytics-core": "1.5.0-canary.0",
     "debug": "^4.4.3"
   },
   "description": "> TODO: description",
@@ -65,5 +65,5 @@
     "prepublishOnly": "npm run build",
     "test": "jest --config jest.config.ts"
   },
-  "version": "1.4.0-canary.24"
+  "version": "1.5.0-canary.0"
 }

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/nextjs",
-  "version": "1.4.0-canary.24",
+  "version": "1.5.0-canary.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -91,8 +91,8 @@
   },
   "dependencies": {
     "@babel/parser": "^7.27.2",
-    "@sitecore-content-sdk/core": "1.4.0-canary.24",
-    "@sitecore-content-sdk/react": "1.4.0-canary.24",
+    "@sitecore-content-sdk/core": "1.5.0-canary.0",
+    "@sitecore-content-sdk/react": "1.5.0-canary.0",
     "recast": "^0.23.11",
     "regex-parser": "^2.3.1",
     "sync-disk-cache": "^2.1.0"

--- a/packages/personalize/package.json
+++ b/packages/personalize/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/analytics-core": "1.4.0-canary.24",
-    "@sitecore-content-sdk/events": "1.4.0-canary.24",
+    "@sitecore-content-sdk/analytics-core": "1.5.0-canary.0",
+    "@sitecore-content-sdk/events": "1.5.0-canary.0",
     "debug": "^4.4.3"
   },
   "description": "> TODO: description",
@@ -65,5 +65,5 @@
     "prepublishOnly": "npm run build",
     "test": "jest --config jest.config.ts"
   },
-  "version": "1.4.0-canary.24"
+  "version": "1.5.0-canary.0"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/react",
-  "version": "1.4.0-canary.24",
+  "version": "1.5.0-canary.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -76,8 +76,8 @@
     "react-dom": "^19.2.1"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "1.4.0-canary.24",
-    "@sitecore-content-sdk/search": "1.4.0-canary.24",
+    "@sitecore-content-sdk/core": "1.5.0-canary.0",
+    "@sitecore-content-sdk/search": "0.2.0-canary.0",
     "fast-deep-equal": "^3.1.3"
   },
   "description": "",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/search",
-  "version": "1.4.0-canary.24",
+  "version": "0.2.0-canary.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -36,7 +36,7 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "1.4.0-canary.24"
+    "@sitecore-content-sdk/core": "1.5.0-canary.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,7 +3539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sitecore-content-sdk/analytics-core@npm:1.4.0-canary.24, @sitecore-content-sdk/analytics-core@workspace:packages/analytics-core":
+"@sitecore-content-sdk/analytics-core@npm:1.5.0-canary.0, @sitecore-content-sdk/analytics-core@workspace:packages/analytics-core":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/analytics-core@workspace:packages/analytics-core"
   dependencies:
@@ -3568,7 +3568,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/cli@workspace:packages/cli"
   dependencies:
-    "@sitecore-content-sdk/core": "npm:1.4.0-canary.24"
+    "@sitecore-content-sdk/core": "npm:1.5.0-canary.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@types/chai": "npm:^5.2.2"
     "@types/inquirer": "npm:^9.0.9"
@@ -3607,7 +3607,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/core@npm:1.4.0-canary.24, @sitecore-content-sdk/core@workspace:packages/core":
+"@sitecore-content-sdk/core@npm:1.5.0-canary.0, @sitecore-content-sdk/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/core@workspace:packages/core"
   dependencies:
@@ -3659,13 +3659,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/events@npm:1.4.0-canary.24, @sitecore-content-sdk/events@workspace:packages/events":
+"@sitecore-content-sdk/events@npm:1.5.0-canary.0, @sitecore-content-sdk/events@workspace:packages/events":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/events@workspace:packages/events"
   dependencies:
     "@jest/globals": "npm:^30.2.0"
     "@jest/types": "npm:^29.6.3"
-    "@sitecore-content-sdk/analytics-core": "npm:1.4.0-canary.24"
+    "@sitecore-content-sdk/analytics-core": "npm:1.5.0-canary.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@types/debug": "npm:^4.1.12"
     "@types/jest": "npm:^29.5.12"
@@ -3693,8 +3693,8 @@ __metadata:
     "@babel/parser": "npm:^7.27.2"
     "@sitecore-cloudsdk/core": "npm:^0.5.1"
     "@sitecore-cloudsdk/personalize": "npm:^0.5.1"
-    "@sitecore-content-sdk/core": "npm:1.4.0-canary.24"
-    "@sitecore-content-sdk/react": "npm:1.4.0-canary.24"
+    "@sitecore-content-sdk/core": "npm:1.5.0-canary.0"
+    "@sitecore-content-sdk/react": "npm:1.5.0-canary.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/react": "npm:^16.3.0"
@@ -3757,8 +3757,8 @@ __metadata:
   resolution: "@sitecore-content-sdk/personalize@workspace:packages/personalize"
   dependencies:
     "@jest/types": "npm:^29.6.3"
-    "@sitecore-content-sdk/analytics-core": "npm:1.4.0-canary.24"
-    "@sitecore-content-sdk/events": "npm:1.4.0-canary.24"
+    "@sitecore-content-sdk/analytics-core": "npm:1.5.0-canary.0"
+    "@sitecore-content-sdk/events": "npm:1.5.0-canary.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@types/debug": "npm:^4.1.12"
     "@types/jest": "npm:^29.5.12"
@@ -3779,12 +3779,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/react@npm:1.4.0-canary.24, @sitecore-content-sdk/react@workspace:packages/react":
+"@sitecore-content-sdk/react@npm:1.5.0-canary.0, @sitecore-content-sdk/react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/react@workspace:packages/react"
   dependencies:
-    "@sitecore-content-sdk/core": "npm:1.4.0-canary.24"
-    "@sitecore-content-sdk/search": "npm:1.4.0-canary.24"
+    "@sitecore-content-sdk/core": "npm:1.5.0-canary.0"
+    "@sitecore-content-sdk/search": "npm:0.2.0-canary.0"
     "@sitecore-feaas/clientside": "npm:^0.6.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@testing-library/dom": "npm:^10.4.0"
@@ -3830,11 +3830,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/search@npm:1.4.0-canary.24, @sitecore-content-sdk/search@workspace:packages/search":
+"@sitecore-content-sdk/search@npm:0.2.0-canary.0, @sitecore-content-sdk/search@workspace:packages/search":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/search@workspace:packages/search"
   dependencies:
-    "@sitecore-content-sdk/core": "npm:1.4.0-canary.24"
+    "@sitecore-content-sdk/core": "npm:1.5.0-canary.0"
     "@types/chai": "npm:^5.2.3"
     "@types/mocha": "npm:^10.0.10"
     chai: "npm:^6.2.1"


### PR DESCRIPTION
Bump canary version in dev to 1.5.0-canary, following minor 1.4 release.

Next planned Content SDK release: 2.0.
1.5.0 canary chosen in case more patches or minor updates will be needed for 1.x.
