### PR TITLE
[nextjs]  Fix basePath preservation logic in redirects-proxy in case `basePath` is not configured; Fix nextjs specific header names in redirects-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Our versioning strategy is as follows:
 
 * `[nextjs]` Sitecore Content SDK does not support X-Forwarded-Host, causing incorrect hostname resolution behind proxies ([#330](https://github.com/Sitecore/content-sdk/pull/330))
 * `[core]` `[search]` `[analytics]` Pass Sitecore Context ID only in headers ([#336](https://github.com/Sitecore/content-sdk/pull/336))
-* `[nextjs]` Fix basePath preservation and header names in redirects-proxy ([#352](https://github.com/Sitecore/content-sdk/pull/352))
+* `[nextjs]` Fix basePath preservation logic in redirects-proxy in case `basePath` is not configured; Fix nextjs specific header names in redirects-proxy ([#352](https://github.com/Sitecore/content-sdk/pull/352))
 
 ### 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Our versioning strategy is as follows:
 
 * `[nextjs]` Sitecore Content SDK does not support X-Forwarded-Host, causing incorrect hostname resolution behind proxies ([#330](https://github.com/Sitecore/content-sdk/pull/330))
 * `[core]` `[search]` `[analytics]` Pass Sitecore Context ID only in headers ([#336](https://github.com/Sitecore/content-sdk/pull/336))
+* `[nextjs]` Fix basePath preservation and header names in redirects-proxy ([#352](https://github.com/Sitecore/content-sdk/pull/352))
 
 ### 1.4.0
 

--- a/packages/nextjs/src/proxy/redirects-proxy.test.ts
+++ b/packages/nextjs/src/proxy/redirects-proxy.test.ts
@@ -697,6 +697,41 @@ describe('RedirectsProxy', () => {
       expect(finalRes).to.deep.equal(redirectRes);
     });
 
+    it('should preserve basePath if basePath is empty string', async () => {
+      const req = createRequest({
+        nextUrl: {
+          pathname: '/old-page',
+          search: '?param1=value1&param2=value2',
+          basePath: '',
+        },
+      });
+      const res = createResponse();
+
+      const redirectRes = createResponse({
+        redirected: true,
+        status: 302,
+        url: 'http://localhost:3000/new-page',
+      });
+      nextRedirectStub.returns(redirectRes);
+
+      const { proxy } = createProxy({
+        pattern: '/old-page',
+        target: '/new-page',
+        redirectType: REDIRECT_TYPE_301,
+        isQueryStringPreserved: true,
+      });
+
+      const finalRes = await proxy.handle(req, res);
+
+      expect(nextRedirectStub.calledOnce).to.be.true;
+      const redirectUrl = nextRedirectStub.getCall(0).args[0];
+      expect(redirectUrl).to.include('/new-page');
+      expect(redirectUrl).to.include('param1=value1');
+      expect(redirectUrl).to.include('param2=value2');
+
+      expect(finalRes).to.deep.equal(redirectRes);
+    });
+
     it('should handle absolute URL targets', async () => {
       const req = createRequest({
         nextUrl: {

--- a/packages/nextjs/src/proxy/redirects-proxy.ts
+++ b/packages/nextjs/src/proxy/redirects-proxy.ts
@@ -209,7 +209,11 @@ export class RedirectsProxy extends ProxyBase {
         url.href = prepareNewURL.href;
         url.pathname = prepareNewURL.pathname;
         url.search = prepareNewURL.search;
-        url.basePath = basePath;
+        // nextjs seter sets '/' by default if basePath is empty
+        // this causes issues when basePath is not configured so we need to set it only if exists
+        if (basePath) {
+          url.basePath = basePath;
+        }
 
         if (!isAppRouterRequest) {
           // for pages router i18n implementation, apply default locale as backup
@@ -410,7 +414,11 @@ export class RedirectsProxy extends ProxyBase {
     url.search = newUrl.search;
     url.pathname = newUrl.pathname.toLocaleLowerCase();
     url.href = newUrl.href;
-    url.basePath = basePath;
+    // nextjs seter sets '/' by default if basePath is empty
+    // this causes issues when basePath is not configured so we need to set it only if exists
+    if (basePath) {
+      url.basePath = basePath;
+    }
 
     return url;
   }
@@ -503,8 +511,8 @@ export class RedirectsProxy extends ProxyBase {
       headers: res?.headers,
     });
     if (res?.headers) {
-      redirect.headers.delete('x-proxy-next');
-      redirect.headers.delete('x-proxy-rewrite');
+      redirect.headers.delete('x-middleware-next');
+      redirect.headers.delete('x-middleware-rewrite');
       redirect.headers.delete(REWRITE_HEADER_NAME);
     }
     return redirect;

--- a/packages/nextjs/src/proxy/redirects-proxy.ts
+++ b/packages/nextjs/src/proxy/redirects-proxy.ts
@@ -209,7 +209,7 @@ export class RedirectsProxy extends ProxyBase {
         url.href = prepareNewURL.href;
         url.pathname = prepareNewURL.pathname;
         url.search = prepareNewURL.search;
-        // nextjs seter sets '/' by default if basePath is empty
+        // NextUrl setter sets '/' by default if basePath is empty
         // this causes issues when basePath is not configured so we need to set it only if exists
         if (basePath) {
           url.basePath = basePath;
@@ -414,7 +414,7 @@ export class RedirectsProxy extends ProxyBase {
     url.search = newUrl.search;
     url.pathname = newUrl.pathname.toLocaleLowerCase();
     url.href = newUrl.href;
-    // nextjs seter sets '/' by default if basePath is empty
+    // NextUrl setter sets '/' by default if basePath is empty
     // this causes issues when basePath is not configured so we need to set it only if exists
     if (basePath) {
       url.basePath = basePath;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is a follow-up to #344 and addresses two issues:
 - when assigning `basePath` property of NextUrl, if `basePath` is empty string it gets assigned as '/' instead of ''; this causes redirects to not work properly when `basePath` is not configured;
 - fix the names of the next js specific headers that are removed from the response; this was causing redirects to not work properly in case of pages router application and client side navigation.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - test both app router and pages router applications, with and without `basePath`, in both client side and server side navigation;

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
