### PR TITLE
[create-content-sdk-app] Fix static generation error by marking route handlers as force-dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Our versioning strategy is as follows:
 
 ### 🛠 Breaking Changes
 
-* `[nextjs]` `[create-content-sdk-app]` Upgrade to Next.js 16 ([#334](https://github.com/Sitecore/content-sdk/pull/334))([#343](https://github.com/Sitecore/content-sdk/pull/343))
+* `[nextjs]` `[create-content-sdk-app]` Upgrade to Next.js 16 ([#334](https://github.com/Sitecore/content-sdk/pull/334))([#343](https://github.com/Sitecore/content-sdk/pull/343))([#353](https://github.com/Sitecore/content-sdk/pull/353))
   - Next.js 16 is now required (minimum version `^16.0.0`)
   - `middleware.ts` renamed to `proxy.ts` with updated function signature
   - Removed deprecated `images.domains` usage (use `remotePatterns` instead)

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/README.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/README.md
@@ -10,8 +10,6 @@
 
 Cache Components is **disabled by default** in this template. 
 
-**📖 For complete documentation**, including theory, step-by-step enabling guide, edge cases, and examples, see **[CACHE_COMPONENTS.md](./CACHE_COMPONENTS.md)**.
-
 **Quick Start:**
 1. Enable `cacheComponents: true` in `next.config.ts`
 2. Add uncached data access (`draftMode()`, `cookies()`, `headers()`, or `searchParams`) before calling client methods

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/README.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/README.md
@@ -8,11 +8,36 @@
 
 ## Next.js Cache Components
 
-Cache Components is **disabled by default** in this template. 
+Cache Components is **disabled by default** in this template. To enable it:
 
-**Quick Start:**
-1. Enable `cacheComponents: true` in `next.config.ts`
-2. Add uncached data access (`draftMode()`, `cookies()`, `headers()`, or `searchParams`) before calling client methods
-3. Use Suspense boundaries for Partial Prerendering (PPR)
+1. **Enable in `next.config.ts`**:
+   ```typescript
+   const nextConfig: NextConfig = {
+     cacheComponents: true,
+     // ... rest of config
+   };
+   ```
 
-**Note:** Route handlers are not affected by Cache Components and require `export const dynamic = 'force-dynamic'` when using request headers/cookies.
+2. **Add uncached data access** in all server components that call client methods:
+   
+   Next.js 16 with Cache Components requires accessing uncached data (`draftMode()`, `cookies()`, `headers()`, or `searchParams`) before any operations that might use `new Date()` or other time-related functions.
+   
+   Example:
+   ```typescript
+   export default async function Page({ params, searchParams }: PageProps) {
+     // Access uncached data first
+     await draftMode();
+     
+     const { site, locale, path } = await params;
+     // ... rest of component
+   }
+   ```
+   
+   Apply this pattern to:
+   - Page components that call `client.getPage()`, `client.getPreview()`, etc.
+   - `generateMetadata` functions
+   - Layout components that call client methods
+   - Not-found handlers
+   - Any server component calling Sitecore client methods
+
+3. **See the sample app** (`samples/nextjs-app-router`) for a working example with Cache Components enabled.

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/README.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/README.md
@@ -8,38 +8,13 @@
 
 ## Next.js Cache Components
 
-Cache Components is **disabled by default** in this template. To enable it:
+Cache Components is **disabled by default** in this template. 
 
-1. **Enable in `next.config.ts`**:
-   ```typescript
-   const nextConfig: NextConfig = {
-     cacheComponents: true,
-     // ... rest of config
-   };
-   ```
+**📖 For complete documentation**, including theory, step-by-step enabling guide, edge cases, and examples, see **[CACHE_COMPONENTS.md](./CACHE_COMPONENTS.md)**.
 
-2. **Add uncached data access** in all server components that call client methods:
-   
-   Next.js 16 with Cache Components requires accessing uncached data (`draftMode()`, `cookies()`, `headers()`, or `searchParams`) before any operations that might use `new Date()` or other time-related functions.
-   
-   Example:
-   ```typescript
-   export default async function Page({ params, searchParams }: PageProps) {
-     // Access uncached data first
-     await draftMode();
-     
-     const { site, locale, path } = await params;
-     // ... rest of component
-   }
-   ```
-   
-   Apply this pattern to:
-   - Page components that call `client.getPage()`, `client.getPreview()`, etc.
-   - `generateMetadata` functions
-   - Layout components that call client methods
-   - Not-found handlers
-   - Any server component calling Sitecore client methods
+**Quick Start:**
+1. Enable `cacheComponents: true` in `next.config.ts`
+2. Add uncached data access (`draftMode()`, `cookies()`, `headers()`, or `searchParams`) before calling client methods
+3. Use Suspense boundaries for Partial Prerendering (PPR)
 
-3. **See the sample app** (`samples/nextjs-app-router`) for a working example with Cache Components enabled.
-
-For more information, see [Next.js Cache Components documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents).
+**Note:** Route handlers are not affected by Cache Components and require `export const dynamic = 'force-dynamic'` when using request headers/cookies.

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/api/editing/config/route.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/api/editing/config/route.ts
@@ -8,6 +8,9 @@ import metadata from '.sitecore/metadata.json';
  * to determine feature compatibility and configuration.
  */
 
+// Force dynamic rendering since this route uses request headers
+export const dynamic = 'force-dynamic';
+
 export const { GET, OPTIONS } = createEditingConfigRouteHandler({
   components,
   clientComponents,

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/api/editing/render/route.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/api/editing/render/route.ts
@@ -12,4 +12,7 @@ import { createEditingRenderRouteHandlers } from '@sitecore-content-sdk/nextjs/r
  *  4. Return the rendered HTML for editing mode
  */
 
+// Force dynamic rendering since this route uses request headers, cookies, and draftMode
+export const dynamic = 'force-dynamic';
+
 export const { GET, POST, OPTIONS } = createEditingRenderRouteHandlers({});

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/api/robots/route.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/api/robots/route.ts
@@ -10,6 +10,9 @@ import client from 'lib/sitecore-client';
  * used by search engine crawlers to determine crawl and indexing rules.
  */
 
+// Force dynamic rendering since this route uses request headers
+export const dynamic = 'force-dynamic';
+
 export const { GET } = createRobotsRouteHandler({
   client,
   sites,

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/api/sitemap/route.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/api/sitemap/route.ts
@@ -9,6 +9,9 @@ import client from 'lib/sitecore-client';
  * The sitemap configuration can be managed within XM Cloud.
  */
 
+// Force dynamic rendering since this route uses request headers
+export const dynamic = 'force-dynamic';
+
 export const { GET } = createSitemapRouteHandler({
   client,
   sites,


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
### Fix route handler static generation error

Fixed an issue where Next.js was attempting to statically generate route handlers that use `request.headers`, causing build failures with the error "Route couldn't be rendered statically because it used `request.headers`".

**Solution:**
Added `export const dynamic = 'force-dynamic'` to all route handlers that access request headers, cookies, or draftMode. This explicitly marks them as dynamic routes that must be rendered at request time.

**Affected routes:**
- Sitemap route handler
- Robots route handler  
- Editing config route handler
- Editing render route handler


## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
