### PR TITLE
[codegen] Fix getImportMap stripping extensions from 3rd party library names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[core]` `[search]` `[analytics]` Pass Sitecore Context ID only in headers ([#336](https://github.com/Sitecore/content-sdk/pull/336))
+* `[core]` `[DesignLibrary]` Fix faux-extentions being stripped from 3rd party modules' names in import-map ([#358](https://github.com/Sitecore/content-sdk/pull/358))
 
 ### 1.4.1
 

--- a/packages/content/src/tools/codegen/import-map.test.ts
+++ b/packages/content/src/tools/codegen/import-map.test.ts
@@ -248,6 +248,81 @@ describe('Import Map Generation', () => {
 
       expect(convertToTestable(result)).to.deep.equal(expected);
     });
+
+    it('should return map with imports from 3rd party modules', () => {
+      const fakeCode = `import { coolFeature } from 'coolFeatureLib';
+        import { fancyNameFeature } from 'fancy.js';
+        export default function logic() {
+          console.log('document imports', coolFeature, fancyNameFeature);
+        };
+      `;
+
+      const ts = require('typescript');
+      const fakeFilePath = path.resolve(process.cwd(), 'fake-file.ts');
+      const nodeModulesPath = path.resolve(process.cwd(), 'node_modules');
+
+      // Store original functions
+      const originalReadFile = ts.sys.readFile;
+      const originalFileExists = ts.sys.fileExists;
+
+      try {
+        // Mock ts.sys.readFile to return our fake code
+        ts.sys.readFile = (filePath: string) => {
+          if (filePath === fakeFilePath) {
+            return fakeCode;
+          }
+          if (filePath.includes('tsconfig.json')) {
+            return originalReadFile(filePath);
+          }
+          // For node_modules resolution, return minimal valid module content
+          if (
+            filePath.includes('coolFeatureLib') ||
+            filePath.includes('fancy.js') ||
+            filePath.includes(nodeModulesPath)
+          ) {
+            return 'export const placeholder = true;';
+          }
+          return originalReadFile(filePath);
+        };
+
+        // Mock ts.sys.fileExists to confirm our files exist
+        ts.sys.fileExists = (filePath: string) => {
+          if (filePath === fakeFilePath) {
+            return true;
+          }
+          if (
+            filePath.includes('coolFeatureLib') ||
+            filePath.includes('fancy.js') ||
+            filePath.includes(nodeModulesPath)
+          ) {
+            return true;
+          }
+          return originalFileExists(filePath);
+        };
+
+        const result = getImportMap([fakeFilePath]);
+        const expected = [
+          {
+            module: 'coolFeatureLib',
+            namedImports: [{ name: 'coolFeature', value: 'coolFeature' }],
+            defaultImport: null,
+            namespaceImport: null,
+          },
+          {
+            module: 'fancy.js',
+            namedImports: [{ name: 'fancyNameFeature', value: 'fancyNameFeature' }],
+            defaultImport: null,
+            namespaceImport: null,
+          },
+        ];
+
+        expect(convertToTestable(result)).to.deep.equal(expected);
+      } finally {
+        // Always restore original functions, even if test fails
+        ts.sys.readFile = originalReadFile;
+        ts.sys.fileExists = originalFileExists;
+      }
+    });
   });
 
   describe('defaultMapTemplate', () => {
@@ -583,4 +658,3 @@ ${defaultMapTemplate(indexedImportMap)}`;
     });
   });
 });
-

--- a/packages/content/src/tools/codegen/import-map.ts
+++ b/packages/content/src/tools/codegen/import-map.ts
@@ -5,7 +5,7 @@ import { debug } from '@sitecore-content-sdk/core';
 import { getComponentList } from './../templating';
 import { SitecoreConfig } from './../../config';
 import crypto from 'crypto';
-import { isNodeModuleImport, stripExtension, getRelativeImportPath, toPosixPath } from './utils';
+import { isNodeModuleImportOrAlias, getRelativeImportPath } from './utils';
 
 let _getComponentList = getComponentList;
 const aliasImport = /^([a-zA-Z0-9]+) as .+$/;
@@ -274,23 +274,11 @@ function _getImportMap(paths: string[]) {
 
         let importModuleName: string;
 
-        if (
-          resolvedImportPath.includes('node_modules') ||
-          resolvedImportPath.endsWith('.d.ts') ||
-          !toPosixPath(resolvedImportPath).startsWith(toPosixPath(appPath) + '/')
-        ) {
-          // if import path points to a file in local app - process import path to the file (i.e. ./myComponent)
-          // if it points to node_modules or a file in monorepo - parse import path as dependency module name (i.e. React)
-          // external dependency → keep as-is
-          importModuleName = isNodeModuleImport(moduleName)
-            ? stripExtension(moduleName)
-            : getRelativeImportPath(resolvedImportPath, appPath);
-        } else {
-          // local file
-          importModuleName = isNodeModuleImport(moduleName)
-            ? stripExtension(moduleName)
-            : getRelativeImportPath(resolvedImportPath, appPath);
-        }
+        // if module path points to local app - get relative import path to the file (i.e. ./myComponent)
+        // if it points to node_modules, file or an alias - keep as-is
+        importModuleName = isNodeModuleImportOrAlias(moduleName)
+          ? moduleName
+          : getRelativeImportPath(resolvedImportPath, appPath);
 
         // Set module import info in the map. If module import exists - add entries to existing entry
         // Otherwise, add new entry

--- a/packages/content/src/tools/codegen/utils.test.ts
+++ b/packages/content/src/tools/codegen/utils.test.ts
@@ -6,7 +6,12 @@ import * as path from 'path';
 import nock from 'nock';
 import fs from 'fs';
 import * as codegenUtils from './utils';
-import { toPosixPath, stripExtension, getRelativeImportPath, isNodeModuleImport } from './utils';
+import {
+  toPosixPath,
+  stripExtension,
+  getRelativeImportPath,
+  isNodeModuleImportOrAlias,
+} from './utils';
 
 const uniqueFilesFrom = (res: Array<{ filePath: string }>) => {
   const set = new Set<string>();
@@ -490,16 +495,16 @@ describe('codegen-utils', () => {
       });
     });
 
-    describe('isNodeModuleImport', () => {
+    describe('isNodeModuleImportOrAlias', () => {
       it('returns true for package names and alias-like specifiers', () => {
         ['react', '@scope/pkg', 'components/Button', '#internal', 'somePkg'].forEach((s) =>
-          expect(isNodeModuleImport(s), s).to.equal(true)
+          expect(isNodeModuleImportOrAlias(s), s).to.equal(true)
         );
       });
 
       it('returns false for relative and absolute specifiers', () => {
         ['./x', '../x', '/abs/path'].forEach((s) =>
-          expect(isNodeModuleImport(s), s).to.equal(false)
+          expect(isNodeModuleImportOrAlias(s), s).to.equal(false)
         );
       });
     });

--- a/packages/content/src/tools/codegen/utils.ts
+++ b/packages/content/src/tools/codegen/utils.ts
@@ -471,6 +471,6 @@ export const getRelativeImportPath = (absFile: string, appPath: string) => {
   return stripExtension(rel);
 };
 
-// Determine if a specifier is bare/aliased (i.e., not relative "./" or "../" and not absolute "/").
-export const isNodeModuleImport = (name: string) =>
+// check if resolved import module path
+export const isNodeModuleImportOrAlias = (name: string) =>
   !name.startsWith('./') && !name.startsWith('../') && !name.startsWith('/');


### PR DESCRIPTION

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
When codebase includes imports from 3rd party libraries with names like `jazz.js`, the `.js` part would be stripped when building import map.
This PR fixes it.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
