### PR TITLE
Bugfix/issues 361

### DIFF
--- a/packages/react/src/enhancers/withDatasourceCheck.test.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.test.tsx
@@ -2,37 +2,23 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-import { spy } from 'sinon';
-
-import { withDatasourceCheck, WithDatasourceCheckProps } from '../enhancers/withDatasourceCheck';
 import {
-  SitecoreProviderReactContext,
-  SitecoreProviderState,
-} from '../components/SitecoreProvider';
-import { LayoutServicePageState } from '@sitecore-content-sdk/content/layout';
+  withDatasourceCheck,
+  WithDatasourceCheckProps,
+  Page,
+  PageMode,
+} from '../enhancers/withDatasourceCheck';
 
-const mockContext = (editing: boolean): SitecoreProviderState => {
+// Helper to create the Page object state for tests
+const mockPage = (overrides?: Partial<PageMode>): Page => {
   return {
-    page: {
-      locale: 'en',
-      layout: {
-        sitecore: {
-          context: {},
-          route: null,
-        },
-      },
-      mode: {
-        name: LayoutServicePageState.Normal,
-        isNormal: false,
-        isPreview: false,
-        isEditing: editing,
-        isDesignLibrary: false,
-        designLibrary: {
-          isVariantGeneration: false,
-        },
-      },
+    mode: {
+      isNormal: false,
+      isPreview: false,
+      isEditing: false,
+      isDesignLibrary: false,
+      ...overrides,
     },
-    setPage: spy(),
   };
 };
 
@@ -53,26 +39,22 @@ describe('withDatasourceCheck', () => {
         componentName: 'TestComponent',
         dataSource: '',
       },
-    };
+      page: mockPage({ isNormal: true }),
+    } as WithDatasourceCheckProps;
 
-    const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={mockContext(false)}>
-        <TestComponentWithDatasourceCheck {...props} />
-      </SitecoreProviderReactContext.Provider>
-    );
+    const wrapper = render(<TestComponentWithDatasourceCheck {...props} />);
 
     expect(wrapper.container.innerHTML).to.be.empty;
   });
 
   it('should return null if rendering missing in normal mode', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
-    const props = {} as WithDatasourceCheckProps;
+    // @ts-ignore - simulating missing props
+    const props = {
+      page: mockPage({ isNormal: true }),
+    } as WithDatasourceCheckProps;
 
-    const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={mockContext(false)}>
-        <TestComponentWithDatasourceCheck {...props} />
-      </SitecoreProviderReactContext.Provider>
-    );
+    const wrapper = render(<TestComponentWithDatasourceCheck {...props} />);
 
     expect(wrapper.container.innerHTML).to.be.empty;
   });
@@ -84,13 +66,10 @@ describe('withDatasourceCheck', () => {
         componentName: 'TestComponent',
         dataSource: '',
       },
-    };
+      page: mockPage({ isEditing: true }),
+    } as WithDatasourceCheckProps;
 
-    const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={mockContext(true)}>
-        <TestComponentWithDatasourceCheck {...props} />
-      </SitecoreProviderReactContext.Provider>
-    );
+    const wrapper = render(<TestComponentWithDatasourceCheck {...props} />);
 
     expect(wrapper.container.querySelectorAll('div.sc-jss-editing-error')).to.have.length(1);
   });
@@ -100,18 +79,16 @@ describe('withDatasourceCheck', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck({
       editingErrorComponent: CustomEditingError,
     })(TestComponent);
+
     const props = {
       rendering: {
         componentName: 'TestComponent',
         dataSource: '',
       },
-    };
+      page: mockPage({ isEditing: true }),
+    } as WithDatasourceCheckProps;
 
-    const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={mockContext(true)}>
-        <TestComponentWithDatasourceCheck {...props} />
-      </SitecoreProviderReactContext.Provider>
-    );
+    const wrapper = render(<TestComponentWithDatasourceCheck {...props} />);
 
     expect(wrapper.container.innerHTML).to.contain('Better than yours');
   });
@@ -123,20 +100,12 @@ describe('withDatasourceCheck', () => {
         componentName: 'TestComponent',
         dataSource: '',
       },
-    };
+      page: mockPage({ isDesignLibrary: true }),
+    } as WithDatasourceCheckProps;
 
-    const context = mockContext(false);
-
-    context.page.mode.isDesignLibrary = true;
-
-    const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={context}>
-        <TestComponentWithDatasourceCheck {...props} />
-      </SitecoreProviderReactContext.Provider>
-    );
+    const wrapper = render(<TestComponentWithDatasourceCheck {...props} />);
 
     expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
-    expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
   });
 
   it('should return wrapped component if datasource present in normal mode', () => {
@@ -146,13 +115,10 @@ describe('withDatasourceCheck', () => {
         componentName: 'TestComponent',
         dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
       },
-    };
+      page: mockPage({ isNormal: true }),
+    } as WithDatasourceCheckProps;
 
-    const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={mockContext(false)}>
-        <TestComponentWithDatasourceCheck {...props} />
-      </SitecoreProviderReactContext.Provider>
-    );
+    const wrapper = render(<TestComponentWithDatasourceCheck {...props} />);
 
     expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
     expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
@@ -165,32 +131,10 @@ describe('withDatasourceCheck', () => {
         componentName: 'TestComponent',
         dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
       },
-    };
+      page: mockPage({ isEditing: true }),
+    } as WithDatasourceCheckProps;
 
-    const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={mockContext(true)}>
-        <TestComponentWithDatasourceCheck {...props} />
-      </SitecoreProviderReactContext.Provider>
-    );
-
-    expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
-    expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
-  });
-
-  it('should return wrapped component if not within SitecoreProvider', () => {
-    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
-    const props = {
-      rendering: {
-        componentName: 'TestComponent',
-        dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
-      },
-    };
-
-    const wrapper = render(
-      <SitecoreProviderReactContext.Provider value={mockContext(false)}>
-        <TestComponentWithDatasourceCheck {...props} />
-      </SitecoreProviderReactContext.Provider>
-    );
+    const wrapper = render(<TestComponentWithDatasourceCheck {...props} />);
 
     expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
     expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);

--- a/packages/react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.tsx
@@ -1,7 +1,16 @@
 ﻿import React, { JSX } from 'react';
-import { ComponentRendering } from '@sitecore-content-sdk/content/layout';
-import { useSitecore } from './withSitecore';
+import { ComponentRendering, LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
+import { DesignLibraryMode } from '@sitecore-content-sdk/core/editing';
 
+export type PageMode = {
+  isNormal: boolean;
+  isPreview: boolean;
+  isEditing: boolean;
+  isDesignLibrary: boolean;
+};
+export type Page = {
+  mode: PageMode;
+};
 export const DefaultEditingError = (): JSX.Element => (
   <div className="sc-jss-editing-error" role="alert">
     Datasource is required. Please choose a content item for this component.
@@ -10,6 +19,8 @@ export const DefaultEditingError = (): JSX.Element => (
 
 export interface WithDatasourceCheckProps {
   rendering: ComponentRendering;
+  pageState?: LayoutServicePageState;
+  libraryMode?: DesignLibraryMode;
 }
 
 export interface WithDatasourceCheckOptions {
@@ -33,15 +44,15 @@ export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
     Component: React.ComponentType<ComponentProps>
   ) {
     return function WithDatasourceCheck(props: ComponentProps) {
-      const { page } = useSitecore();
       const EditingError = options?.editingErrorComponent ?? DefaultEditingError;
-
+      const { pageState, libraryMode } = props;
       // If the component is rendered in DesignLibrary, we don't need to check for datasource
-      const isDesignLibrary = page.mode.isDesignLibrary;
+      const isDesignLibrary = !!libraryMode;
+      const isEditing = pageState === LayoutServicePageState.Edit;
 
       return isDesignLibrary || props.rendering?.dataSource ? (
         <Component {...props} />
-      ) : page.mode.isEditing ? (
+      ) : isEditing ? (
         <EditingError />
       ) : null;
     };

--- a/packages/react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/react/src/enhancers/withDatasourceCheck.tsx
@@ -1,7 +1,11 @@
 ﻿import React, { JSX } from 'react';
-import { ComponentRendering, LayoutServicePageState } from '@sitecore-content-sdk/core/layout';
-import { DesignLibraryMode } from '@sitecore-content-sdk/core/editing';
+import { ComponentRendering } from '@sitecore-content-sdk/core/layout';
 
+export const DefaultEditingError = (): JSX.Element => (
+  <div className="sc-jss-editing-error" role="alert">
+    Datasource is required. Please choose a content item for this component.
+  </div>
+);
 export type PageMode = {
   isNormal: boolean;
   isPreview: boolean;
@@ -11,16 +15,9 @@ export type PageMode = {
 export type Page = {
   mode: PageMode;
 };
-export const DefaultEditingError = (): JSX.Element => (
-  <div className="sc-jss-editing-error" role="alert">
-    Datasource is required. Please choose a content item for this component.
-  </div>
-);
-
 export interface WithDatasourceCheckProps {
   rendering: ComponentRendering;
-  pageState?: LayoutServicePageState;
-  libraryMode?: DesignLibraryMode;
+  page: Page;
 }
 
 export interface WithDatasourceCheckOptions {
@@ -45,14 +42,12 @@ export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
   ) {
     return function WithDatasourceCheck(props: ComponentProps) {
       const EditingError = options?.editingErrorComponent ?? DefaultEditingError;
-      const { pageState, libraryMode } = props;
+      const page = props?.page;
       // If the component is rendered in DesignLibrary, we don't need to check for datasource
-      const isDesignLibrary = !!libraryMode;
-      const isEditing = pageState === LayoutServicePageState.Edit;
-
+      const isDesignLibrary = page?.mode?.isDesignLibrary;
       return isDesignLibrary || props.rendering?.dataSource ? (
         <Component {...props} />
-      ) : isEditing ? (
+      ) : page?.mode?.isEditing ? (
         <EditingError />
       ) : null;
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Issue: #361 (referenced by branch name bugfix/issues-361)

This PR refactors the withDatasourceCheck and withDatasourceCheck tests in sitecore-content-sdk/react to:

- Resolve #361 by removing the `useSitecore();` and update it as per `props?.page;`
- Remove dependency on SitecoreProviderReactContext from tests
- Replace mockContext helper with mockPage helper that creates Page objects directly
- Simplify test setup by passing page prop directly to components instead of wrapping in Provider
- Remove test for "not within SitecoreProvider" scenario (no longer applicable)
- Export Page and PageMode types from the enhancer for test usage

Files Changed:

- withDatasourceCheck.tsx - Added type exports
- withDatasourceCheck.test.tsx - Refactored tests

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
