### PR TITLE
Fix behaviour of renderEach in page editing mode

### DIFF
--- a/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
@@ -1080,6 +1080,52 @@ describe('App Placeholder logic', () => {
     });
   });
 
+  it('should use renderEach for each child in the placeholder when page editing is enabled', () => {
+    const page = getPage();
+    const components = new Map<string, React.FC>();
+  
+    page.mode.isEditing = true;
+  
+    components.set('Child', () => 'Child');
+  
+    const route = {
+      name: 'Render Each Test',
+      placeholders: {
+        main: [
+          {
+            componentName: 'Child',
+          },
+          {
+            componentName: 'Child',
+          },
+        ],
+      },
+    };
+    page.layout = {
+      sitecore: {
+        context: {},
+        route,
+      },
+    };
+    const phKey = 'main';
+  
+    const renderedComponent = render(
+      <SitecoreProvider componentMap={componentMap} page={page}>
+        <AppPlaceholder
+          name={phKey}
+          rendering={page.layout.sitecore.route}
+          componentMap={components}
+          page={page}
+          render={(children) => <div className="parentWrapper">{children}</div>}
+          renderEach={(child) => <div className="wrapper">{child}</div>}
+        />
+      </SitecoreProvider>
+    );
+  
+    expect(renderedComponent.container.querySelectorAll('.parentWrapper').length).to.equal(1);
+    expect(renderedComponent.container.querySelectorAll('.wrapper').length).to.equal(2);
+  });
+
   describe('AppPlaceholder PlaceholderMetadata', () => {
     const {
       layoutData,

--- a/packages/react/src/components/Placeholder/AppPlaceholder.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.tsx
@@ -91,6 +91,10 @@ export const AppPlaceholder = (props: AppPlaceholderProps) => {
             {rendered}
           </ErrorBoundary>
         );
+
+        if (props.renderEach) {
+          rendered = props.renderEach(rendered, index) as React.ReactElement<{ [attr: string]: unknown }>;
+        }
       }
 
       // if in edit mode then emit shallow chromes for hydration in Pages
@@ -128,16 +132,6 @@ export const AppPlaceholder = (props: AppPlaceholderProps) => {
 
   if (props.render) {
     return props.render(components, placeholderRenderings, props);
-  } else if (props.renderEach) {
-    const renderEach = props.renderEach;
-
-    return finalRendering.map((component, index) => {
-      if (component && component.props && component.props.type === 'text/sitecore') {
-        return component;
-      }
-
-      return renderEach(component, index);
-    });
   } else {
     return finalRendering;
   }

--- a/packages/react/src/components/Placeholder/Placeholder.test.tsx
+++ b/packages/react/src/components/Placeholder/Placeholder.test.tsx
@@ -151,7 +151,7 @@ describe('<Placeholder />', () => {
         ).to.equal(1);
       });
 
-      it('should render components based on the rendereach function', () => {
+      it('should render components based on the renderEach function', () => {
         const page = getPage();
         page.layout = dataSet.data;
         const component = dataSet.data.sitecore.route as RouteData;
@@ -880,6 +880,51 @@ it('should render custom HiddenRendering when rendering is hidden', () => {
       'Hidden Rendering'
     )
   );
+});
+
+it('should use renderEach for each child in the placeholder when page editing is enabled', () => {
+  const page = getPage();
+  const components = new Map<string, React.FC>();
+
+  page.mode.isEditing = true;
+
+  components.set('Child', () => 'Child');
+
+  const route = {
+    name: 'Render Each Test',
+    placeholders: {
+      main: [
+        {
+          componentName: 'Child',
+        },
+        {
+          componentName: 'Child',
+        },
+      ],
+    },
+  };
+  page.layout = {
+    sitecore: {
+      context: {},
+      route,
+    },
+  };
+  const phKey = 'main';
+
+  const renderedComponent = render(
+    <SitecoreProvider componentMap={componentMap} page={page}>
+      <Placeholder
+        name={phKey}
+        rendering={page.layout.sitecore.route}
+        componentMap={components}
+        render={(children) => <div className="parentWrapper">{children}</div>}
+        renderEach={(child) => <div className="wrapper">{child}</div>}
+      />
+    </SitecoreProvider>
+  );
+
+  expect(renderedComponent.container.querySelectorAll('.parentWrapper').length).to.equal(1);
+  expect(renderedComponent.container.querySelectorAll('.wrapper').length).to.equal(2);
 });
 
 describe('PlaceholderMetadata', () => {

--- a/packages/react/src/components/Placeholder/Placeholder.tsx
+++ b/packages/react/src/components/Placeholder/Placeholder.tsx
@@ -71,6 +71,10 @@ export class PlaceholderComponent extends React.Component<PlaceholderProps> {
               {rendered}
             </ErrorBoundary>
           );
+
+          if (props.renderEach) {
+            rendered = props.renderEach(rendered, index) as React.ReactElement<{ [attr: string]: unknown }>;
+          }
         }
 
         // if in edit mode then emit shallow chromes for hydration in Pages
@@ -147,16 +151,6 @@ export class PlaceholderComponent extends React.Component<PlaceholderProps> {
       return this.props.page.mode.isEditing ? renderEmptyPlaceholder(rendered) : rendered;
     } else if (this.props.render) {
       return this.props.render(components, placeholderRenderings, childProps);
-    } else if (this.props.renderEach) {
-      const renderEach = this.props.renderEach;
-
-      return components.map((component, index) => {
-        if (component && component.props && component.props.type === 'text/sitecore') {
-          return component;
-        }
-
-        return renderEach(component, index);
-      });
     } else {
       return components;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
The `renderEach` attribute on the `Placeholder` and `AppPlaceholder` show weird behaviour during editing mode in the Page Builder. This is because all of the children of the placeholder are wrapped in the `PlaceholderMetadata` component before being returned from the `getRenderedComponents` function. The result is only a single wrapper is being added when there are more than one children in the placeholder.

The fix is to call the `renderEach` inside the `getRenderedComponents` function instead of on the result. As a side effect, you can now also combine `render` and `renderEach` where before `renderEach` was ignored when you pass a `render` function to the `Placeholder`.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

### Before:
<img width="1150" height="808" alt="image" src="https://github.com/user-attachments/assets/f671d4f3-7e95-4883-a169-f3bb09e8103d" />

### After:
<img width="1162" height="953" alt="image" src="https://github.com/user-attachments/assets/5746e3b6-dec9-4010-9cc1-06bb9a241dda" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
