### PR TITLE
[nextjs] Secured variants generation for server components in Design Studio - Follow Up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Our versioning strategy is as follows:
 
 * `[nextjs]` `[Pages Router]` Adjust static path generation when multisite is disabled ([#345](https://github.com/Sitecore/content-sdk/pull/345))
 
-* `[nextjs]` Enable secured component variant generation for App Router Server Components in Design Studio ([#369](https://github.com/Sitecore/content-sdk/pull/369))
+* `[nextjs]` Enable secured component variant generation for App Router Server Components in Design Studio ([#369](https://github.com/Sitecore/content-sdk/pull/369))([#375](https://github.com/Sitecore/content-sdk/pull/375))
 
 ### 🛠 Breaking Changes
 

--- a/packages/content/api/content-sdk-content.api.md
+++ b/packages/content/api/content-sdk-content.api.md
@@ -1377,7 +1377,7 @@ export type WriteImportMapArgsInternal = WriteImportMapArgs & {
 // Warnings were encountered during analysis:
 //
 // src/client/sitecore-client.ts:65:3 - (ae-forgotten-export) The symbol "PageModeName" needs to be exported by the entry point api-surface.d.ts
-// src/editing/codegen/preview.ts:109:3 - (ae-forgotten-export) The symbol "ComponentImport_2" needs to be exported by the entry point api-surface.d.ts
+// src/editing/codegen/preview.ts:110:3 - (ae-forgotten-export) The symbol "ComponentImport_2" needs to be exported by the entry point api-surface.d.ts
 // src/tools/generate-map.ts:24:3 - (ae-incompatible-release-tags) The symbol "mapTemplate" is marked as @public, but its signature references "ComponentMapTemplate" which is marked as @internal
 // src/tools/generate-map.ts:24:3 - (ae-incompatible-release-tags) The symbol "mapTemplate" is marked as @public, but its signature references "EnhancedComponentMapTemplate" which is marked as @internal
 // src/tools/generate-map.ts:28:3 - (ae-incompatible-release-tags) The symbol "clientMapTemplate" is marked as @public, but its signature references "ComponentMapTemplate" which is marked as @internal

--- a/packages/content/src/editing/codegen/preview.test.ts
+++ b/packages/content/src/editing/codegen/preview.test.ts
@@ -932,7 +932,10 @@ describe('design library codegen', () => {
       fetchStub.resolves({
         status: 200,
         statusText: 'OK',
-        data: mockComponentData,
+        data: {
+          id: testId,
+          content: JSON.stringify(mockComponentData),
+        },
       });
 
       const result = await fetchGeneratedComponentFromCache(testId, testToken, testEdgeUrl);
@@ -953,7 +956,10 @@ describe('design library codegen', () => {
       fetchStub.resolves({
         status: 200,
         statusText: 'OK',
-        data: mockComponentData,
+        data: {
+          id: testId,
+          content: JSON.stringify(mockComponentData),
+        },
       });
 
       const result = await fetchGeneratedComponentFromCache(testId, testToken);
@@ -1035,7 +1041,10 @@ describe('design library codegen', () => {
       fetchStub.resolves({
         status: 200,
         statusText: 'OK',
-        data: mockComponentData,
+        data: {
+          id: customId,
+          content: JSON.stringify(mockComponentData),
+        },
       });
 
       await fetchGeneratedComponentFromCache(customId, testToken, testEdgeUrl);
@@ -1049,7 +1058,10 @@ describe('design library codegen', () => {
       fetchStub.resolves({
         status: 200,
         statusText: 'OK',
-        data: mockComponentData,
+        data: {
+          id: testId,
+          content: JSON.stringify(mockComponentData),
+        },
       });
 
       await fetchGeneratedComponentFromCache(testId, customToken, testEdgeUrl);
@@ -1062,7 +1074,10 @@ describe('design library codegen', () => {
       fetchStub.resolves({
         status: 200,
         statusText: 'OK',
-        data: mockComponentData,
+        data: {
+          id: testId,
+          content: JSON.stringify(mockComponentData),
+        },
       });
 
       await fetchGeneratedComponentFromCache(testId, testToken, testEdgeUrl);

--- a/packages/content/src/editing/codegen/preview.ts
+++ b/packages/content/src/editing/codegen/preview.ts
@@ -4,6 +4,7 @@ import { validateEvent, DesignLibraryEvent } from '../design-library';
 import debug from '../../debug';
 
 const { SITECORE_EDGE_PLATFORM_URL_DEFAULT } = constants;
+
 /**
  * Event to send import map to design library
  */
@@ -189,6 +190,21 @@ export enum DesignLibraryPreviewError {
    */
   RenderInit = 'render-init',
 }
+
+/**
+ * The generated component data response from the secured endpoint
+ * @internal
+ */
+type GeneratedComponentDataResponse = {
+  /**
+   * The unique identifier for the cache entry.
+   */
+  id: string;
+  /**
+   * The component data content in string format, which includes the component code, styles and imports.
+   */
+  content: string;
+};
 
 /**
  * Builds the component dependencies from the component imports and the import map.
@@ -516,7 +532,7 @@ export async function fetchGeneratedComponentFromCache(
 ): Promise<GeneratedComponentData> {
   const dataFetcher = new NativeDataFetcher({ debugger: debug.editing });
 
-  const componentDataResponse = await dataFetcher.fetch<GeneratedComponentData>(
+  const componentDataResponse = await dataFetcher.fetch<GeneratedComponentDataResponse>(
     `${edgeUrl}/authoring/api/v1/components/cache/${id}`,
     {
       method: 'GET',
@@ -532,5 +548,9 @@ export async function fetchGeneratedComponentFromCache(
     );
   }
 
-  return componentDataResponse.data;
+  const generatedComponentData = JSON.parse(
+    componentDataResponse.data.content
+  ) as GeneratedComponentData;
+
+  return generatedComponentData;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is a follow up to #369 . 
Fixes the result of `fetchGeneratedComponentFromCache` by properly parsing the response from the secured endpoint.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
