### PR TITLE
[chore] Consistent tools import path in next samples

### DIFF
--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/sitecore.cli.config.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/sitecore.cli.config.ts
@@ -4,7 +4,7 @@ import {
   generateMetadata,
   extractFiles,
   writeImportMap,
-} from '@sitecore-content-sdk/nextjs/node-tools';
+} from '@sitecore-content-sdk/nextjs/tools';
 import scConfig from './sitecore.config';
 
 export default defineCliConfig({
@@ -24,4 +24,3 @@ export default defineCliConfig({
     exclude: ['src/components/content-sdk/*'],
   },
 });
-

--- a/packages/create-content-sdk-app/src/templates/nextjs/sitecore.cli.config.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs/sitecore.cli.config.ts
@@ -5,7 +5,7 @@ import {
   generateMetadata,
   extractFiles,
   writeImportMap,
-} from '@sitecore-content-sdk/nextjs/node-tools';
+} from '@sitecore-content-sdk/nextjs/tools';
 
 export default defineCliConfig({
   config: scConfig,
@@ -25,4 +25,3 @@ export default defineCliConfig({
     exclude: ['src/components/content-sdk/*'],
   },
 });
-


### PR DESCRIPTION
Short follow up to https://github.com/Sitecore/content-sdk/pull/383 , to ensure next samples behave correctly.