### PR TITLE
[Chore] v2.0 release prep

### DIFF
--- a/.cursor/rules/sitecore.mdc
+++ b/.cursor/rules/sitecore.mdc
@@ -32,7 +32,10 @@ export default defineConfig({
     edge: {
       contextId: process.env.SITECORE_EDGE_CONTEXT_ID || '',
       clientContextId: process.env.NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID,
-      edgeUrl: process.env.SITECORE_EDGE_URL || 'https://edge-platform.sitecorecloud.io',
+      edgeUrl:
+        process.env.NEXT_PUBLIC_SITECORE_EDGE_PLATFORM_HOSTNAME ||
+        process.env.SITECORE_EDGE_PLATFORM_HOSTNAME ||
+        'https://edge-platform.sitecorecloud.io',
     },
     local: {
       apiKey: process.env.SITECORE_API_KEY || '',

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -234,7 +234,10 @@ export default defineConfig({
     edge: {
       contextId: process.env.SITECORE_EDGE_CONTEXT_ID || '',
       clientContextId: process.env.NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID,
-      edgeUrl: process.env.SITECORE_EDGE_URL || 'https://edge-platform.sitecorecloud.io',
+      edgeUrl:
+        process.env.NEXT_PUBLIC_SITECORE_EDGE_PLATFORM_HOSTNAME ||
+        process.env.SITECORE_EDGE_PLATFORM_HOSTNAME ||
+        'https://edge-platform.sitecorecloud.io',
     },
     local: {
       apiKey: process.env.SITECORE_API_KEY || '',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Our versioning strategy is as follows:
 - Minor: non-breaking feature additions – no breaking changes (e.g. new features, improvements)
 - Major: new features + breaking changes (e.g. framework upgrades, major architectural changes, major features)
 
-## Unreleased
+## 2.0.0
 
 ### 🎉 New Features & Improvements
 
@@ -64,7 +64,7 @@ Our versioning strategy is as follows:
   - `DesignLibrary` component now does not accept any props
   - `SitecoreProvider`'s `loadImportMap` is now required
 * [react] [nextjs] Major revamp of components in the react package ([#371](https://github.com/Sitecore/content-sdk/pull/371)):
-  - `Placeholder` and `AppPlaceholder` components' prop `modifyComponentProps` has been removed. `passThroughComponentProps` prop has been added to fill the role of passing props to child components
+  - `Placeholder` and `AppPlaceholder`, `passThroughComponentProps` prop has been added to fill make passing props to child components easier
   - `componentMap` and `loadImportMap` have been added to the context shared via `SitecoreProvider`
   - `useLoadImportMap`, `useComponentMap` HOCs have been removed. The Sitecore context data can be accessed via `useSitecore` hook.
   - `withSitecore`'s `updatePage` prop has been renamed to `setPage`. This HOC has also been marked deprecated, and will eventually be removed in favor of `useSitecore` hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ Our versioning strategy is as follows:
 
 * `[nextjs]` `[create-content-sdk-app]` Enable Next.js 16 Cache Components and Turbopack File System Caching ([#334](https://github.com/Sitecore/content-sdk/pull/334))
 
-* `[core]` `[content]` `[nextjs]` Support custom Edge hostnames via `SITECORE_EDGE_PLATFORM_HOSTNAME` (Next.js: `NEXT_PUBLIC_SITECORE_EDGE_PLATFORM_HOSTNAME`) ([#359](https://github.com/Sitecore/content-sdk/pull/359))
-  - New `rewriteMediaUrls` option: when `true`, rewrites layout media URLs to the custom Edge hostname; when a function, applies a custom string transformer.
-
 * Search integration ([#295](https://github.com/Sitecore/content-sdk/pull/295))
   * `[search]` New `@sitecore-content-sdk/search` package providing search functionality
     - `SearchService` class for performing search queries with support for pagination, sorting, request cancellation.
@@ -45,12 +42,18 @@ Our versioning strategy is as follows:
 
 ### 🛠 Breaking Changes
 
+* `[core]` `[content]` `[nextjs]` Support custom Edge hostnames via `SITECORE_EDGE_PLATFORM_HOSTNAME` (Next.js: `NEXT_PUBLIC_SITECORE_EDGE_PLATFORM_HOSTNAME`) ([#359](https://github.com/Sitecore/content-sdk/pull/359))
+  - New `rewriteMediaUrls` option: when `true`, rewrites layout media URLs to the custom Edge hostname; when a function, applies a custom string transformer.
+  - The old `SITECORE_EDGE_URL` environment variable is no longer used
+
 * Decouple `@sitecore-content-sdk/content` from `@sitecore-content-sdk/core` ([#351](https://github.com/Sitecore/content-sdk/pull/351)([#383](https://github.com/Sitecore/content-sdk/pull/383))):
   - See a detailed upgrade guide for migration instructions
+
 * `[nextjs]` `[create-content-sdk-app]` Upgrade to Next.js 16 ([#334](https://github.com/Sitecore/content-sdk/pull/334))([#343](https://github.com/Sitecore/content-sdk/pull/343))([#353](https://github.com/Sitecore/content-sdk/pull/353))
   - Next.js 16 is now required (minimum version `^16.0.0`)
   - `middleware.ts` renamed to `proxy.ts` with updated function signature
   - Removed deprecated `images.domains` usage (use `remotePatterns` instead)
+
 * `[nextjs]` Expand SXA redirects logic with support for isLanguagePreserved flag. This provides an option to preserve current locale when target redirect URL does not have a locale prefix ([#305](https://github.com/Sitecore/content-sdk/pull/305))
   - This changes the default redirects behavior out of the box.
     - Previously, `/da/source -> /target` rule would redirect to `/da/target` path when default locale is not `da`

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -208,7 +208,10 @@ export default defineConfig({
     edge: {
       contextId: process.env.SITECORE_EDGE_CONTEXT_ID || '',
       clientContextId: process.env.NEXT_PUBLIC_SITECORE_EDGE_CONTEXT_ID,
-      edgeUrl: process.env.SITECORE_EDGE_URL || 'https://edge-platform.sitecorecloud.io',
+      edgeUrl:
+        process.env.NEXT_PUBLIC_SITECORE_EDGE_PLATFORM_HOSTNAME ||
+        process.env.SITECORE_EDGE_PLATFORM_HOSTNAME ||
+        'https://edge-platform.sitecorecloud.io',
     },
     local: {
       apiKey: process.env.SITECORE_API_KEY || '',

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "2.0.0-canary.20",
+    "@sitecore-content-sdk/core": "^2.0.0",
     "debug": "^4.4.3"
   },
   "description": "Provides shared logic and runtime initialization. Required for the Content SDK 'events' and 'personalize' packages to function.",
@@ -73,5 +73,5 @@
     "api-extractor": "npm run build && api-extractor run --local --verbose",
     "api-extractor:verify": "api-extractor run"
   },
-  "version": "2.0.0-canary.20"
+  "version": "2.0.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/cli",
-  "version": "2.0.0-canary.20",
+  "version": "2.0.0",
   "description": "Sitecore Content SDK CLI",
   "main": "dist/cjs/cli.js",
   "module": "dist/esm/cli.js",
@@ -34,8 +34,8 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/content": "2.0.0-canary.20",
-    "@sitecore-content-sdk/core": "2.0.0-canary.20",
+    "@sitecore-content-sdk/content": "^2.0.0",
+    "@sitecore-content-sdk/core": "^2.0.0",
     "chokidar": "^4.0.3",
     "dotenv": "^16.5.0",
     "dotenv-expand": "^12.0.2",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -74,7 +74,7 @@
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
-    "@sitecore-content-sdk/events": "^2.0.0-canary"
+    "@sitecore-content-sdk/events": "^2.0.0"
   },
   "dependencies": {
     "@sitecore-content-sdk/core": "^2.0.0",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/content",
-  "version": "2.0.0-canary.20",
+  "version": "2.0.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -36,7 +36,7 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "devDependencies": {
-    "@sitecore-content-sdk/events": "2.0.0-canary.20",
+    "@sitecore-content-sdk/events": "^2.0.0",
     "@stylistic/eslint-plugin": "^5.2.2",
     "@types/chai": "^5.2.2",
     "@types/chai-spies": "^1.0.6",
@@ -77,7 +77,7 @@
     "@sitecore-content-sdk/events": "^2.0.0-canary"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "2.0.0-canary.20",
+    "@sitecore-content-sdk/core": "^2.0.0",
     "chalk": "^4.1.2",
     "debug": "^4.4.0",
     "glob": "^11.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/core",
-  "version": "2.0.0-canary.20",
+  "version": "2.0.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/packages/create-content-sdk-app/package.json
+++ b/packages/create-content-sdk-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-content-sdk-app",
-  "version": "2.0.0-canary.20",
+  "version": "2.0.0",
   "description": "Sitecore Content SDK initializer",
   "bin": "./dist/index.js",
   "scripts": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/Sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/analytics-core": "2.0.0-canary.20",
-    "@sitecore-content-sdk/core": "2.0.0-canary.20",
+    "@sitecore-content-sdk/analytics-core": "^2.0.0",
+    "@sitecore-content-sdk/core": "^2.0.0",
     "debug": "^4.4.3"
   },
   "description": "Enables real-time, unified tracking to send events to Sitecore.",
@@ -75,5 +75,5 @@
     "api-extractor": "npm run build && api-extractor run --local --verbose",
     "api-extractor:verify": "api-extractor run"
   },
-  "version": "2.0.0-canary.20"
+  "version": "2.0.0"
 }

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/nextjs",
-  "version": "2.0.0-canary.20",
+  "version": "2.0.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -32,8 +32,8 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "devDependencies": {
-    "@sitecore-content-sdk/analytics-core": "2.0.0-canary.20",
-    "@sitecore-content-sdk/personalize": "2.0.0-canary.20",
+    "@sitecore-content-sdk/analytics-core": "^2.0.0",
+    "@sitecore-content-sdk/personalize": "^2.0.0",
     "@stylistic/eslint-plugin": "^5.2.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.0",
@@ -91,9 +91,9 @@
   },
   "dependencies": {
     "@babel/parser": "^7.27.2",
-    "@sitecore-content-sdk/content": "2.0.0-canary.20",
-    "@sitecore-content-sdk/core": "2.0.0-canary.20",
-    "@sitecore-content-sdk/react": "2.0.0-canary.20",
+    "@sitecore-content-sdk/content": "^2.0.0",
+    "@sitecore-content-sdk/core": "^2.0.0",
+    "@sitecore-content-sdk/react": "^2.0.0",
     "recast": "^0.23.11",
     "regex-parser": "^2.3.1",
     "sync-disk-cache": "^2.1.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -76,9 +76,9 @@
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
-    "@sitecore-content-sdk/analytics-core": "^2.0.0-canary",
-    "@sitecore-content-sdk/events": "^2.0.0-canary",
-    "@sitecore-content-sdk/personalize": "^2.0.0-canary",
+    "@sitecore-content-sdk/analytics-core": "^2.0.0",
+    "@sitecore-content-sdk/events": "^2.0.0",
+    "@sitecore-content-sdk/personalize": "^2.0.0",
     "next": "^16.1.1",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/packages/personalize/package.json
+++ b/packages/personalize/package.json
@@ -7,9 +7,9 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/analytics-core": "2.0.0-canary.20",
-    "@sitecore-content-sdk/core": "2.0.0-canary.20",
-    "@sitecore-content-sdk/events": "2.0.0-canary.20",
+    "@sitecore-content-sdk/analytics-core": "^2.0.0",
+    "@sitecore-content-sdk/core": "^2.0.0",
+    "@sitecore-content-sdk/events": "^2.0.0",
     "debug": "^4.4.3"
   },
   "description": "Provides personalization capabilities to build tailored experiences for site visitors.",
@@ -70,5 +70,5 @@
     "api-extractor": "npm run build && api-extractor run --local --verbose",
     "api-extractor:verify": "api-extractor run"
   },
-  "version": "2.0.0-canary.20"
+  "version": "2.0.0"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/react",
-  "version": "2.0.0-canary.20",
+  "version": "2.0.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -77,9 +77,9 @@
     "react-dom": "^19.2.1"
   },
   "dependencies": {
-    "@sitecore-content-sdk/content": "2.0.0-canary.20",
-    "@sitecore-content-sdk/core": "2.0.0-canary.20",
-    "@sitecore-content-sdk/search": "0.2.0-canary.30",
+    "@sitecore-content-sdk/content": "^2.0.0",
+    "@sitecore-content-sdk/core": "^2.0.0",
+    "@sitecore-content-sdk/search": "^0.2.0",
     "fast-deep-equal": "^3.1.3"
   },
   "description": "",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,8 +70,8 @@
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
-    "@sitecore-content-sdk/analytics-core": "^2.0.0-canary",
-    "@sitecore-content-sdk/events": "^2.0.0-canary",
+    "@sitecore-content-sdk/analytics-core": "^2.0.0",
+    "@sitecore-content-sdk/events": "^2.0.0",
     "@sitecore-feaas/clientside": "^0.6.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-content-sdk/search",
-  "version": "0.2.0-canary.30",
+  "version": "0.2.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -36,7 +36,7 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "dependencies": {
-    "@sitecore-content-sdk/core": "2.0.0-canary.20"
+    "@sitecore-content-sdk/core": "^2.0.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,12 +3501,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sitecore-content-sdk/analytics-core@npm:2.0.0-canary.20, @sitecore-content-sdk/analytics-core@workspace:packages/analytics-core":
+"@sitecore-content-sdk/analytics-core@npm:^2.0.0, @sitecore-content-sdk/analytics-core@workspace:packages/analytics-core":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/analytics-core@workspace:packages/analytics-core"
   dependencies:
     "@jest/types": "npm:^29.6.3"
-    "@sitecore-content-sdk/core": "npm:2.0.0-canary.20"
+    "@sitecore-content-sdk/core": "npm:^2.0.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@types/debug": "npm:^4.1.12"
     "@types/jest": "npm:^29.5.12"
@@ -3531,8 +3531,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/cli@workspace:packages/cli"
   dependencies:
-    "@sitecore-content-sdk/content": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/core": "npm:2.0.0-canary.20"
+    "@sitecore-content-sdk/content": "npm:^2.0.0"
+    "@sitecore-content-sdk/core": "npm:^2.0.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@types/chai": "npm:^5.2.2"
     "@types/inquirer": "npm:^9.0.9"
@@ -3571,12 +3571,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/content@npm:2.0.0-canary.20, @sitecore-content-sdk/content@workspace:packages/content":
+"@sitecore-content-sdk/content@npm:^2.0.0, @sitecore-content-sdk/content@workspace:packages/content":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/content@workspace:packages/content"
   dependencies:
-    "@sitecore-content-sdk/core": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/events": "npm:2.0.0-canary.20"
+    "@sitecore-content-sdk/core": "npm:^2.0.0"
+    "@sitecore-content-sdk/events": "npm:^2.0.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@types/chai": "npm:^5.2.2"
     "@types/chai-spies": "npm:^1.0.6"
@@ -3622,7 +3622,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/core@npm:2.0.0-canary.20, @sitecore-content-sdk/core@workspace:packages/core":
+"@sitecore-content-sdk/core@npm:^2.0.0, @sitecore-content-sdk/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/core@workspace:packages/core"
   dependencies:
@@ -3662,14 +3662,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/events@npm:2.0.0-canary.20, @sitecore-content-sdk/events@workspace:packages/events":
+"@sitecore-content-sdk/events@npm:^2.0.0, @sitecore-content-sdk/events@workspace:packages/events":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/events@workspace:packages/events"
   dependencies:
     "@jest/globals": "npm:^30.2.0"
     "@jest/types": "npm:^29.6.3"
-    "@sitecore-content-sdk/analytics-core": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/core": "npm:2.0.0-canary.20"
+    "@sitecore-content-sdk/analytics-core": "npm:^2.0.0"
+    "@sitecore-content-sdk/core": "npm:^2.0.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@types/debug": "npm:^4.1.12"
     "@types/jest": "npm:^29.5.12"
@@ -3695,11 +3695,11 @@ __metadata:
   resolution: "@sitecore-content-sdk/nextjs@workspace:packages/nextjs"
   dependencies:
     "@babel/parser": "npm:^7.27.2"
-    "@sitecore-content-sdk/analytics-core": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/content": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/core": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/personalize": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/react": "npm:2.0.0-canary.20"
+    "@sitecore-content-sdk/analytics-core": "npm:^2.0.0"
+    "@sitecore-content-sdk/content": "npm:^2.0.0"
+    "@sitecore-content-sdk/core": "npm:^2.0.0"
+    "@sitecore-content-sdk/personalize": "npm:^2.0.0"
+    "@sitecore-content-sdk/react": "npm:^2.0.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/react": "npm:^16.3.0"
@@ -3757,14 +3757,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/personalize@npm:2.0.0-canary.20, @sitecore-content-sdk/personalize@workspace:packages/personalize":
+"@sitecore-content-sdk/personalize@npm:^2.0.0, @sitecore-content-sdk/personalize@workspace:packages/personalize":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/personalize@workspace:packages/personalize"
   dependencies:
     "@jest/types": "npm:^29.6.3"
-    "@sitecore-content-sdk/analytics-core": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/core": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/events": "npm:2.0.0-canary.20"
+    "@sitecore-content-sdk/analytics-core": "npm:^2.0.0"
+    "@sitecore-content-sdk/core": "npm:^2.0.0"
+    "@sitecore-content-sdk/events": "npm:^2.0.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@types/debug": "npm:^4.1.12"
     "@types/jest": "npm:^29.5.12"
@@ -3785,13 +3785,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/react@npm:2.0.0-canary.20, @sitecore-content-sdk/react@workspace:packages/react":
+"@sitecore-content-sdk/react@npm:^2.0.0, @sitecore-content-sdk/react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/react@workspace:packages/react"
   dependencies:
-    "@sitecore-content-sdk/content": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/core": "npm:2.0.0-canary.20"
-    "@sitecore-content-sdk/search": "npm:0.2.0-canary.30"
+    "@sitecore-content-sdk/content": "npm:^2.0.0"
+    "@sitecore-content-sdk/core": "npm:^2.0.0"
+    "@sitecore-content-sdk/search": "npm:^0.2.0"
     "@sitecore-feaas/clientside": "npm:^0.6.0"
     "@stylistic/eslint-plugin": "npm:^5.2.2"
     "@testing-library/dom": "npm:^10.4.0"
@@ -3838,11 +3838,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-content-sdk/search@npm:0.2.0-canary.30, @sitecore-content-sdk/search@workspace:packages/search":
+"@sitecore-content-sdk/search@npm:^0.2.0, @sitecore-content-sdk/search@workspace:packages/search":
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/search@workspace:packages/search"
   dependencies:
-    "@sitecore-content-sdk/core": "npm:2.0.0-canary.20"
+    "@sitecore-content-sdk/core": "npm:^2.0.0"
     "@types/chai": "npm:^5.2.3"
     "@types/mocha": "npm:^10.0.10"
     chai: "npm:^6.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3618,7 +3618,7 @@ __metadata:
     typescript: "npm:~5.8.3"
     url-parse: "npm:^1.5.10"
   peerDependencies:
-    "@sitecore-content-sdk/events": ^2.0.0-canary
+    "@sitecore-content-sdk/events": ^2.0.0
   languageName: unknown
   linkType: soft
 
@@ -3744,9 +3744,9 @@ __metadata:
     ts-node: "npm:^10.9.2"
     typescript: "npm:~5.8.3"
   peerDependencies:
-    "@sitecore-content-sdk/analytics-core": ^2.0.0-canary
-    "@sitecore-content-sdk/events": ^2.0.0-canary
-    "@sitecore-content-sdk/personalize": ^2.0.0-canary
+    "@sitecore-content-sdk/analytics-core": ^2.0.0
+    "@sitecore-content-sdk/events": ^2.0.0
+    "@sitecore-content-sdk/personalize": ^2.0.0
     next: ^16.1.1
     react: ^19.2.1
     react-dom: ^19.2.1
@@ -3830,8 +3830,8 @@ __metadata:
     ts-node: "npm:^10.9.2"
     typescript: "npm:~5.8.3"
   peerDependencies:
-    "@sitecore-content-sdk/analytics-core": ^2.0.0-canary
-    "@sitecore-content-sdk/events": ^2.0.0-canary
+    "@sitecore-content-sdk/analytics-core": ^2.0.0
+    "@sitecore-content-sdk/events": ^2.0.0
     "@sitecore-feaas/clientside": ^0.6.0
     react: ^19.2.1
     react-dom: ^19.2.1


### PR DESCRIPTION
- Graduate all canary package versions
- Add corresponding git tags
- Adjust changelog
- Sets the ground for applying the changeset release flow after release
- Prepares the repo for npm release publish