### PR TITLE
[content] Preview mode shows unpublishable content

### DIFF
--- a/.changeset/great-pianos-cut.md
+++ b/.changeset/great-pianos-cut.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/content': patch
+---
+
+Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,6 @@ Our versioning strategy is as follows:
 - Minor: non-breaking feature additions – no breaking changes (e.g. new features, improvements)
 - Major: new features + breaking changes (e.g. framework upgrades, major architectural changes, major features)
 
-## Unreleased
-
-### 🐛 Bug Fixes
-
-* `[content]` Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))
-
 ## 2.0.0
 
 ### 🎉 New Features & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Our versioning strategy is as follows:
 - Minor: non-breaking feature additions – no breaking changes (e.g. new features, improvements)
 - Major: new features + breaking changes (e.g. framework upgrades, major architectural changes, major features)
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+* `[content]` Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))
+
 ## 2.0.0
 
 ### 🎉 New Features & Improvements

--- a/packages/content/src/editing/editing-service.test.ts
+++ b/packages/content/src/editing/editing-service.test.ts
@@ -94,6 +94,7 @@ describe('EditingService', () => {
         headers: {
           sc_layoutKind: 'final',
           sc_editMode: 'true',
+          sc_previewMode: 'false',
         },
       }
     );
@@ -143,6 +144,7 @@ describe('EditingService', () => {
         headers: {
           sc_layoutKind: 'final',
           sc_editMode: 'false',
+          sc_previewMode: 'true',
         },
       }
     );
@@ -196,6 +198,7 @@ describe('EditingService', () => {
         headers: {
           sc_layoutKind: 'final',
           sc_editMode: 'true',
+          sc_previewMode: 'false',
         },
       }
     );
@@ -249,6 +252,7 @@ describe('EditingService', () => {
         headers: {
           sc_layoutKind: 'final',
           sc_editMode: 'true',
+          sc_previewMode: 'false',
         },
       }
     );
@@ -294,6 +298,7 @@ describe('EditingService', () => {
         headers: {
           sc_layoutKind: 'shared',
           sc_editMode: 'true',
+          sc_previewMode: 'false',
         },
       }
     );
@@ -401,12 +406,18 @@ describe('EditingService', () => {
     await service.fetchEditingData(editingOptions, fetchOptions);
 
     expect(requestMock.calledOnce).to.be.true;
-    expect(requestMock.firstCall.args[2]).to.deep.equal({
-      ...fetchOptions,
-      headers: {
-        sc_editMode: 'true',
-        sc_layoutKind: LayoutKind.Final,
-      },
+
+    const requestOptions = requestMock.firstCall.args[2];
+
+    expect(requestOptions.retries).to.equal(fetchOptions.retries);
+    expect(requestOptions.fetch).to.equal(fetchOptions.fetch);
+    expect(requestOptions.retryStrategy).to.equal(fetchOptions.retryStrategy);
+    expect(requestOptions.headers).to.deep.equal({
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+      sc_editMode: 'true',
+      sc_layoutKind: LayoutKind.Final,
+      sc_previewMode: 'false',
     });
   });
 });

--- a/packages/content/src/editing/editing-service.ts
+++ b/packages/content/src/editing/editing-service.ts
@@ -1,4 +1,8 @@
-import { GraphQLClient, GraphQLRequestClientFactory, FetchOptions } from '@sitecore-content-sdk/core';
+import {
+  GraphQLClient,
+  GraphQLRequestClientFactory,
+  FetchOptions,
+} from '@sitecore-content-sdk/core';
 import debug from '../debug';
 import { LayoutServiceData, LayoutServicePageState } from '../layout';
 import { LayoutKind } from './models';
@@ -83,6 +87,7 @@ export class EditingService {
     }
 
     const editModeHeader = mode === 'edit' ? 'true' : 'false';
+    const previewModeHeader = mode === 'preview' ? 'true' : 'false';
 
     const editingData = await this.graphQLClient.request<GraphQLEditingQueryResponse>(
       query,
@@ -94,8 +99,10 @@ export class EditingService {
       {
         ...fetchOptions,
         headers: {
+          ...fetchOptions?.headers,
           sc_layoutKind: layoutKind,
           sc_editMode: editModeHeader,
+          sc_previewMode: previewModeHeader,
         },
       }
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- To address the issue where viewing a page in preview mode shows unpublishable content, EditingService needs to pass the `sc-previewMode` header to instruct backend.
- Additionally fix a bug where the 'headers' prop of 'fetchOptions' is not properly passed through to the graphql client.


## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
