### PR TITLE
[content] Backend needs site context when handling preview requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Our versioning strategy is as follows:
 
 ## unreleased 
 
+### 🐛 Bug Fixes
+
 * Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
 
 ## 2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Our versioning strategy is as follows:
 - Minor: non-breaking feature additions – no breaking changes (e.g. new features, improvements)
 - Major: new features + breaking changes (e.g. framework upgrades, major architectural changes, major features)
 
+## unreleased 
+
+* Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
+
 ## 2.0.1
 
 ### ✨ Bug fixes

--- a/packages/content/api/content-sdk-content.api.md
+++ b/packages/content/api/content-sdk-content.api.md
@@ -333,6 +333,7 @@ export type EditingOptions = {
     version?: string;
     layoutKind?: LayoutKind;
     mode: Exclude<LayoutServicePageState, 'Normal'>;
+    site?: string;
 };
 
 // @public
@@ -373,7 +374,7 @@ export interface EditingRenderQueryParams {
 // @public
 export class EditingService {
     constructor(serviceConfig: EditingServiceConfig);
-    fetchEditingData({ itemId, language, version, layoutKind, mode }: EditingOptions, fetchOptions?: FetchOptions): Promise<{
+    fetchEditingData({ itemId, language, version, layoutKind, mode, site }: EditingOptions, fetchOptions?: FetchOptions): Promise<{
         layoutData: LayoutServiceData;
     }>;
     protected getGraphQLClient(): GraphQLClient;

--- a/packages/content/src/client/sitecore-client.test.ts
+++ b/packages/content/src/client/sitecore-client.test.ts
@@ -498,8 +498,7 @@ describe('SitecoreClient', () => {
         },
       };
       layoutServiceStub.fetchLayoutData.returns(rawLayout);
-      const stringTransformer = (value: string) =>
-        value === 'home' ? 'rewritten' : value;
+      const stringTransformer = (value: string) => (value === 'home' ? 'rewritten' : value);
       const clientWithRewrite = new SitecoreClient({
         ...defaultInitOptions,
         rewriteMediaUrls: stringTransformer,
@@ -537,9 +536,9 @@ describe('SitecoreClient', () => {
 
       const result = await clientWithRewrite.getPage(path, { locale });
 
-      expect(
-        (result?.layout.sitecore.route?.fields?.image?.value as { src: string }).src
-      ).to.equal('https://custom.example.com/-/media/hero.jpg');
+      expect((result?.layout.sitecore.route?.fields?.image?.value as { src: string }).src).to.equal(
+        'https://custom.example.com/-/media/hero.jpg'
+      );
       delete process.env[SITECORE_EXPERIENCE_EDGE_HOSTNAME_ENV];
     });
 
@@ -899,6 +898,7 @@ describe('SitecoreClient', () => {
           version: previewData.version,
           layoutKind: previewData.layoutKind,
           mode: previewData.mode,
+          site: previewData.site,
         })
       ).to.be.true;
     });
@@ -950,6 +950,7 @@ describe('SitecoreClient', () => {
           version: previewData.version,
           layoutKind: previewData.layoutKind,
           mode: previewData.mode,
+          site: previewData.site,
         })
       ).to.be.true;
     });
@@ -1049,6 +1050,7 @@ describe('SitecoreClient', () => {
           version: previewData.version,
           layoutKind: previewData.layoutKind,
           mode: previewData.mode,
+          site: previewData.site,
         })
         .resolves(editingData);
 
@@ -1062,6 +1064,7 @@ describe('SitecoreClient', () => {
             version: previewData.version,
             layoutKind: previewData.layoutKind,
             mode: previewData.mode,
+            site: previewData.site,
           },
           fetchOptions
         )

--- a/packages/content/src/client/sitecore-client.ts
+++ b/packages/content/src/client/sitecore-client.ts
@@ -477,12 +477,17 @@ export class SitecoreClient implements BaseSitecoreClient {
         version,
         layoutKind,
         mode,
+        site,
       },
       fetchOptions
     );
 
     if (!data) {
-      throw new Error(`Unable to fetch editing data for preview ${JSON.stringify(previewData)}. ${ERROR_MESSAGES.CONTACT_SUPPORT}`);
+      throw new Error(
+        `Unable to fetch editing data for preview ${JSON.stringify(previewData)}. ${
+          ERROR_MESSAGES.CONTACT_SUPPORT
+        }`
+      );
     }
     let layout = data.layoutData;
     const personalizeData = getGroomedVariantIds(variantIds);
@@ -536,7 +541,11 @@ export class SitecoreClient implements BaseSitecoreClient {
     );
 
     if (!componentData) {
-      throw new Error(`Unable to fetch editing data for preview ${JSON.stringify(designLibData)}. ${ERROR_MESSAGES.CONTACT_SUPPORT}`);
+      throw new Error(
+        `Unable to fetch editing data for preview ${JSON.stringify(designLibData)}. ${
+          ERROR_MESSAGES.CONTACT_SUPPORT
+        }`
+      );
     }
     const layout = this.applyContentRewrite(componentData);
     const page: Page = {

--- a/packages/content/src/editing/editing-service.test.ts
+++ b/packages/content/src/editing/editing-service.test.ts
@@ -119,11 +119,14 @@ describe('EditingService', () => {
 
     spy.on(clientFactorySpy.returnValues[0], 'request');
 
+    const site = 'test-site';
+
     const result = await service.fetchEditingData({
       language,
       version,
       itemId,
       mode: LayoutServicePageState.Preview,
+      site,
     });
 
     expect(clientFactorySpy.calledOnce).to.be.true;
@@ -145,6 +148,7 @@ describe('EditingService', () => {
           sc_layoutKind: 'final',
           sc_editMode: 'false',
           sc_previewMode: 'true',
+          sc_site: site,
         },
       }
     );

--- a/packages/content/src/editing/editing-service.ts
+++ b/packages/content/src/editing/editing-service.ts
@@ -47,6 +47,7 @@ export type EditingOptions = {
   version?: string;
   layoutKind?: LayoutKind;
   mode: Exclude<LayoutServicePageState, 'Normal'>;
+  site?: string;
 };
 
 /**
@@ -73,11 +74,12 @@ export class EditingService {
    * @param {string} variables.mode - The editing mode to fetch layout data for.
    * @param {string} [variables.version] - The version of the item (optional).
    * @param {LayoutKind} [variables.layoutKind] - The final or shared layout variant.
+   * @param {string} [variables.site] - The site context for fetching layout data (optional).
    * @param {FetchOptions} [fetchOptions] Options to override graphQL client details like retries and fetch implementation
    * @returns {Promise} The layout data and dictionary phrases.
    */
   async fetchEditingData(
-    { itemId, language, version, layoutKind = LayoutKind.Final, mode }: EditingOptions,
+    { itemId, language, version, layoutKind = LayoutKind.Final, mode, site }: EditingOptions,
     fetchOptions?: FetchOptions
   ) {
     debug.editing('fetching editing data for %s %s %s %s', itemId, language, version, layoutKind);
@@ -103,6 +105,7 @@ export class EditingService {
           sc_layoutKind: layoutKind,
           sc_editMode: editModeHeader,
           sc_previewMode: previewModeHeader,
+          ...(site && { sc_site: site }),
         },
       }
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to pass `sc_site` header to preview requests, so that backend could use site specific settings (`previewUnpublishableItems`) and workflows that influence what can be viewed in preview mode

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
