### PR TITLE
Add redirect handled callback

### DIFF
--- a/packages/nextjs/src/proxy/redirects-proxy.test.ts
+++ b/packages/nextjs/src/proxy/redirects-proxy.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@sitecore-content-sdk/content/site';
 import chai, { use } from 'chai';
 import chaiString from 'chai-string';
-import { NextRequest, NextResponse } from 'next/server';
+import nextjs, { NextRequest, NextResponse } from 'next/server';
 import sinon, { spy } from 'sinon';
 import sinonChai from 'sinon-chai';
 import { RedirectsProxy, RedirectsProxyConfig } from './redirects-proxy';
@@ -48,6 +48,7 @@ describe('RedirectsProxy', () => {
 
   let nextRedirectStub: sinon.SinonStub;
   let nextRewriteStub: sinon.SinonStub;
+  let afterStub: sinon.SinonStub;
 
   const sandbox = sinon.createSandbox();
 
@@ -314,12 +315,14 @@ describe('RedirectsProxy', () => {
   before(() => {
     nextRedirectStub = sandbox.stub(NextResponse, 'redirect');
     nextRewriteStub = sandbox.stub(NextResponse, 'rewrite');
+    afterStub = sandbox.stub(nextjs, 'after');
   });
 
   beforeEach(() => {
     debugSpy.resetHistory();
     nextRedirectStub.reset();
     nextRewriteStub.reset();
+    afterStub.reset();
     // Reset the stubs to return undefined by default, tests will override
     nextRedirectStub.returns(undefined);
     nextRewriteStub.returns(undefined);
@@ -328,6 +331,7 @@ describe('RedirectsProxy', () => {
   after(() => {
     nextRedirectStub.restore();
     nextRewriteStub.restore();
+    afterStub.restore();
   });
 
   describe('request skipped', () => {
@@ -923,6 +927,35 @@ describe('RedirectsProxy', () => {
       expect(nextRedirectStub.calledOnce).to.be.true;
       expect(finalRes.redirected).to.be.true;
       expect(finalRes.status).to.equal(301);
+    });
+
+    it('should call redirectHandled callback if provided for', async () => {
+      const req = createRequest();
+      const res = createResponse();
+
+      const redirectHandled = sandbox.stub();
+      const { proxy } = createProxy({
+        redirectsProxyConfig: { redirectHandled },
+        target: 'https://example.com/new-page',
+      });
+
+      afterStub.callsFake((callback) => {
+        if (typeof callback === 'function') {
+          callback();
+        }
+      });
+
+      await proxy.handle(req, res);
+
+      const firstArg = redirectHandled.getCall(0).args[0];
+      const secondArg = redirectHandled.getCall(0).args[1];
+      expect(redirectHandled.calledOnce).to.be.true;
+      expect(firstArg).to.deep.equal(req);
+      expect(secondArg).to.deep.equal({
+        target: 'https://example.com/new-page',
+        type: REDIRECT_TYPE_301,
+        isExternal: true,
+      });
     });
   });
 

--- a/packages/nextjs/src/proxy/redirects-proxy.ts
+++ b/packages/nextjs/src/proxy/redirects-proxy.ts
@@ -14,7 +14,7 @@ import {
   mergeURLSearchParams,
 } from '@sitecore-content-sdk/core/tools';
 import { NextURL } from 'next/dist/server/web/next-url';
-import { NextRequest, NextResponse } from 'next/server';
+import { after, NextRequest, NextResponse } from 'next/server';
 import regexParser from 'regex-parser';
 import { ProxyBase, ProxyBaseConfig, REWRITE_HEADER_NAME } from './proxy';
 import { SitecoreConfig } from '../config';
@@ -24,6 +24,12 @@ const REGEXP_CONTEXT_SITE_LANG = new RegExp(/\$siteLang/, 'i');
 const REGEXP_ABSOLUTE_URL = new RegExp('^(?:[a-z]+:)?//', 'i');
 
 type RedirectResult = RedirectInfo & { matchedQueryString?: string };
+
+type HandledRedirectInfo = {
+  target: NextURL | string;
+  type: string;
+  isExternal: boolean;
+};
 
 /**
  * The interface for the RedirectsProxy configuration.
@@ -35,6 +41,7 @@ export type RedirectsProxyConfig = Omit<RedirectsServiceConfig, 'fetch' | 'clien
   ProxyBaseConfig &
   SitecoreConfig['redirects'] & {
     redirectsService?: RedirectsService;
+    redirectHandled?: (req: NextRequest, redirect: HandledRedirectInfo) => Promise<void> | void;
   };
 /**
  * Proxy / handler fetches all redirects from Sitecore instance by grapqhl service
@@ -440,6 +447,11 @@ export class RedirectsProxy extends ProxyBase {
     res: NextResponse,
     isExternal = false
   ): NextResponse {
+    if (this.config.redirectHandled) {
+      const redirectHandled = this.config.redirectHandled;
+      after(() => redirectHandled(req, { target, type, isExternal }));
+    }
+
     switch (type) {
       case REDIRECT_TYPE_301:
         return this.createRedirectResponse(target, res, 301, 'Moved Permanently');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a redirect handled callback so that analytics can be collected for redirects. This is a POC implementation of https://github.com/Sitecore/content-sdk/discussions/420.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. Added an optional redirectHandled parameter to RedirectsProxyConfig
2. Added a HandledRedirectInfo type to represent the handled redirect that is passed to the callback
3. Added a check to the dispatchRedirect method to call the redirectHandled callback if provided. It uses the Vercel [after](https://nextjs.org/docs/app/api-reference/functions/after) function so that it doesn't block the proxy 

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a unit test to validate that callback is called when supplied.

- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
