### PR TITLE
[nextjs] NextLink is throwing Locale error in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Our versioning strategy is as follows:
 
 * Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
 * `[core] [content]` Fix GraphQL client factory ignoring custom `fetch` and related options ([#418](https://github.com/Sitecore/content-sdk/pull/418))
+* `[nextjs]` AppRouter - NextLink is throwing Locale error in dev mode ([#427](https://github.com/Sitecore/content-sdk/pull/427))
 
 ## 2.0.1
 

--- a/packages/nextjs/src/components/Link.test.tsx
+++ b/packages/nextjs/src/components/Link.test.tsx
@@ -400,7 +400,7 @@ describe('<Link />', () => {
     expect(rendered.container.innerHTML).to.have.length(0);
   });
 
-  describe.only('Locale', () => {
+  describe('Locale', () => {
     it('should set locale to false when Pages Router is available', () => {
       const field = {
         value: {

--- a/packages/nextjs/src/components/Link.test.tsx
+++ b/packages/nextjs/src/components/Link.test.tsx
@@ -400,6 +400,42 @@ describe('<Link />', () => {
     expect(rendered.container.innerHTML).to.have.length(0);
   });
 
+  describe.only('Locale', () => {
+    it('should set locale to false when Pages Router is available', () => {
+      const field = {
+        value: {
+          href: '/lorem',
+          text: 'ipsum',
+        },
+      };
+
+      const rendered = render(
+        <Page>
+          <Link field={field} />
+        </Page>
+      );
+
+      const link = rendered.container.querySelector('a');
+      expect(link?.getAttribute('data-nextjs-link')).to.equal('true');
+      expect(link?.getAttribute('data-nextjs-locale')).to.equal('false');
+    });
+
+    it('should not set locale when Pages Router is not available', () => {
+      const field = {
+        value: {
+          href: '/lorem',
+          text: 'ipsum',
+        },
+      };
+
+      const rendered = render(<Link field={field} />);
+
+      const link = rendered.container.querySelector('a');
+      expect(link?.getAttribute('data-nextjs-link')).to.equal('true');
+      expect(link?.getAttribute('data-nextjs-locale')).to.equal(null);
+    });
+  });
+
   describe('editMode metadata', () => {
     const testMetadata = {
       contextItem: {

--- a/packages/nextjs/src/components/Link.tsx
+++ b/packages/nextjs/src/components/Link.tsx
@@ -7,6 +7,7 @@ import {
   LinkField,
   LinkProps as ReactLinkProps,
 } from '@sitecore-content-sdk/react';
+import { useRouter as usePageRouter } from 'next/compat/router';
 
 /**
  * The list of NextLink props to be supported by the Link component.
@@ -44,6 +45,8 @@ const FILE_EXTENSION_MATCHER = /^\/.*\.\w+$/;
  */
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
   (props: LinkProps, ref): JSX.Element | null => {
+    const pageRouter = usePageRouter();
+
     const {
       field,
       editable = true,
@@ -81,7 +84,8 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             target={value.target}
             className={value.class}
             {...rest}
-            locale={false}
+            // locale prop is supported only in Pages Router
+            locale={pageRouter ? false : undefined}
             ref={ref}
             {...(process.env.TEST
               ? {

--- a/packages/nextjs/src/components/Link.tsx
+++ b/packages/nextjs/src/components/Link.tsx
@@ -91,6 +91,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
               ? {
                   'data-nextjs-link': true,
                   'data-nextjs-prefetch': props.prefetch,
+                  'data-nextjs-locale': pageRouter ? false : undefined,
                 }
               : {})}
           >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- Used `useRouter` from `next/compat/router` to verify if the app runs on Pages or App router
  - Set to `false` if Pages router
  - Set to `undefined` if App router

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
