### PR TITLE
[Lightweight Tracking] Prevent sending Form event when user is Bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[events]` `[nextjs]` Lightweight Tracking ([#414](https://github.com/Sitecore/content-sdk/pull/414))([#435](https://github.com/Sitecore/content-sdk/pull/435))([#438](https://github.com/Sitecore/content-sdk/pull/438))([#443](https://github.com/Sitecore/content-sdk/pull/443))
+* `[events]` `[nextjs]` Lightweight Tracking ([#414](https://github.com/Sitecore/content-sdk/pull/414))([#435](https://github.com/Sitecore/content-sdk/pull/435))([#438](https://github.com/Sitecore/content-sdk/pull/438))([#443](https://github.com/Sitecore/content-sdk/pull/443))([#444](https://github.com/Sitecore/content-sdk/pull/444))
   - Introduced `BotTrackingProxy` Next.js proxy to capture bot tracking events.
 * `[nextjs]` Upgrade to Next.js 16.2 ([#429](https://github.com/Sitecore/content-sdk/pull/429))
 * `[create-content-sdk-app]` Use native flat ESLint config for App Router templates ([#431](https://github.com/Sitecore/content-sdk/pull/431))

--- a/packages/analytics-core/api/content-sdk-analytics-core.api.md
+++ b/packages/analytics-core/api/content-sdk-analytics-core.api.md
@@ -180,12 +180,6 @@ export function generateV4UUID(): string;
 // @internal
 export function getAnalyticsPlugin(): AnalyticsPlugin;
 
-// @internal
-export function getBotCookieClientSide(): string | undefined;
-
-// @internal
-export function getBotCookieServerSide(cookie?: string): string | undefined;
-
 // @public
 export function getClientId(): string;
 
@@ -217,6 +211,12 @@ export interface Infer {
 
 // @internal
 export const isBot: (userAgent?: string | null) => boolean;
+
+// @internal
+export const isBotClientSide: () => boolean;
+
+// @internal
+export const isBotServerSide: (cookie?: string, userAgent?: string | null) => boolean;
 
 // @internal
 export function isShortISODateString(date: string): boolean;

--- a/packages/analytics-core/src/bot-detection/bot-detection.ts
+++ b/packages/analytics-core/src/bot-detection/bot-detection.ts
@@ -9,12 +9,37 @@ export const BOT_DETECTION_COOKIE = 'sc_bot';
 
 /**
  * A function that checks if visitor is a bot.
+ * Performs a check based on the user agent.
  * @param {string} userAgent - The user agent of the visitor
  * @returns {boolean} True if the visitor is a bot, false otherwise
  * @internal
  */
 export const isBot = (userAgent?: string | null): boolean => {
   return isbot(userAgent);
+};
+
+/**
+ * A function that checks if visitor is a bot.
+ * Performs a check based on the bot cookie and the user agent.
+ * Only available on the client-side.
+ * @returns {boolean} True if the visitor is a bot, false otherwise
+ * @internal
+ */
+export const isBotClientSide = (): boolean => {
+  return !!getBotCookieClientSide() || isbot(navigator.userAgent);
+};
+
+/**
+ * A function that checks if visitor is a bot.
+ * Performs a check based on the bot cookie and the user agent.
+ * Only available on the server-side.
+ * @param {string} cookie - The cookie string.
+ * @param {string} userAgent - The user agent of the visitor
+ * @returns {boolean} True if the visitor is a bot, false otherwise
+ * @internal
+ */
+export const isBotServerSide = (cookie?: string, userAgent?: string | null): boolean => {
+  return !!getBotCookieServerSide(cookie) || isbot(userAgent);
 };
 
 /**

--- a/packages/analytics-core/src/initialization/browser-adapter.spec.ts
+++ b/packages/analytics-core/src/initialization/browser-adapter.spec.ts
@@ -13,8 +13,7 @@ jest.mock('@sitecore-content-sdk/core', () => ({
 }));
 
 jest.mock('../bot-detection/bot-detection', () => ({
-  isBot: jest.fn(),
-  getBotCookieClientSide: jest.fn(),
+  isBotClientSide: jest.fn(),
 }));
 
 jest.mock('./plugin', () => ({
@@ -84,7 +83,7 @@ describe('analyticsBrowserAdapter', () => {
 
   describe('isBot', () => {
     it('should return true when isBot returns true', () => {
-      (botDetectionModule.isBot as jest.Mock).mockReturnValue(true);
+      (botDetectionModule.isBotClientSide as jest.Mock).mockReturnValue(true);
 
       const adapter = analyticsBrowserAdapter();
       const result = adapter.isBot?.();
@@ -93,22 +92,12 @@ describe('analyticsBrowserAdapter', () => {
     });
 
     it('should return false when isBot returns false', () => {
-      (botDetectionModule.isBot as jest.Mock).mockReturnValue(false);
+      (botDetectionModule.isBotClientSide as jest.Mock).mockReturnValue(false);
 
       const adapter = analyticsBrowserAdapter();
       const result = adapter.isBot?.();
 
       expect(result).toBe(false);
-    });
-
-    it('should return true when bot cookie is set', () => {
-      (botDetectionModule.getBotCookieClientSide as jest.Mock).mockReturnValue('1');
-      (botDetectionModule.isBot as jest.Mock).mockReturnValue(false);
-
-      const adapter = analyticsBrowserAdapter();
-      const result = adapter.isBot?.();
-
-      expect(result).toBe(true);
     });
   });
 

--- a/packages/analytics-core/src/initialization/browser-adapter.ts
+++ b/packages/analytics-core/src/initialization/browser-adapter.ts
@@ -1,4 +1,4 @@
-import { getBotCookieClientSide, isBot } from '../bot-detection/bot-detection';
+import { isBotClientSide } from '../bot-detection/bot-detection';
 import {
   COOKIE_NAME_PREFIX,
   fetchClientIdFromEdgeProxy,
@@ -32,8 +32,7 @@ export function analyticsBrowserAdapter(): AnalyticsBrowserAdapter {
   return {
     type: 'browser',
     isBot: () => {
-      const botCookie = getBotCookieClientSide();
-      return !!botCookie || isBot(navigator.userAgent);
+      return isBotClientSide();
     },
     getClientId: () => {
       return getCookieValueClientSide(getAnalyticsPlugin().options.cookies.name);

--- a/packages/analytics-core/src/initialization/server-adapter.spec.ts
+++ b/packages/analytics-core/src/initialization/server-adapter.spec.ts
@@ -13,8 +13,7 @@ jest.mock('@sitecore-content-sdk/core', () => ({
 }));
 
 jest.mock('../bot-detection/bot-detection', () => ({
-  isBot: jest.fn(),
-  getBotCookieServerSide: jest.fn(),
+  isBotServerSide: jest.fn(),
 }));
 
 jest.mock('./plugin', () => ({
@@ -101,7 +100,7 @@ describe('analyticsServerAdapter', () => {
 
   describe('isBot', () => {
     it('should return true when isBot returns true', () => {
-      (botDetectionModule.isBot as jest.Mock).mockReturnValue(true);
+      (botDetectionModule.isBotServerSide as jest.Mock).mockReturnValue(true);
 
       const adapter = analyticsServerAdapter(createMockRequest(), createMockResponse());
       const result = adapter.isBot?.();
@@ -110,22 +109,12 @@ describe('analyticsServerAdapter', () => {
     });
     
     it('should return false when isBot returns false', () => {
-      (botDetectionModule.isBot as jest.Mock).mockReturnValue(false);
+      (botDetectionModule.isBotServerSide as jest.Mock).mockReturnValue(false);
 
       const adapter = analyticsServerAdapter(createMockRequest(), createMockResponse());
       const result = adapter.isBot?.();
 
       expect(result).toBe(false);
-    });
-    
-    it('should return true when bot cookie is set', () => {
-      (botDetectionModule.getBotCookieServerSide as jest.Mock).mockReturnValue('1');
-      (botDetectionModule.isBot as jest.Mock).mockReturnValue(false);
-
-      const adapter = analyticsServerAdapter(createMockRequest(), createMockResponse());
-      const result = adapter.isBot?.();
-
-      expect(result).toBe(true);
     });
   });
 

--- a/packages/analytics-core/src/initialization/server-adapter.ts
+++ b/packages/analytics-core/src/initialization/server-adapter.ts
@@ -1,4 +1,4 @@
-import { getBotCookieServerSide, isBot } from '../bot-detection/bot-detection';
+import { isBotServerSide } from '../bot-detection/bot-detection';
 import {
   COOKIE_NAME_PREFIX,
   fetchClientIdFromEdgeProxy,
@@ -39,8 +39,7 @@ export function analyticsServerAdapter<
   return {
     type: 'server',
     isBot: () => {
-      const botCookie = getBotCookieServerSide(request.headers.cookie);
-      return !!botCookie || isBot(request.headers['user-agent']);
+      return isBotServerSide(request.headers.cookie, request.headers['user-agent']);
     },
     getClientId: () => {
       return getClientId(request);

--- a/packages/analytics-core/src/internal.ts
+++ b/packages/analytics-core/src/internal.ts
@@ -23,4 +23,4 @@ export type { AnalyticsPlugin } from './initialization/types';
 export { AnalyticsAdapter, AnalyticsOptions } from './initialization/types';
 export type { VisitorIds } from './interfaces';
 
-export { isBot, getBotCookieServerSide, getBotCookieClientSide, BOT_DETECTION_COOKIE } from './bot-detection/bot-detection';
+export { isBot, isBotClientSide, isBotServerSide, BOT_DETECTION_COOKIE } from './bot-detection/bot-detection';

--- a/packages/nextjs/src/initialization/proxy/analytics-adapter.test.ts
+++ b/packages/nextjs/src/initialization/proxy/analytics-adapter.test.ts
@@ -16,8 +16,7 @@ describe('analyticsProxyAdapter', () => {
   let getCoreContextStub: sinon.SinonStub;
   let getDefaultCookieAttributesStub: sinon.SinonStub;
   let fetchClientIdFromEdgeProxyStub: sinon.SinonStub;
-  let getBotCookieServerSideStub: sinon.SinonStub;
-  let isBotStub: sinon.SinonStub;
+  let isBotServerSideStub: sinon.SinonStub;
 
   const mockAnalyticsPlugin = {
     options: {
@@ -99,8 +98,7 @@ describe('analyticsProxyAdapter', () => {
     getCoreContextStub = sandbox.stub().returns(mockCoreContext);
     getDefaultCookieAttributesStub = sandbox.stub().returns(mockCookieAttributes);
     fetchClientIdFromEdgeProxyStub = sandbox.stub();
-    getBotCookieServerSideStub = sandbox.stub();
-    isBotStub = sandbox.stub();
+    isBotServerSideStub = sandbox.stub();
 
     analyticsProxyAdapterModule = proxyquire('./analytics-adapter', {
       '@sitecore-content-sdk/core': {
@@ -111,8 +109,7 @@ describe('analyticsProxyAdapter', () => {
         getDefaultCookieAttributes: getDefaultCookieAttributesStub,
         fetchClientIdFromEdgeProxy: fetchClientIdFromEdgeProxyStub,
         getAnalyticsPlugin: getAnalyticsPluginStub,
-        getBotCookieServerSide: getBotCookieServerSideStub,
-        isBot: isBotStub,
+        isBotServerSide: isBotServerSideStub,
       },
     });
   });
@@ -170,8 +167,8 @@ describe('analyticsProxyAdapter', () => {
     });
 
     describe('isBot', () => {
-      it('should return true when bot cookie is set', () => {
-        getBotCookieServerSideStub.returns('1');
+      it('should return true when isBotServerSide returns true', () => {
+        isBotServerSideStub.returns(true);
         const request = createMockRequest({});
         const response = createMockResponse();
 
@@ -181,9 +178,8 @@ describe('analyticsProxyAdapter', () => {
         expect(result).to.be.true;
       });
 
-      it('should return false when bot cookie is not set', () => {
-        getBotCookieServerSideStub.returns(null);
-        isBotStub.returns(false);
+      it('should return false when isBotServerSide returns false', () => {
+        isBotServerSideStub.returns(false);
 
         const request = createMockRequest({});
         const response = createMockResponse();
@@ -192,16 +188,6 @@ describe('analyticsProxyAdapter', () => {
         const result = adapter.isBot?.();
 
         expect(result).to.be.false;
-      });
-
-      it('should return true when isBot returns true', () => {
-        isBotStub.returns(true);
-        const request = createMockRequest({});
-        const response = createMockResponse();
-
-        const adapter = analyticsProxyAdapterModule.analyticsProxyAdapter(request, response);
-        const result = adapter.isBot?.();
-        expect(result).to.be.true;
       });
     });
 

--- a/packages/nextjs/src/initialization/proxy/analytics-adapter.ts
+++ b/packages/nextjs/src/initialization/proxy/analytics-adapter.ts
@@ -1,11 +1,10 @@
 import {
   COOKIE_NAME_PREFIX,
   fetchClientIdFromEdgeProxy,
-  getBotCookieServerSide,
+  isBotServerSide,
   getDefaultCookieAttributes,
   getAnalyticsPlugin,
   AnalyticsAdapter,
-  isBot,
 } from '@sitecore-content-sdk/analytics-core/internal';
 import { getCoreContext } from '@sitecore-content-sdk/core';
 import { NextRequest, NextResponse } from 'next/server';
@@ -37,8 +36,7 @@ export function analyticsProxyAdapter(
   return {
     type: 'proxy',
     isBot: () => {
-      const botCookie = getBotCookieServerSide(request.cookies.toString());
-      return !!botCookie || isBot(request.headers.get('user-agent'));
+      return isBotServerSide(request.cookies.toString(), request.headers.get('user-agent'));
     },
     getClientId: () => {
       return getClientId(request);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/sitecore/content-sdk/issues"
   },
   "devDependencies": {
+    "@sitecore-content-sdk/analytics-core": "2.1.0-canary.10",
     "@sitecore-feaas/clientside": "^0.6.0",
     "@stylistic/eslint-plugin": "^5.2.2",
     "@testing-library/dom": "^10.4.0",

--- a/packages/react/src/components/Form.test.tsx
+++ b/packages/react/src/components/Form.test.tsx
@@ -4,7 +4,7 @@ import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { expect } from 'chai';
 import { SitecoreProvider } from './SitecoreProvider';
-import { Form, mockFormModule } from './Form';
+import { Form, mockFormModule, mockAnalyticsInternalModule } from './Form';
 import sinon from 'sinon';
 import { PageMode } from '@sitecore-content-sdk/content/client';
 import { LayoutServicePageState } from '@sitecore-content-sdk/content/layout';
@@ -80,11 +80,16 @@ describe('Form', () => {
 
     const subscribeSpy = sinon.spy();
     const execSpy = sinon.spy();
+    const isBotClientSideSpy = sinon.stub().returns(false);
 
     mockFormModule({
       loadForm: loadFormSpy,
       subscribeToFormSubmitEvent: subscribeSpy,
       executeScriptElements: execSpy,
+    });
+
+    mockAnalyticsInternalModule({
+      isBotClientSide: isBotClientSideSpy,
     });
 
     const rendered = await render(
@@ -117,10 +122,16 @@ describe('Form', () => {
       return Promise.resolve('<form></form>');
     });
 
+    const isBotClientSideSpy = sinon.stub().returns(false);
+
     mockFormModule({
       loadForm: loadFormSpy,
       subscribeToFormSubmitEvent: sinon.spy(),
       executeScriptElements: sinon.spy(),
+    });
+
+    mockAnalyticsInternalModule({
+      isBotClientSide: isBotClientSideSpy,
     });
 
     const rendered = await render(
@@ -141,16 +152,16 @@ describe('Form', () => {
       .resolves('<form id="test-form"><script>console.log(1);</script></form>');
     const subscribeSpy = sinon.spy();
     const execSpy = sinon.spy();
-
-    const mode: PageMode = {
-      name: LayoutServicePageState.Edit,
-      isEditing: true,
-    };
+    const isBotClientSideSpy = sinon.stub().returns(false);
 
     mockFormModule({
       loadForm: loadFormSpy,
       subscribeToFormSubmitEvent: subscribeSpy,
       executeScriptElements: execSpy,
+    });
+
+    mockAnalyticsInternalModule({
+      isBotClientSide: isBotClientSideSpy,
     });
 
     const rendered = await render(
@@ -168,11 +179,46 @@ describe('Form', () => {
     });
   });
 
+  it('does not subscribe to form submit event if visitor is a bot', async () => {
+    const subscribeSpy = sinon.spy();
+    const execSpy = sinon.spy();
+    const isBotClientSideSpy = sinon.stub().returns(true);
+
+    mockFormModule({
+      loadForm: sinon.stub().resolves('<form id="test-form"><script>console.log(1);</script></form>'),
+      subscribeToFormSubmitEvent: subscribeSpy,
+      executeScriptElements: execSpy,
+    });
+
+    mockAnalyticsInternalModule({
+      isBotClientSide: isBotClientSideSpy,
+    });
+
+    const rendered = await render(
+      <SitecoreProvider api={ctx.api} page={ctx.page.normal}>
+        <Form rendering={rendering} params={rendering.params} />
+      </SitecoreProvider>
+    );
+
+    await waitFor(() => {
+      expect(subscribeSpy.notCalled).to.be.true;
+      expect(execSpy.calledOnce).to.be.true;
+
+      expect(rendered.container.innerHTML).to.contain('<form id="test-form">');
+    });
+  });
+
   it('renders empty component on load failure (non-edit mode)', async () => {
+    const isBotClientSideSpy = sinon.stub().returns(false);
+
     mockFormModule({
       loadForm: sinon.stub().rejects(),
       subscribeToFormSubmitEvent: sinon.spy(),
       executeScriptElements: sinon.spy(),
+    });
+
+    mockAnalyticsInternalModule({
+      isBotClientSide: isBotClientSideSpy,
     });
 
     const rendered = await render(
@@ -187,10 +233,16 @@ describe('Form', () => {
   });
 
   it('renders edit-mode error placeholder on load failure', async () => {
+    const isBotClientSideSpy = sinon.stub().returns(false);
+
     mockFormModule({
       loadForm: sinon.stub().rejects(),
       subscribeToFormSubmitEvent: sinon.spy(),
       executeScriptElements: sinon.spy(),
+    });
+
+    mockAnalyticsInternalModule({
+      isBotClientSide: isBotClientSideSpy,
     });
 
     const mode: PageMode = {

--- a/packages/react/src/components/Form.tsx
+++ b/packages/react/src/components/Form.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useEffect, useRef, useState } from 'react';
 import { ComponentRendering } from '@sitecore-content-sdk/content/layout';
+import * as analyticsCoreInternalModule from '@sitecore-content-sdk/analytics-core/internal';
 import { form } from '@sitecore-content-sdk/content';
 import { constants } from '@sitecore-content-sdk/core';
 import { useSitecore } from './SitecoreProvider';
@@ -9,6 +10,7 @@ import { ErrorComponent } from './ErrorBoundary';
 const { ERROR_MESSAGES } = constants;
 
 let { executeScriptElements, loadForm, subscribeToFormSubmitEvent } = form;
+let { isBotClientSide } = analyticsCoreInternalModule;
 
 /**
  * Mock function to replace the form module functions for `testing` purposes.
@@ -18,6 +20,10 @@ export const mockFormModule = (formModule: any) => {
   executeScriptElements = formModule.executeScriptElements;
   loadForm = formModule.loadForm;
   subscribeToFormSubmitEvent = formModule.subscribeToFormSubmitEvent;
+};
+
+export const mockAnalyticsInternalModule = (analyticsCoreInternalModule: any) => {
+  isBotClientSide = analyticsCoreInternalModule.isBotClientSide;
 };
 
 /**
@@ -81,7 +87,7 @@ export const Form = ({ params, rendering }: FormProps) => {
       if (!formRef.current) return;
 
       // If we are in editing mode, we don't want to send any events
-      if (!isEditing) {
+      if (!isEditing && !isBotClientSide()) {
         subscribeToFormSubmitEvent(formRef.current, rendering.uid);
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3804,6 +3804,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-content-sdk/react@workspace:packages/react"
   dependencies:
+    "@sitecore-content-sdk/analytics-core": "npm:2.1.0-canary.10"
     "@sitecore-content-sdk/content": "npm:2.1.0-canary.10"
     "@sitecore-content-sdk/core": "npm:2.1.0-canary.10"
     "@sitecore-content-sdk/search": "npm:0.2.2-canary.19"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Prevent sending Form event when user is Bot
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
