### PR TITLE
[react] Preserve form state and interactivity between rerenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Our versioning strategy is as follows:
 * Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
 * `[core] [content]` Fix GraphQL client factory ignoring custom `fetch` and related options ([#418](https://github.com/Sitecore/content-sdk/pull/418))
 * `[nextjs]` AppRouter - NextLink is throwing Locale error in dev mode ([#427](https://github.com/Sitecore/content-sdk/pull/427))
+* `[react]` Form component loses interactivity and state between rerenders ([#447](https://github.com/Sitecore/content-sdk/pull/447))
 
 ### ✨ Chores
 

--- a/packages/react/src/components/Form.test.tsx
+++ b/packages/react/src/components/Form.test.tsx
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 import { PageMode } from '@sitecore-content-sdk/content/client';
 import { LayoutServicePageState } from '@sitecore-content-sdk/content/layout';
 
-describe('Form', () => {
+describe.only('Form', () => {
   const ctx = {
     api: {
       edge: {
@@ -185,7 +185,9 @@ describe('Form', () => {
     const isBotClientSideSpy = sinon.stub().returns(true);
 
     mockFormModule({
-      loadForm: sinon.stub().resolves('<form id="test-form"><script>console.log(1);</script></form>'),
+      loadForm: sinon
+        .stub()
+        .resolves('<form id="test-form"><script>console.log(1);</script></form>'),
       subscribeToFormSubmitEvent: subscribeSpy,
       executeScriptElements: execSpy,
     });
@@ -267,6 +269,62 @@ describe('Form', () => {
       expect(rendered.baseElement.innerHTML).to.equal(
         '<div class="sc-content-sdk-placeholder-error">There was a problem loading this section</div>'
       );
+    });
+  });
+
+  it('initializes form DOM only once (prevents re-initialization on re-render)', async () => {
+    const loadFormSpy = sinon
+      .stub()
+      .resolves('<form id="test-form"><input type="text" name="field1" /></form>');
+    const subscribeSpy = sinon.spy();
+    const execSpy = sinon.spy();
+    const isBotClientSideSpy = sinon.stub().returns(false);
+
+    mockFormModule({
+      loadForm: loadFormSpy,
+      subscribeToFormSubmitEvent: subscribeSpy,
+      executeScriptElements: execSpy,
+    });
+
+    mockAnalyticsInternalModule({
+      isBotClientSide: isBotClientSideSpy,
+    });
+
+    const rendered = render(
+      <SitecoreProvider api={ctx.api} page={ctx.page.normal}>
+        <Form rendering={rendering} params={rendering.params} />
+      </SitecoreProvider>
+    );
+
+    // Wait for initial render
+    await waitFor(() => {
+      expect(execSpy.calledOnce).to.be.true;
+      expect(subscribeSpy.calledOnce).to.be.true;
+    });
+
+    // Simulate user entering data
+    const input = rendered.container.querySelector('input[name="field1"]') as HTMLInputElement;
+    if (input) {
+      input.value = 'user-entered-value';
+    }
+
+    // Force re-render with same props
+    rendered.rerender(
+      <SitecoreProvider api={ctx.api} page={ctx.page.normal}>
+        <Form rendering={rendering} params={rendering.params} />
+      </SitecoreProvider>
+    );
+
+    await waitFor(() => {
+      // Scripts and subscription should still only be called once
+      expect(execSpy.calledOnce).to.be.true;
+      expect(subscribeSpy.calledOnce).to.be.true;
+
+      // User input should be preserved
+      const inputAfterRerender = rendered.container.querySelector(
+        'input[name="field1"]'
+      ) as HTMLInputElement;
+      expect(inputAfterRerender?.value).to.equal('user-entered-value');
     });
   });
 });

--- a/packages/react/src/components/Form.test.tsx
+++ b/packages/react/src/components/Form.test.tsx
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 import { PageMode } from '@sitecore-content-sdk/content/client';
 import { LayoutServicePageState } from '@sitecore-content-sdk/content/layout';
 
-describe.only('Form', () => {
+describe('Form', () => {
   const ctx = {
     api: {
       edge: {

--- a/packages/react/src/components/Form.tsx
+++ b/packages/react/src/components/Form.tsx
@@ -62,6 +62,7 @@ export const Form = ({ params, rendering }: FormProps) => {
 
   const isEditing = context.page.mode.isEditing;
 
+  // fetch form content
   useEffect(() => {
     if (!content) {
       // Forms must use clientContextId since they are rendered client-side
@@ -83,35 +84,31 @@ export const Form = ({ params, rendering }: FormProps) => {
           }
           setError(true);
         });
-    } else {
-      if (!formRef.current) return;
-
-      // If we are in editing mode, we don't want to send any events
-      if (!isEditing && !isBotClientSide()) {
-        subscribeToFormSubmitEvent(formRef.current, rendering.uid);
-      }
-
-      executeScriptElements(formRef.current);
     }
   }, [
     content,
     isEditing,
     params.FormId,
-    rendering.uid,
     context.api?.edge?.clientContextId,
     context.api?.edge?.edgeUrl,
   ]);
+
+  // Set innerHTML and execute scripts whenever form content changes
+  useEffect(() => {
+    if (!content || !formRef.current) return;
+
+    formRef.current.innerHTML = content;
+    executeScriptElements(formRef.current);
+
+    // If we are in editing mode, we don't want to send any events
+    if (!isEditing && !isBotClientSide()) {
+      subscribeToFormSubmitEvent(formRef.current, rendering.uid);
+    }
+  }, [content, isEditing, rendering.uid]);
 
   if (isEditing && error) {
     return <ErrorComponent message="There was a problem loading this section" />;
   }
 
-  return (
-    <div
-      ref={formRef}
-      dangerouslySetInnerHTML={{ __html: content }}
-      className={params.styles?.trimEnd()}
-      id={id ? id : undefined}
-    ></div>
-  );
+  return <div ref={formRef} className={params.styles?.trimEnd()} id={id ? id : undefined}></div>;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using dangerouslySetInnerHTML caused scripts to execute only on the initial render. Subsequent re-renders would update the HTML but would not re-trigger executeScripts, breaking form validation and interactive features.
Avoid this by replacing dangerouslySetInnerHTML with setting innerHtml  offormRef.
Decoupled logic into two distinct useEffects: one for fetching content and one for injecting HTML/executing scripts.
- Form scripts now run correctly on every re-render.
- Form state is now preserved across renders.


## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - simulate rerender

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
