### PR TITLE
[next.js] Preview allows users to access pages without proper permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[nextjs]` Preview allows users to access pages without proper permissions ([#448](https://github.com/Sitecore/content-sdk/pull/448))
+  - App Router: Extract `authorization` header from request headers and propagate it to page data fetching requests. Requires users to share headers via `client.getPreviewFetchOptions` method. See more details in 'What's New' section of the release notes.
+  - Pages Router: Set `authorization` header in preview data and propagate it to page data fetching requests.
 * Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
 * `[core] [content]` Fix GraphQL client factory ignoring custom `fetch` and related options ([#418](https://github.com/Sitecore/content-sdk/pull/418))
 * `[nextjs]` AppRouter - NextLink is throwing Locale error in dev mode ([#427](https://github.com/Sitecore/content-sdk/pull/427))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[nextjs]` `[App Router]` searchParams empty on statically generated pages when Draft Mode is enabled (Vercel only) ([#448](https://github.com/Sitecore/content-sdk/pull/448))
+  - `searchParams` are not expected to be accessible in `draftMode` (this is a known Next.js issue). By design, preview data should be passed via request headers. To support this, we introduced the `client.getPreviewInputs` helper method. At the same time, preview data continues to be available via searchParams for backward compatibility. See more details in 'What's New' section of the release notes.
 * `[nextjs]` Preview allows users to access pages without proper permissions ([#448](https://github.com/Sitecore/content-sdk/pull/448))
-  - App Router: Extract `authorization` header from request headers and propagate it to page data fetching requests. Requires users to share headers via `client.getPreviewFetchOptions` method. See more details in 'What's New' section of the release notes.
-  - Pages Router: Set `authorization` header in preview data and propagate it to page data fetching requests.
+  - App Router: Extract `authorization` header from request headers and propagate it to page data fetching requests. Requires users to share headers via `client.getPreviewInputs` method. See more details in 'What's New' section of the release notes.
+  - Pages Router: Set `authorization` header in preview data and propagate it to page data fetching requests. No changes are required for consumers.
 * Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
 * `[core] [content]` Fix GraphQL client factory ignoring custom `fetch` and related options ([#418](https://github.com/Sitecore/content-sdk/pull/418))
 * `[nextjs]` AppRouter - NextLink is throwing Locale error in dev mode ([#427](https://github.com/Sitecore/content-sdk/pull/427))

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/[site]/[locale]/[[...path]]/page.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/[site]/[locale]/[[...path]]/page.tsx
@@ -1,6 +1,6 @@
 import { isDesignLibraryPreviewData } from '@sitecore-content-sdk/nextjs/editing';
 import { notFound } from 'next/navigation';
-import { draftMode } from 'next/headers';
+import { draftMode, headers as nextHeaders } from 'next/headers';
 <% if (prerender === 'SSG') { -%>
 import { SiteInfo } from '@sitecore-content-sdk/nextjs';
 import sites from '.sitecore/sites.json';
@@ -30,10 +30,13 @@ export default async function Page({ params, searchParams }: PageProps) {
   let page;
   if (draft.isEnabled) {
     const editingParams = await searchParams;
+    const headers = await nextHeaders();
+    const fetchOptions = client.getPreviewFetchOptions(headers);
+
     if (isDesignLibraryPreviewData(editingParams)) {
-      page = await client.getDesignLibraryData(editingParams);
+      page = await client.getDesignLibraryData(editingParams, fetchOptions);
     } else {
-      page = await client.getPreview(editingParams);
+      page = await client.getPreview(editingParams, fetchOptions);
     }
   } else {
     page = await client.getPage(path ?? [], { site, locale });

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/[site]/[locale]/[[...path]]/page.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/[site]/[locale]/[[...path]]/page.tsx
@@ -15,10 +15,9 @@ import { setRequestLocale } from 'next-intl/server';
 
 type PageProps = {
   params: Promise<{ site: string; locale: string; path?: string[]; [key: string]: string | string[] | undefined }>;
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-export default async function Page({ params, searchParams }: PageProps) {
+export default async function Page({ params }: PageProps) {
   const { site, locale, path } = await params;
 
   // Set site and locale to be available in src/i18n/request.ts for fetching the dictionary
@@ -29,14 +28,13 @@ export default async function Page({ params, searchParams }: PageProps) {
   // Fetch the page data from Sitecore
   let page;
   if (draft.isEnabled) {
-    const editingParams = await searchParams;
     const headers = await nextHeaders();
-    const fetchOptions = client.getPreviewFetchOptions(headers);
+    const { previewData, fetchOptions } = client.getPreviewInputs(headers);
 
-    if (isDesignLibraryPreviewData(editingParams)) {
-      page = await client.getDesignLibraryData(editingParams, fetchOptions);
+    if (isDesignLibraryPreviewData(previewData)) {
+      page = await client.getDesignLibraryData(previewData, fetchOptions);
     } else {
-      page = await client.getPreview(editingParams, fetchOptions);
+      page = await client.getPreview(previewData, fetchOptions);
     }
   } else {
     page = await client.getPage(path ?? [], { site, locale });

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -911,7 +911,10 @@ export class SitecoreClient extends SitecoreClient_2 {
     getPage(path: string | string[], pageOptions: PageOptions, options?: FetchOptions): Promise<Page | null>;
     getPagePaths(sites: string[], languages?: string[], fetchOptions?: FetchOptions): Promise<StaticPath[]>;
     getPreview(previewData: PreviewData, fetchOptions?: FetchOptions): Promise<Page | null>;
-    getPreviewFetchOptions(headers: Headers, fetchOptions?: FetchOptions): FetchOptions;
+    getPreviewInputs(headers: Headers, extra?: FetchOptions): {
+        previewData: PreviewData;
+        fetchOptions: FetchOptions;
+    };
     getSiteNameFromPath(path: string | string[]): string;
     // Warning: (ae-forgotten-export) The symbol "SitecoreNextjsClientInit" needs to be exported by the entry point api-surface.d.ts
     //

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -911,6 +911,7 @@ export class SitecoreClient extends SitecoreClient_2 {
     getPage(path: string | string[], pageOptions: PageOptions, options?: FetchOptions): Promise<Page | null>;
     getPagePaths(sites: string[], languages?: string[], fetchOptions?: FetchOptions): Promise<StaticPath[]>;
     getPreview(previewData: PreviewData, fetchOptions?: FetchOptions): Promise<Page | null>;
+    getPreviewFetchOptions(headers: Headers, fetchOptions?: FetchOptions): FetchOptions;
     getSiteNameFromPath(path: string | string[]): string;
     // Warning: (ae-forgotten-export) The symbol "SitecoreNextjsClientInit" needs to be exported by the entry point api-surface.d.ts
     //

--- a/packages/nextjs/src/client/sitecore-nextjs-client.test.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.test.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { SitecoreNextjsClient } from './sitecore-nextjs-client';
 import { DefaultRetryStrategy } from '@sitecore-content-sdk/core';
+import { SitecoreClient } from '@sitecore-content-sdk/content/client';
 import * as siteTools from '@sitecore-content-sdk/content/site';
 import { SITE_PREFIX } from '@sitecore-content-sdk/content/site';
 import { GetServerSidePropsContext } from 'next';
@@ -323,6 +324,160 @@ describe('SitecoreClient', () => {
     });
   });
 
+  describe('getPreview', () => {
+    const localSandbox = sinon.createSandbox();
+    let basePreviewStub: sinon.SinonStub;
+
+    const basePreviewData = {
+      site: 'my-site',
+      itemId: 'item-id',
+      language: 'en',
+      mode: 'edit',
+      variantIds: ['v1'],
+    };
+
+    beforeEach(() => {
+      basePreviewStub = localSandbox.stub(SitecoreClient.prototype, 'getPreview').resolves(null);
+    });
+
+    afterEach(() => {
+      localSandbox.restore();
+    });
+
+    it('should forward previewData and fetchOptions unchanged when previewData has no authorization', async () => {
+      const fetchOptions = { retries: 2 };
+
+      await sitecoreClient.getPreview(basePreviewData, fetchOptions);
+
+      expect(basePreviewStub).to.have.been.calledOnce;
+
+      const [forwardedPreview, forwardedFetchOptions] = basePreviewStub.firstCall.args;
+
+      expect(forwardedPreview).to.deep.equal(basePreviewData);
+      expect(forwardedFetchOptions).to.equal(fetchOptions);
+    });
+
+    it('should promote previewData.authorization to Authorization header and strip it from previewData', async () => {
+      const previewData = { ...basePreviewData, authorization: 'Bearer abc' };
+
+      await sitecoreClient.getPreview(previewData);
+
+      expect(basePreviewStub).to.have.been.calledOnce;
+
+      const [forwardedPreview, forwardedFetchOptions] = basePreviewStub.firstCall.args;
+
+      expect(forwardedPreview).to.deep.equal(basePreviewData);
+      expect(forwardedPreview).to.not.have.property('authorization');
+      expect(forwardedFetchOptions?.headers).to.deep.equal({ Authorization: 'Bearer abc' });
+    });
+
+    it('should preserve other fetchOptions fields and other headers when merging authorization', async () => {
+      const previewData = { ...basePreviewData, authorization: 'Bearer abc' };
+      const fetchOptions = {
+        retries: 5,
+        headers: { 'X-Custom': 'value' },
+      };
+
+      await sitecoreClient.getPreview(previewData, fetchOptions);
+
+      const [, forwardedFetchOptions] = basePreviewStub.firstCall.args;
+      expect(forwardedFetchOptions).to.deep.include({ retries: 5 });
+      expect(forwardedFetchOptions?.headers).to.deep.equal({
+        'X-Custom': 'value',
+        Authorization: 'Bearer abc',
+      });
+    });
+
+    it('should override caller-supplied Authorization with stashed value', async () => {
+      const previewData = { ...basePreviewData, authorization: 'Bearer stashed' };
+      const fetchOptions = { headers: { Authorization: 'Bearer caller' } };
+
+      await sitecoreClient.getPreview(previewData, fetchOptions);
+
+      const [, forwardedFetchOptions] = basePreviewStub.firstCall.args;
+      expect(forwardedFetchOptions?.headers).to.deep.equal({ Authorization: 'Bearer stashed' });
+    });
+  });
+
+  describe('getDesignLibraryData', () => {
+    const localSandbox = sinon.createSandbox();
+    let baseDesignLibraryStub: sinon.SinonStub;
+
+    const baseDesignLibraryData = {
+      site: 'my-site',
+      itemId: 'item-id',
+      renderingId: 'rendering-id',
+      componentUid: 'component-uid',
+      language: 'en',
+      mode: 'library',
+    };
+
+    beforeEach(() => {
+      baseDesignLibraryStub = localSandbox
+        .stub(SitecoreClient.prototype, 'getDesignLibraryData')
+        .resolves({} as any);
+    });
+
+    afterEach(() => {
+      localSandbox.restore();
+    });
+
+    it('should forward designLibData and fetchOptions unchanged when designLibData has no authorization', async () => {
+      const fetchOptions = { retries: 2 };
+
+      await sitecoreClient.getDesignLibraryData(baseDesignLibraryData, fetchOptions);
+
+      expect(baseDesignLibraryStub).to.have.been.calledOnce;
+
+      const [forwardedData, forwardedFetchOptions] = baseDesignLibraryStub.firstCall.args;
+
+      expect(forwardedData).to.deep.equal(baseDesignLibraryData);
+      expect(forwardedFetchOptions).to.equal(fetchOptions);
+    });
+
+    it('should promote designLibData.authorization to Authorization header and strip it from designLibData', async () => {
+      const designLibData = { ...baseDesignLibraryData, authorization: 'Bearer abc' };
+
+      await sitecoreClient.getDesignLibraryData(designLibData);
+
+      expect(baseDesignLibraryStub).to.have.been.calledOnce;
+
+      const [forwardedData, forwardedFetchOptions] = baseDesignLibraryStub.firstCall.args;
+
+      expect(forwardedData).to.deep.equal(baseDesignLibraryData);
+      expect(forwardedData).to.not.have.property('authorization');
+      expect(forwardedFetchOptions?.headers).to.deep.equal({ Authorization: 'Bearer abc' });
+    });
+
+    it('should preserve other fetchOptions fields and other headers when merging authorization', async () => {
+      const designLibData = { ...baseDesignLibraryData, authorization: 'Bearer abc' };
+      const fetchOptions = {
+        retries: 5,
+        headers: { 'X-Custom': 'value' },
+      };
+
+      await sitecoreClient.getDesignLibraryData(designLibData, fetchOptions);
+
+      const [, forwardedFetchOptions] = baseDesignLibraryStub.firstCall.args;
+
+      expect(forwardedFetchOptions).to.deep.include({ retries: 5 });
+      expect(forwardedFetchOptions?.headers).to.deep.equal({
+        'X-Custom': 'value',
+        Authorization: 'Bearer abc',
+      });
+    });
+
+    it('should override caller-supplied Authorization with stashed value', async () => {
+      const designLibData = { ...baseDesignLibraryData, authorization: 'Bearer stashed' };
+      const fetchOptions = { headers: { Authorization: 'Bearer caller' } };
+
+      await sitecoreClient.getDesignLibraryData(designLibData, fetchOptions);
+
+      const [, forwardedFetchOptions] = baseDesignLibraryStub.firstCall.args;
+      expect(forwardedFetchOptions?.headers).to.deep.equal({ Authorization: 'Bearer stashed' });
+    });
+  });
+
   describe('getPagePaths', () => {
     it('should return static paths with site prefixes - multisite enabled by default', async () => {
       const paths = [
@@ -375,6 +530,29 @@ describe('SitecoreClient', () => {
       const result = await sitecoreClient.getPagePaths(['site-one'], ['en'], undefined, false);
 
       expect(result).to.deep.equal(expectedPaths);
+    });
+  });
+
+  describe('getPreviewFetchOptions', () => {
+    it('should return fetch options with Authorization', () => {
+      const headers = new Headers({ Authorization: 'Bearer abc' });
+      const fetchOptions = { retries: 2 };
+
+      const result = sitecoreClient.getPreviewFetchOptions(headers, fetchOptions);
+
+      expect(result).to.deep.equal({ retries: 2, headers: { Authorization: 'Bearer abc' } });
+    });
+
+    it('should return fetch options with custom headers and Authorization header', () => {
+      const headers = new Headers({ Authorization: 'Bearer abc' });
+      const fetchOptions = { retries: 2, headers: { 'X-Custom': 'value' } };
+
+      const result = sitecoreClient.getPreviewFetchOptions(headers, fetchOptions);
+
+      expect(result).to.deep.equal({
+        retries: 2,
+        headers: { 'X-Custom': 'value', Authorization: 'Bearer abc' },
+      });
     });
   });
 });

--- a/packages/nextjs/src/client/sitecore-nextjs-client.test.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.test.ts
@@ -533,25 +533,112 @@ describe('SitecoreClient', () => {
     });
   });
 
-  describe('getPreviewFetchOptions', () => {
-    it('should return fetch options with Authorization', () => {
-      const headers = new Headers({ Authorization: 'Bearer abc' });
-      const fetchOptions = { retries: 2 };
+  describe('getPreviewInputs', () => {
+    const editingParamsHeader = 'x-sitecore-editing-params';
 
-      const result = sitecoreClient.getPreviewFetchOptions(headers, fetchOptions);
+    it('should return empty previewData when EDITING_PARAMS_HEADER is missing', () => {
+      const headers = new Headers();
 
-      expect(result).to.deep.equal({ retries: 2, headers: { Authorization: 'Bearer abc' } });
+      const result = sitecoreClient.getPreviewInputs(headers);
+
+      expect(result.previewData).to.deep.equal({});
+      expect(result.fetchOptions).to.deep.equal({ headers: {} });
     });
 
-    it('should return fetch options with custom headers and Authorization header', () => {
+    it('should return empty previewData when EDITING_PARAMS_HEADER is invalid JSON', () => {
+      const headers = new Headers({ [editingParamsHeader]: 'not-json' });
+
+      const result = sitecoreClient.getPreviewInputs(headers);
+
+      expect(result.previewData).to.deep.equal({});
+    });
+
+    it('should parse EDITING_PARAMS_HEADER into previewData', () => {
+      const previewPayload = {
+        site: 'my-site',
+        itemId: 'item-id',
+        language: 'en',
+        mode: 'edit',
+        variantIds: 'v1',
+      };
+      const headers = new Headers({
+        [editingParamsHeader]: JSON.stringify(previewPayload),
+      });
+
+      const result = sitecoreClient.getPreviewInputs(headers);
+
+      expect(result.previewData).to.deep.equal(previewPayload);
+    });
+
+    it('should merge Authorization header into fetchOptions', () => {
       const headers = new Headers({ Authorization: 'Bearer abc' });
-      const fetchOptions = { retries: 2, headers: { 'X-Custom': 'value' } };
+      const extra = { retries: 2 };
 
-      const result = sitecoreClient.getPreviewFetchOptions(headers, fetchOptions);
+      const result = sitecoreClient.getPreviewInputs(headers, extra);
 
-      expect(result).to.deep.equal({
+      expect(result.fetchOptions).to.deep.equal({
+        retries: 2,
+        headers: { Authorization: 'Bearer abc' },
+      });
+    });
+
+    it('should preserve caller-supplied custom headers and add Authorization', () => {
+      const headers = new Headers({ Authorization: 'Bearer abc' });
+      const extra = { retries: 2, headers: { 'X-Custom': 'value' } };
+
+      const result = sitecoreClient.getPreviewInputs(headers, extra);
+
+      expect(result.fetchOptions).to.deep.equal({
         retries: 2,
         headers: { 'X-Custom': 'value', Authorization: 'Bearer abc' },
+      });
+    });
+
+    it('should not emit Authorization when header is absent', () => {
+      const headers = new Headers();
+      const extra = { headers: { 'X-Custom': 'value' } };
+
+      const result = sitecoreClient.getPreviewInputs(headers, extra);
+
+      expect(result.fetchOptions.headers).to.deep.equal({ 'X-Custom': 'value' });
+    });
+
+    it('should override caller-supplied lowercase authorization with the request value (no duplicate keys)', () => {
+      const headers = new Headers({ Authorization: 'Bearer request' });
+      const extra = { headers: { authorization: 'Bearer caller' } };
+
+      const result = sitecoreClient.getPreviewInputs(headers, extra);
+
+      expect(result.fetchOptions.headers).to.deep.equal({ Authorization: 'Bearer request' });
+    });
+
+    it('should preserve caller-supplied lowercase authorization when the request has no Authorization', () => {
+      const headers = new Headers();
+      const extra = { headers: { authorization: 'Bearer caller' } };
+
+      const result = sitecoreClient.getPreviewInputs(headers, extra);
+
+      expect(result.fetchOptions.headers).to.deep.equal({ authorization: 'Bearer caller' });
+    });
+
+    it('should return both previewData and fetchOptions populated together', () => {
+      const previewPayload = {
+        site: 'my-site',
+        itemId: 'item-id',
+        language: 'en',
+        mode: 'library',
+      };
+
+      const headers = new Headers({
+        [editingParamsHeader]: JSON.stringify(previewPayload),
+        Authorization: 'Bearer xyz',
+      });
+
+      const result = sitecoreClient.getPreviewInputs(headers);
+
+      expect(result.previewData).to.deep.equal(previewPayload);
+      expect(result.fetchOptions).to.deep.equal({
+        headers: { Authorization: 'Bearer xyz' },
       });
     });
   });

--- a/packages/nextjs/src/client/sitecore-nextjs-client.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.ts
@@ -18,6 +18,7 @@ import {
   DesignLibraryRenderPreviewData,
   EditingPreviewData,
 } from '@sitecore-content-sdk/content/editing';
+import { EDITING_PARAMS_HEADER } from '../editing/constants';
 import { getSiteRewriteData, normalizeSiteRewrite } from '@sitecore-content-sdk/content/site';
 import {
   getPersonalizedRewriteData,
@@ -127,32 +128,31 @@ export class SitecoreNextjsClient extends SitecoreClient {
   }
 
   /**
-   * Builds FetchOptions for preview calls by extracting
-   * propagation-eligible headers from the incoming request.
-   *
-   * Currently, only the `authorization` header is forwarded to Sitecore.
-   * All other headers present on the input are ignored.
-   *
-   * If `fetchOptions` is provided, its values are preserved.
-   * Headers are merged with the caller-supplied headers.
-   *
    * **NOTE**: App Router only.
+   * 
+   * Builds the inputs for the Preview mode based on incoming request headers.
+   *
+   * - Reads editing preview data from the `x-sitecore-editing-params` header.
+   * - Reads the `authorization` header from the request and merges it as
+   *   `Authorization` into `fetchOptions.headers`. The request value takes
+   *   precedence over any `Authorization` (case-insensitive) supplied via
+   *   `extra.headers`; existing case-variant keys are removed so the result
+   *   never contains duplicates. An empty `Authorization` is never emitted.
+   *
+   * Other headers present on the input are ignored. Non-`headers` fields of
+   * `extra` are preserved as-is. Extra headers are merged into `fetchOptions.headers`.
    * @param {Headers} headers - The headers from the incoming request.
-   * @param {FetchOptions} [fetchOptions] - Additional fetch options.
-   * @returns {FetchOptions} The FetchOptions for the preview call.
+   * @param {FetchOptions} [extra] - Optional base fetch options to merge with.
+   * @returns The `previewData` and `fetchOptions` to forward
    */
-  getPreviewFetchOptions(headers: Headers, fetchOptions?: FetchOptions): FetchOptions {
-    const authorization = headers.get('authorization');
-    const mergedHeaders: Record<string, string> = { ...(fetchOptions?.headers ?? {}) };
+  getPreviewInputs(
+    headers: Headers,
+    extra?: FetchOptions
+  ): { previewData: PreviewData; fetchOptions: FetchOptions } {
+    const previewData = this.parsePreviewDataFromHeader(headers);
+    const fetchOptions = this.mergeAuthorizationHeader(headers, extra);
 
-    if (authorization) {
-      mergedHeaders.Authorization = authorization;
-    }
-  
-    return {
-      ...fetchOptions,
-      headers: mergedHeaders,
-    };
+    return { previewData, fetchOptions };
   }
 
   /**
@@ -260,8 +260,16 @@ export class SitecoreNextjsClient extends SitecoreClient {
   }
 
   /**
-   * Merges the authorization header from the preview data into the fetch options.
    * **NOTE**: Pages Router only.
+   *
+   * Merges the authorization header from the preview data into the fetch options.
+   * The `authorization` field is always stripped from the returned preview data
+   * to avoid leaking it back into request payloads.
+   *
+   * The value stashed in preview data takes precedence over any caller-supplied
+   * `Authorization` header. Existing `Authorization` keys are removed
+   * case-insensitively before the merged value is set, so the result never
+   * contains duplicate keys.
    * @param {PreviewData} previewData - The preview data to merge the authorization header from.
    * @param {FetchOptions} [fetchOptions] - The fetch options to merge the authorization header into.
    * @returns The preview data and fetch options with the authorization header merged.
@@ -277,15 +285,71 @@ export class SitecoreNextjsClient extends SitecoreClient {
     const { authorization, ...rest } = previewData as PreviewDataWithAuth<T>;
 
     if (!authorization) {
-      return { previewData: previewData as T, fetchOptions };
+      return { previewData: rest as T, fetchOptions };
     }
 
-    const existing = fetchOptions?.headers ?? {};
-    const mergedHeaders = {
-      ...existing,
-      Authorization: authorization,
-    };
+    const mergedHeaders = this.applyAuthorizationHeader(fetchOptions?.headers, authorization);
 
     return { previewData: rest as T, fetchOptions: { ...fetchOptions, headers: mergedHeaders } };
+  }
+
+  /**
+   * Reads and JSON-parses the editing preview data propagated via
+   * `EDITING_PARAMS_HEADER`. Returns an empty object when the header is
+   * missing or its value is not valid JSON.
+   * @param {Headers} headers - The incoming request headers.
+   * @returns {PreviewData} The parsed preview data, or an empty object.
+   */
+  private parsePreviewDataFromHeader(headers: Headers): PreviewData {
+    const packed = headers.get(EDITING_PARAMS_HEADER);
+    if (!packed) return {} as PreviewData;
+    try {
+      return JSON.parse(packed) as PreviewData;
+    } catch {
+      return {} as PreviewData;
+    }
+  }
+
+  /**
+   * Builds `FetchOptions` by merging the `Authorization` header from the
+   * incoming request headers into `extra`. The request value takes precedence
+   * over any caller-supplied `Authorization` header (case-insensitive). An
+   * empty `Authorization` is never emitted.
+   * @param {Headers} headers - The incoming request headers.
+   * @param {FetchOptions} [extra] - Optional base fetch options to merge with.
+   * @returns {FetchOptions} The merged fetch options.
+   */
+  private mergeAuthorizationHeader(headers: Headers, extra?: FetchOptions): FetchOptions {
+    const authorization = headers.get('authorization');
+    const mergedHeaders = this.applyAuthorizationHeader(extra?.headers, authorization);
+
+    return { ...extra, headers: mergedHeaders };
+  }
+
+  /**
+   * Returns a shallow-cloned headers record with `Authorization` set to
+   * `authorization` (when truthy). Any pre-existing `Authorization` key is
+   * removed case-insensitively to avoid emitting both `authorization` and
+   * `Authorization` in the same record.
+   * @param {Record<string, string> | undefined} headers - Existing headers, if any.
+   * @param {string | null | undefined} authorization - The authorization value to apply, or null/undefined to leave headers unchanged.
+   * @returns {Record<string, string>} The merged headers.
+   */
+  private applyAuthorizationHeader(
+    headers: Record<string, string> | undefined,
+    authorization: string | null | undefined
+  ): Record<string, string> {
+    const merged: Record<string, string> = { ...((headers ?? {}) as Record<string, string>) };
+    if (!authorization) return merged;
+
+    for (const key of Object.keys(merged)) {
+      if (key.toLowerCase() === 'authorization') {
+        delete merged[key];
+      }
+    }
+
+    merged.Authorization = authorization;
+
+    return merged;
   }
 }

--- a/packages/nextjs/src/client/sitecore-nextjs-client.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.ts
@@ -27,6 +27,14 @@ import { ComponentMap } from '@sitecore-content-sdk/react';
 import { StaticParams } from './models';
 import { SitecoreConfig } from '../config';
 
+type PreviewDataWithAuth<T> = T & {
+  /**
+   * The authorization header value to use for the request.
+   * Provided only in Pages Router Preview mode.
+   */
+  authorization?: string;
+};
+
 /**
  * Init options for Sitecore Client that allows you to override services too
  * @public
@@ -99,10 +107,12 @@ export class SitecoreNextjsClient extends SitecoreClient {
     designLibData: PreviewData,
     fetchOptions?: FetchOptions
   ): Promise<Page> {
-    return super.getDesignLibraryData(
-      designLibData as DesignLibraryRenderPreviewData,
+    const merged = this.mergePreviewAuthorization<DesignLibraryRenderPreviewData>(
+      designLibData,
       fetchOptions
     );
+
+    return super.getDesignLibraryData(merged.previewData, merged.fetchOptions);
   }
 
   /**
@@ -111,7 +121,38 @@ export class SitecoreNextjsClient extends SitecoreClient {
    * @param {FetchOptions} [fetchOptions] Additional fetch fetch options to override GraphQL requests (like retries and fetch)
    */
   async getPreview(previewData: PreviewData, fetchOptions?: FetchOptions): Promise<Page | null> {
-    return super.getPreview(previewData as EditingPreviewData, fetchOptions);
+    const merged = this.mergePreviewAuthorization<EditingPreviewData>(previewData, fetchOptions);
+
+    return super.getPreview(merged.previewData, merged.fetchOptions);
+  }
+
+  /**
+   * Builds FetchOptions for preview calls by extracting
+   * propagation-eligible headers from the incoming request.
+   *
+   * Currently, only the `authorization` header is forwarded to Sitecore.
+   * All other headers present on the input are ignored.
+   *
+   * If `fetchOptions` is provided, its values are preserved.
+   * Headers are merged with the caller-supplied headers.
+   *
+   * **NOTE**: App Router only.
+   * @param {Headers} headers - The headers from the incoming request.
+   * @param {FetchOptions} [fetchOptions] - Additional fetch options.
+   * @returns {FetchOptions} The FetchOptions for the preview call.
+   */
+  getPreviewFetchOptions(headers: Headers, fetchOptions?: FetchOptions): FetchOptions {
+    const authorization = headers.get('authorization');
+    const mergedHeaders: Record<string, string> = { ...(fetchOptions?.headers ?? {}) };
+
+    if (authorization) {
+      mergedHeaders.Authorization = authorization;
+    }
+  
+    return {
+      ...fetchOptions,
+      headers: mergedHeaders,
+    };
   }
 
   /**
@@ -216,5 +257,35 @@ export class SitecoreNextjsClient extends SitecoreClient {
 
   protected getComponentPropsService(): ComponentPropsService {
     return new ComponentPropsService();
+  }
+
+  /**
+   * Merges the authorization header from the preview data into the fetch options.
+   * **NOTE**: Pages Router only.
+   * @param {PreviewData} previewData - The preview data to merge the authorization header from.
+   * @param {FetchOptions} [fetchOptions] - The fetch options to merge the authorization header into.
+   * @returns The preview data and fetch options with the authorization header merged.
+   */
+  private mergePreviewAuthorization<T extends object>(
+    previewData: PreviewData,
+    fetchOptions?: FetchOptions
+  ): { previewData: T; fetchOptions?: FetchOptions } {
+    if (!previewData || typeof previewData !== 'object') {
+      return { previewData: previewData as unknown as T, fetchOptions };
+    }
+
+    const { authorization, ...rest } = previewData as PreviewDataWithAuth<T>;
+
+    if (!authorization) {
+      return { previewData: previewData as T, fetchOptions };
+    }
+
+    const existing = fetchOptions?.headers ?? {};
+    const mergedHeaders = {
+      ...existing,
+      Authorization: authorization,
+    };
+
+    return { previewData: rest as T, fetchOptions: { ...fetchOptions, headers: mergedHeaders } };
   }
 }

--- a/packages/nextjs/src/editing/constants.ts
+++ b/packages/nextjs/src/editing/constants.ts
@@ -6,3 +6,9 @@ export const QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE = 'x-vercel-set-bypass-cookie'
  * Note these are in lowercase format to match expected `IncomingHttpHeaders`.
  */
 export const EDITING_PASS_THROUGH_HEADERS = ['authorization', 'cookie'];
+
+/**
+ * Header used to propagate editing preview parameters from the editing render
+ * route handler to the Next.js page when running in App Router.
+ */
+export const EDITING_PARAMS_HEADER = 'x-sitecore-editing-params';

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -32,6 +32,7 @@ type Query = {
 };
 
 const allowedOrigin = 'https://allowed.com';
+const defaultAuthHeader = 'Bearer test-token';
 
 const mockRequest = ({
   query,
@@ -48,6 +49,7 @@ const mockRequest = ({
     headers: {
       host: 'localhost:3000',
       origin: allowedOrigin,
+      authorization: defaultAuthHeader,
       ...headers,
     },
   } as EditingNextApiRequest;
@@ -225,6 +227,7 @@ describe('EditingRenderMiddleware', () => {
       version: 'latest',
       mode: 'edit',
       layoutKind: 'shared',
+      authorization: defaultAuthHeader,
     });
 
     expect(res.send).to.have.been.calledOnce;
@@ -266,6 +269,7 @@ describe('EditingRenderMiddleware', () => {
       version: undefined,
       mode: 'edit',
       layoutKind: undefined,
+      authorization: defaultAuthHeader,
     });
   });
 
@@ -298,6 +302,7 @@ describe('EditingRenderMiddleware', () => {
       version: undefined,
       mode: 'edit',
       layoutKind: undefined,
+      authorization: defaultAuthHeader,
     });
 
     expect(res.status).to.be.calledOnceWith(200);
@@ -336,6 +341,7 @@ describe('EditingRenderMiddleware', () => {
       version: 'latest',
       mode: 'edit',
       layoutKind: 'shared',
+      authorization: defaultAuthHeader,
     });
 
     expect(res.status).to.be.calledOnceWith(200);
@@ -376,6 +382,7 @@ describe('EditingRenderMiddleware', () => {
       version: 'latest',
       mode: 'edit',
       layoutKind: 'shared',
+      authorization: defaultAuthHeader,
     });
 
     expect(res.status).to.be.calledOnceWith(200);
@@ -478,6 +485,7 @@ describe('EditingRenderMiddleware', () => {
         version: 'latest',
         mode: 'edit',
         layoutKind: 'shared',
+        authorization: defaultAuthHeader,
       });
     });
 
@@ -519,6 +527,7 @@ describe('EditingRenderMiddleware', () => {
         customParam1: 'value1',
         customParam2: 'value2',
         stringParam: 'string-value',
+        authorization: defaultAuthHeader,
       });
     });
 
@@ -580,6 +589,7 @@ describe('EditingRenderMiddleware', () => {
         mode: 'edit',
         layoutKind: 'shared',
         requiredParam: 'required-value',
+        authorization: defaultAuthHeader,
       });
       expect(res.status).to.have.been.calledWith(200);
     });
@@ -629,6 +639,7 @@ describe('EditingRenderMiddleware', () => {
         prefixedParam1: 'value1',
         prefixedParam2: 'value2',
         requiredParam: 'required-value',
+        authorization: defaultAuthHeader,
       });
     });
 
@@ -693,6 +704,7 @@ describe('EditingRenderMiddleware', () => {
         version: 'latest',
         mode: 'edit',
         layoutKind: 'shared',
+        authorization: defaultAuthHeader,
       });
       expect(res.status).to.have.been.calledWith(200);
     });
@@ -736,6 +748,7 @@ describe('EditingRenderMiddleware', () => {
         numberParam: '123',
         booleanParam: 'true',
         arrayParam: ['val1', 'val2'],
+        authorization: defaultAuthHeader,
       });
     });
 
@@ -1018,6 +1031,7 @@ describe('EditingRenderMiddleware', () => {
         version: 'latest',
         mode: 'preview',
         layoutKind: 'final',
+        authorization: defaultAuthHeader,
       });
 
       expect(res.setHeader).to.have.been.calledWith('Access-Control-Allow-Origin', allowedOrigin);

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -169,6 +169,7 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
         ...previewDataParams,
         ...allowedQueryParams,
         variantIds: previewDataParams.variantIds?.split(','),
+        authorization: headers.authorization,
       },
       {
         maxAge: 3,

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
@@ -13,6 +13,7 @@ import {
   PREVIEW_KEY,
 } from '@sitecore-content-sdk/content/editing';
 import {
+  EDITING_PARAMS_HEADER,
   QUERY_PARAM_VERCEL_PROTECTION_BYPASS,
   QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE,
 } from '../editing/constants';
@@ -363,10 +364,19 @@ describe('createEditingRenderRouteHandlers', () => {
         layoutKind: mockQuery.sc_layoutKind,
       });
 
-      // Verify propagated headers
+      // Verify propagated headers (includes editing params header for preview)
       expect(propagatedHeaders).to.deep.equal({
         authorization: 'Bearer token123',
         cookie: 'test=value',
+        [EDITING_PARAMS_HEADER]: JSON.stringify({
+          itemId: mockQuery.sc_itemid,
+          language: mockQuery.sc_lang,
+          site: mockQuery.sc_site,
+          mode: mockQuery.mode,
+          variantIds: mockQuery.sc_variant,
+          version: mockQuery.sc_version,
+          layoutKind: mockQuery.sc_layoutKind,
+        }),
       });
 
       // Verify converted cookies from cookieStore.getAll()
@@ -434,7 +444,8 @@ describe('createEditingRenderRouteHandlers', () => {
       expect(getEditingRequestHtmlStub).to.have.been.calledOnce;
 
       const [, , propagatedHeaders] = getEditingRequestHtmlStub.firstCall.args;
-      expect(propagatedHeaders).to.deep.equal(expectedPropagatedHeaders);
+      expect(propagatedHeaders).to.deep.include(expectedPropagatedHeaders);
+      expect(propagatedHeaders[EDITING_PARAMS_HEADER]).to.be.a('string');
     });
 
     it('should pass cookies correctly for internal request', async () => {
@@ -1142,6 +1153,31 @@ describe('createEditingRenderRouteHandlers', () => {
       const fetchCall = fetchStub.getCall(0);
       const fetchHeaders = fetchCall.args[1].headers as Headers;
       expect(fetchHeaders.get('cookie')).to.include('__prerender_bypass=some-value');
+    });
+
+    it('should propagate editing preview data via EDITING_PARAMS_HEADER on forwarded POST', async () => {
+      fetchStub.resolves({
+        status: 200,
+        statusText: 'OK',
+        data: '<html>Server Action Response</html>',
+      });
+
+      await handlers.POST(req);
+
+      expect(fetchStub.calledOnce).to.be.true;
+      const fetchHeaders = fetchStub.getCall(0).args[1].headers as Headers;
+      const packed = fetchHeaders.get(EDITING_PARAMS_HEADER);
+      expect(packed).to.be.a('string');
+      const parsed = JSON.parse(packed as string);
+      expect(parsed).to.deep.equal({
+        itemId: mockQuery.sc_itemid,
+        language: mockQuery.sc_lang,
+        site: mockQuery.sc_site,
+        mode: mockQuery.mode,
+        variantIds: mockQuery.sc_variant,
+        version: mockQuery.sc_version,
+        layoutKind: mockQuery.sc_layoutKind,
+      });
     });
 
     it('should proxy POST request with mapped querry string parameters and propagated vercel protection parameters', async () => {

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.ts
@@ -230,8 +230,7 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
     try {
       debug.editing('fetching page route for %s', query.route);
       // Editing preview data, mapped from the incoming `sc_*` query parameters
-      // into the typed shape consumed by `client.getPreview` /
-      // `client.getDesignLibraryData`.
+      // into the typed shape consumed by preview methods.
       const editingPreviewData = {
         ...mapEditingParams(query as { [key: string]: string }),
         ...(allowedQueryParams as { [key: string]: string }),

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.ts
@@ -23,6 +23,7 @@ import {
   PreviewCookies,
   getAllowedQueryParams,
 } from '../editing/utils';
+import { EDITING_PARAMS_HEADER } from '../editing/constants';
 import { SITE_KEY } from '@sitecore-content-sdk/content/site';
 import debug from '../debug';
 import type { AllowedQueryParams } from '../editing/types';
@@ -228,15 +229,27 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
 
     try {
       debug.editing('fetching page route for %s', query.route);
-      // Get query string parameters to propagate on subsequent requests (e.g. for deployment protection bypass)
-      // Additionally ,in app router preview data is passed through query string instead of preview data cookie
-      const propagatedQsParams = {
-        ...getQueryParamsForPropagation(query as { [key: string]: string }),
+      // Editing preview data, mapped from the incoming `sc_*` query parameters
+      // into the typed shape consumed by `client.getPreview` /
+      // `client.getDesignLibraryData`.
+      const editingPreviewData = {
         ...mapEditingParams(query as { [key: string]: string }),
         ...(allowedQueryParams as { [key: string]: string }),
       };
-      // Get headers to propagate on subsequent requests
-      const propagatedHeaders = getHeadersForPropagation(headers);
+      // Query string parameters required by the runtime/platform itself
+      // (e.g. Vercel deployment protection bypass tokens). Editing preview
+      // data is also appended here for backward compatibility with apps that
+      // still read `searchParams` in the page; new code should consume the
+      // `EDITING_PARAMS_HEADER` instead via `client.getPreviewInputs`.
+      // TODO: Remove preview data from qs before next major release.
+      const propagatedQsParams = {
+        ...getQueryParamsForPropagation(query as { [key: string]: string }),
+        ...editingPreviewData,
+      };
+      const propagatedHeaders = {
+        ...getHeadersForPropagation(headers),
+        [EDITING_PARAMS_HEADER]: JSON.stringify(editingPreviewData),
+      };
       const html = await getEditingRequestHtml(
         requestUrl,
         propagatedQsParams,
@@ -315,12 +328,19 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
       query[key] = value;
     });
 
-    const propagatedQsParams = {
-      ...getQueryParamsForPropagation(query as { [key: string]: string }),
+    const editingPreviewData = {
       ...mapEditingParams(query as { [key: string]: string }),
       ...(getAllowedQueryParams(query, options.allowedQueryParams).allowedQueryParams as {
         [key: string]: string;
       }),
+    };
+
+    /**
+     * TODO: Remove preview data from qs before next major release.
+     */
+    const propagatedQsParams = {
+      ...getQueryParamsForPropagation(query as { [key: string]: string }),
+      ...editingPreviewData,
     };
 
     const base = resolveServerUrl(req);
@@ -349,6 +369,7 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
 
     const forwardHeaders = new Headers(req.headers);
     forwardHeaders.set('cookie', forwardCookie);
+    forwardHeaders.set(EDITING_PARAMS_HEADER, JSON.stringify(editingPreviewData));
 
     const forwardedResponse = await dataFetcher.fetch<string>(targetUrl.toString(), {
       method: req.method,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR addresses a security issue by introducing a mechanism to pass an authentication token to the preview endpoint. This ensures that only authorized users can access content and prevents unauthorized access to restricted preview pages.
- App Router: Extract `authorization` header from request headers and propagate it to page data fetching requests. Requires users to share headers via `client.getPreviewFetchOptions` method. We don't treat it as a breaking change but will notify users about importance of this update
- Pages Router: Set `authorization` header in preview data and propagate it to page data fetching requests.

Since these changes are related, this PR also includes a fix for the missing `searchParams` value on Vercel deployment (#415) (https://github.com/vercel/next.js/issues/92562).
- `searchParams` are not expected to be accessible in `draftMode` (this is a known Next.js issue). By design, preview data should be passed via request headers. To support this, we introduced the `client.getPreviewInputs` helper method. At the same time, preview data continues to be available via searchParams for backward compatibility.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
