### PR TITLE
[nextjs] Authorize preview requests in proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Our versioning strategy is as follows:
 
 * `[nextjs]` `[App Router]` searchParams empty on statically generated pages when Draft Mode is enabled (Vercel only) ([#448](https://github.com/Sitecore/content-sdk/pull/448))
   - `searchParams` are not expected to be accessible in `draftMode` (this is a known Next.js issue). By design, preview data should be passed via request headers. To support this, we introduced the `client.getPreviewData` helper method. At the same time, preview data continues to be available via searchParams for backward compatibility. See more details in 'What's New' section of the release notes.
-* `[nextjs]` `[Internal Host]` Preview allows users to access pages without proper permissions ([#448](https://github.com/Sitecore/content-sdk/pull/448))
+* `[nextjs]` `[Internal Host]` Preview allows users to access pages without proper permissions ([#448](https://github.com/Sitecore/content-sdk/pull/448))([#455](https://github.com/Sitecore/content-sdk/pull/455))
   - App Router & Pages Router: Import and use `PreviewProxy` to gate preview requests. See more details in 'What's New' section of the release notes.
 * Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
 * `[core] [content]` Fix GraphQL client factory ignoring custom `fetch` and related options ([#418](https://github.com/Sitecore/content-sdk/pull/418))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,9 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[nextjs]` `[App Router]` searchParams empty on statically generated pages when Draft Mode is enabled (Vercel only) ([#448](https://github.com/Sitecore/content-sdk/pull/448))
-  - `searchParams` are not expected to be accessible in `draftMode` (this is a known Next.js issue). By design, preview data should be passed via request headers. To support this, we introduced the `client.getPreviewInputs` helper method. At the same time, preview data continues to be available via searchParams for backward compatibility. See more details in 'What's New' section of the release notes.
-* `[nextjs]` Preview allows users to access pages without proper permissions ([#448](https://github.com/Sitecore/content-sdk/pull/448))
-  - App Router: Extract `authorization` header from request headers and propagate it to page data fetching requests. Requires users to share headers via `client.getPreviewInputs` method. See more details in 'What's New' section of the release notes.
-  - Pages Router: Set `authorization` header in preview data and propagate it to page data fetching requests. No changes are required for consumers.
+  - `searchParams` are not expected to be accessible in `draftMode` (this is a known Next.js issue). By design, preview data should be passed via request headers. To support this, we introduced the `client.getPreviewData` helper method. At the same time, preview data continues to be available via searchParams for backward compatibility. See more details in 'What's New' section of the release notes.
+* `[nextjs]` `[Internal Host]` Preview allows users to access pages without proper permissions ([#448](https://github.com/Sitecore/content-sdk/pull/448))
+  - App Router & Pages Router: Import and use `PreviewProxy` to gate preview requests. See more details in 'What's New' section of the release notes.
 * Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
 * `[core] [content]` Fix GraphQL client factory ignoring custom `fetch` and related options ([#418](https://github.com/Sitecore/content-sdk/pull/418))
 * `[nextjs]` AppRouter - NextLink is throwing Locale error in dev mode ([#427](https://github.com/Sitecore/content-sdk/pull/427))

--- a/packages/content/src/client/sitecore-client.test.ts
+++ b/packages/content/src/client/sitecore-client.test.ts
@@ -1070,6 +1070,24 @@ describe('SitecoreClient', () => {
         )
       ).to.be.true;
     });
+
+    it('should return null when route is not found', async () => {
+      const previewData = {
+        site: 'default-site',
+        itemId: 'test-item-id',
+        mode: LayoutServicePageState.Edit,
+        language: 'en',
+        version: '1',
+        variantIds: '',
+        layoutKind: LayoutKind.Final,
+      };
+
+      editingServiceStub.fetchEditingData.resolves({ layoutData: { sitecore: { route: null } } });
+
+      const result = await sitecoreClient.getPreview(previewData);
+
+      expect(result).to.be.null;
+    });
   });
 
   describe('getDesignLibraryData', () => {

--- a/packages/content/src/client/sitecore-client.ts
+++ b/packages/content/src/client/sitecore-client.ts
@@ -489,6 +489,12 @@ export class SitecoreClient implements BaseSitecoreClient {
         }`
       );
     }
+
+    // If the route is not found it means access is denied or preview content is not found
+    if (!data.layoutData.sitecore.route) {
+      return null;
+    }
+
     let layout = data.layoutData;
     const personalizeData = getGroomedVariantIds(variantIds);
     personalizeLayout(layout, personalizeData.variantId, personalizeData.componentVariantIds);

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/[site]/[locale]/[[...path]]/page.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/app/[site]/[locale]/[[...path]]/page.tsx
@@ -29,12 +29,12 @@ export default async function Page({ params }: PageProps) {
   let page;
   if (draft.isEnabled) {
     const headers = await nextHeaders();
-    const { previewData, fetchOptions } = client.getPreviewInputs(headers);
+    const previewData = client.getPreviewData(headers);
 
     if (isDesignLibraryPreviewData(previewData)) {
-      page = await client.getDesignLibraryData(previewData, fetchOptions);
+      page = await client.getDesignLibraryData(previewData);
     } else {
-      page = await client.getPreview(previewData, fetchOptions);
+      page = await client.getPreview(previewData);
     }
   } else {
     page = await client.getPage(path ?? [], { site, locale });

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/proxy.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/proxy.ts
@@ -6,12 +6,20 @@ import {
   RedirectsProxy,
   LocaleProxy,
   BotTrackingProxy,
+  PreviewProxy,
 } from '@sitecore-content-sdk/nextjs/proxy';
 import sites from '.sitecore/sites.json';
 import scConfig from 'sitecore.config';
 import { routing } from './i18n/routing';
+import client from './lib/sitecore-client';
 
 export default function proxy(req: NextRequest, event: NextFetchEvent) {
+  // PreviewProxy authorizes preview requests
+  const preview = new PreviewProxy({
+    client: client,
+    ...scConfig.api.edge,
+  });
+
   // BotTrackingProxy will detect and track bots before any other proxies run
   const botTracking = new BotTrackingProxy({
     ...scConfig.api.edge,
@@ -90,7 +98,7 @@ export default function proxy(req: NextRequest, event: NextFetchEvent) {
     // },
   });
 
-  return defineProxy(botTracking, locale, multisite, redirects, personalize).exec(req);
+  return defineProxy(preview, botTracking, locale, multisite, redirects, personalize).exec(req);
 }
 
 export const config = {

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/proxy.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/proxy.ts
@@ -5,11 +5,19 @@ import {
   PersonalizeProxy,
   RedirectsProxy,
   BotTrackingProxy,
+  PreviewProxy,
 } from '@sitecore-content-sdk/nextjs/proxy';
 import sites from '.sitecore/sites.json';
 import scConfig from 'sitecore.config';
+import client from 'lib/sitecore-client';
 
 export default function proxy(req: NextRequest, event: NextFetchEvent) {
+  // PreviewProxy authorizes preview requests
+  const preview = new PreviewProxy({
+    client: client,
+    ...scConfig.api.edge,
+  });
+
   // BotTrackingProxy will detect and track bots before any other proxies run
   const botTracking = new BotTrackingProxy({
     ...scConfig.api.edge,
@@ -70,7 +78,7 @@ export default function proxy(req: NextRequest, event: NextFetchEvent) {
     // },
   });
 
-  return defineProxy(botTracking, multisite, redirects, personalize).exec(req);
+  return defineProxy(preview, botTracking, multisite, redirects, personalize).exec(req);
 }
 
 export const config = {

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -778,6 +778,20 @@ export { PlaceholderData }
 export { PlaceholdersData }
 
 // @public
+export class PreviewProxy extends ProxyBase {
+    constructor(config: PreviewProxyConfig);
+    // (undocumented)
+    protected client: SitecoreClient;
+    // (undocumented)
+    handle: (req: NextRequest, res: NextResponse) => Promise<NextResponse>;
+}
+
+// @public
+export type PreviewProxyConfig = {
+    client: SitecoreClient;
+};
+
+// @public
 export abstract class ProxyBase extends ProxyHandler_2 {
     constructor(config: ProxyBaseConfig);
     // (undocumented)
@@ -911,10 +925,7 @@ export class SitecoreClient extends SitecoreClient_2 {
     getPage(path: string | string[], pageOptions: PageOptions, options?: FetchOptions): Promise<Page | null>;
     getPagePaths(sites: string[], languages?: string[], fetchOptions?: FetchOptions): Promise<StaticPath[]>;
     getPreview(previewData: PreviewData, fetchOptions?: FetchOptions): Promise<Page | null>;
-    getPreviewInputs(headers: Headers, extra?: FetchOptions): {
-        previewData: PreviewData;
-        fetchOptions: FetchOptions;
-    };
+    getPreviewData(headers: Headers): PreviewData;
     getSiteNameFromPath(path: string | string[]): string;
     // Warning: (ae-forgotten-export) The symbol "SitecoreNextjsClientInit" needs to be exported by the entry point api-surface.d.ts
     //

--- a/packages/nextjs/src/client/sitecore-nextjs-client.test.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.test.ts
@@ -328,7 +328,7 @@ describe('SitecoreClient', () => {
     const localSandbox = sinon.createSandbox();
     let basePreviewStub: sinon.SinonStub;
 
-    const basePreviewData = {
+    const previewData = {
       site: 'my-site',
       itemId: 'item-id',
       language: 'en',
@@ -344,58 +344,26 @@ describe('SitecoreClient', () => {
       localSandbox.restore();
     });
 
-    it('should forward previewData and fetchOptions unchanged when previewData has no authorization', async () => {
-      const fetchOptions = { retries: 2 };
+    it('should forward previewData and fetchOptions to base getPreview', async () => {
+      const fetchOptions = { retries: 2, headers: { Authorization: 'Bearer abc' } };
 
-      await sitecoreClient.getPreview(basePreviewData, fetchOptions);
+      await sitecoreClient.getPreview(previewData, fetchOptions);
 
       expect(basePreviewStub).to.have.been.calledOnce;
 
       const [forwardedPreview, forwardedFetchOptions] = basePreviewStub.firstCall.args;
-
-      expect(forwardedPreview).to.deep.equal(basePreviewData);
+      expect(forwardedPreview).to.equal(previewData);
       expect(forwardedFetchOptions).to.equal(fetchOptions);
     });
 
-    it('should promote previewData.authorization to Authorization header and strip it from previewData', async () => {
-      const previewData = { ...basePreviewData, authorization: 'Bearer abc' };
-
+    it('should call base getPreview without fetchOptions when none provided', async () => {
       await sitecoreClient.getPreview(previewData);
 
       expect(basePreviewStub).to.have.been.calledOnce;
 
       const [forwardedPreview, forwardedFetchOptions] = basePreviewStub.firstCall.args;
-
-      expect(forwardedPreview).to.deep.equal(basePreviewData);
-      expect(forwardedPreview).to.not.have.property('authorization');
-      expect(forwardedFetchOptions?.headers).to.deep.equal({ Authorization: 'Bearer abc' });
-    });
-
-    it('should preserve other fetchOptions fields and other headers when merging authorization', async () => {
-      const previewData = { ...basePreviewData, authorization: 'Bearer abc' };
-      const fetchOptions = {
-        retries: 5,
-        headers: { 'X-Custom': 'value' },
-      };
-
-      await sitecoreClient.getPreview(previewData, fetchOptions);
-
-      const [, forwardedFetchOptions] = basePreviewStub.firstCall.args;
-      expect(forwardedFetchOptions).to.deep.include({ retries: 5 });
-      expect(forwardedFetchOptions?.headers).to.deep.equal({
-        'X-Custom': 'value',
-        Authorization: 'Bearer abc',
-      });
-    });
-
-    it('should override caller-supplied Authorization with stashed value', async () => {
-      const previewData = { ...basePreviewData, authorization: 'Bearer stashed' };
-      const fetchOptions = { headers: { Authorization: 'Bearer caller' } };
-
-      await sitecoreClient.getPreview(previewData, fetchOptions);
-
-      const [, forwardedFetchOptions] = basePreviewStub.firstCall.args;
-      expect(forwardedFetchOptions?.headers).to.deep.equal({ Authorization: 'Bearer stashed' });
+      expect(forwardedPreview).to.equal(previewData);
+      expect(forwardedFetchOptions).to.be.undefined;
     });
   });
 
@@ -403,7 +371,7 @@ describe('SitecoreClient', () => {
     const localSandbox = sinon.createSandbox();
     let baseDesignLibraryStub: sinon.SinonStub;
 
-    const baseDesignLibraryData = {
+    const designLibData = {
       site: 'my-site',
       itemId: 'item-id',
       renderingId: 'rendering-id',
@@ -422,59 +390,26 @@ describe('SitecoreClient', () => {
       localSandbox.restore();
     });
 
-    it('should forward designLibData and fetchOptions unchanged when designLibData has no authorization', async () => {
-      const fetchOptions = { retries: 2 };
+    it('should forward designLibData and fetchOptions to base getDesignLibraryData', async () => {
+      const fetchOptions = { retries: 2, headers: { Authorization: 'Bearer abc' } };
 
-      await sitecoreClient.getDesignLibraryData(baseDesignLibraryData, fetchOptions);
+      await sitecoreClient.getDesignLibraryData(designLibData, fetchOptions);
 
       expect(baseDesignLibraryStub).to.have.been.calledOnce;
 
       const [forwardedData, forwardedFetchOptions] = baseDesignLibraryStub.firstCall.args;
-
-      expect(forwardedData).to.deep.equal(baseDesignLibraryData);
+      expect(forwardedData).to.equal(designLibData);
       expect(forwardedFetchOptions).to.equal(fetchOptions);
     });
 
-    it('should promote designLibData.authorization to Authorization header and strip it from designLibData', async () => {
-      const designLibData = { ...baseDesignLibraryData, authorization: 'Bearer abc' };
-
+    it('should call base getDesignLibraryData without fetchOptions when none provided', async () => {
       await sitecoreClient.getDesignLibraryData(designLibData);
 
       expect(baseDesignLibraryStub).to.have.been.calledOnce;
 
       const [forwardedData, forwardedFetchOptions] = baseDesignLibraryStub.firstCall.args;
-
-      expect(forwardedData).to.deep.equal(baseDesignLibraryData);
-      expect(forwardedData).to.not.have.property('authorization');
-      expect(forwardedFetchOptions?.headers).to.deep.equal({ Authorization: 'Bearer abc' });
-    });
-
-    it('should preserve other fetchOptions fields and other headers when merging authorization', async () => {
-      const designLibData = { ...baseDesignLibraryData, authorization: 'Bearer abc' };
-      const fetchOptions = {
-        retries: 5,
-        headers: { 'X-Custom': 'value' },
-      };
-
-      await sitecoreClient.getDesignLibraryData(designLibData, fetchOptions);
-
-      const [, forwardedFetchOptions] = baseDesignLibraryStub.firstCall.args;
-
-      expect(forwardedFetchOptions).to.deep.include({ retries: 5 });
-      expect(forwardedFetchOptions?.headers).to.deep.equal({
-        'X-Custom': 'value',
-        Authorization: 'Bearer abc',
-      });
-    });
-
-    it('should override caller-supplied Authorization with stashed value', async () => {
-      const designLibData = { ...baseDesignLibraryData, authorization: 'Bearer stashed' };
-      const fetchOptions = { headers: { Authorization: 'Bearer caller' } };
-
-      await sitecoreClient.getDesignLibraryData(designLibData, fetchOptions);
-
-      const [, forwardedFetchOptions] = baseDesignLibraryStub.firstCall.args;
-      expect(forwardedFetchOptions?.headers).to.deep.equal({ Authorization: 'Bearer stashed' });
+      expect(forwardedData).to.equal(designLibData);
+      expect(forwardedFetchOptions).to.be.undefined;
     });
   });
 
@@ -533,24 +468,31 @@ describe('SitecoreClient', () => {
     });
   });
 
-  describe('getPreviewInputs', () => {
+  describe('getPreviewData', () => {
     const editingParamsHeader = 'x-sitecore-editing-params';
 
     it('should return empty previewData when EDITING_PARAMS_HEADER is missing', () => {
       const headers = new Headers();
 
-      const result = sitecoreClient.getPreviewInputs(headers);
+      const result = sitecoreClient.getPreviewData(headers);
 
-      expect(result.previewData).to.deep.equal({});
-      expect(result.fetchOptions).to.deep.equal({ headers: {} });
+      expect(result).to.deep.equal({});
+    });
+
+    it('should return empty previewData when EDITING_PARAMS_HEADER is empty', () => {
+      const headers = new Headers({ [editingParamsHeader]: '' });
+
+      const result = sitecoreClient.getPreviewData(headers);
+
+      expect(result).to.deep.equal({});
     });
 
     it('should return empty previewData when EDITING_PARAMS_HEADER is invalid JSON', () => {
       const headers = new Headers({ [editingParamsHeader]: 'not-json' });
 
-      const result = sitecoreClient.getPreviewInputs(headers);
+      const result = sitecoreClient.getPreviewData(headers);
 
-      expect(result.previewData).to.deep.equal({});
+      expect(result).to.deep.equal({});
     });
 
     it('should parse EDITING_PARAMS_HEADER into previewData', () => {
@@ -565,81 +507,27 @@ describe('SitecoreClient', () => {
         [editingParamsHeader]: JSON.stringify(previewPayload),
       });
 
-      const result = sitecoreClient.getPreviewInputs(headers);
+      const result = sitecoreClient.getPreviewData(headers);
 
-      expect(result.previewData).to.deep.equal(previewPayload);
+      expect(result).to.deep.equal(previewPayload);
     });
 
-    it('should merge Authorization header into fetchOptions', () => {
-      const headers = new Headers({ Authorization: 'Bearer abc' });
-      const extra = { retries: 2 };
-
-      const result = sitecoreClient.getPreviewInputs(headers, extra);
-
-      expect(result.fetchOptions).to.deep.equal({
-        retries: 2,
-        headers: { Authorization: 'Bearer abc' },
-      });
-    });
-
-    it('should preserve caller-supplied custom headers and add Authorization', () => {
-      const headers = new Headers({ Authorization: 'Bearer abc' });
-      const extra = { retries: 2, headers: { 'X-Custom': 'value' } };
-
-      const result = sitecoreClient.getPreviewInputs(headers, extra);
-
-      expect(result.fetchOptions).to.deep.equal({
-        retries: 2,
-        headers: { 'X-Custom': 'value', Authorization: 'Bearer abc' },
-      });
-    });
-
-    it('should not emit Authorization when header is absent', () => {
-      const headers = new Headers();
-      const extra = { headers: { 'X-Custom': 'value' } };
-
-      const result = sitecoreClient.getPreviewInputs(headers, extra);
-
-      expect(result.fetchOptions.headers).to.deep.equal({ 'X-Custom': 'value' });
-    });
-
-    it('should override caller-supplied lowercase authorization with the request value (no duplicate keys)', () => {
-      const headers = new Headers({ Authorization: 'Bearer request' });
-      const extra = { headers: { authorization: 'Bearer caller' } };
-
-      const result = sitecoreClient.getPreviewInputs(headers, extra);
-
-      expect(result.fetchOptions.headers).to.deep.equal({ Authorization: 'Bearer request' });
-    });
-
-    it('should preserve caller-supplied lowercase authorization when the request has no Authorization', () => {
-      const headers = new Headers();
-      const extra = { headers: { authorization: 'Bearer caller' } };
-
-      const result = sitecoreClient.getPreviewInputs(headers, extra);
-
-      expect(result.fetchOptions.headers).to.deep.equal({ authorization: 'Bearer caller' });
-    });
-
-    it('should return both previewData and fetchOptions populated together', () => {
+    it('should ignore unrelated headers when parsing previewData', () => {
       const previewPayload = {
         site: 'my-site',
         itemId: 'item-id',
         language: 'en',
         mode: 'library',
       };
-
       const headers = new Headers({
         [editingParamsHeader]: JSON.stringify(previewPayload),
         Authorization: 'Bearer xyz',
+        'X-Custom': 'value',
       });
 
-      const result = sitecoreClient.getPreviewInputs(headers);
+      const result = sitecoreClient.getPreviewData(headers);
 
-      expect(result.previewData).to.deep.equal(previewPayload);
-      expect(result.fetchOptions).to.deep.equal({
-        headers: { Authorization: 'Bearer xyz' },
-      });
+      expect(result).to.deep.equal(previewPayload);
     });
   });
 });

--- a/packages/nextjs/src/client/sitecore-nextjs-client.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.ts
@@ -215,6 +215,12 @@ export class SitecoreNextjsClient extends SitecoreClient {
     return componentProps;
   }
 
+  /**
+   * **NOTE**: App Router only.
+   * Retrieves preview data from the request headers
+   * @param {Headers} headers - The headers from the incoming request.
+   * @returns {PreviewData} The preview data.
+   */
   getPreviewData(headers: Headers): PreviewData {
     const packed = headers.get(EDITING_PARAMS_HEADER) ?? '';
 

--- a/packages/nextjs/src/client/sitecore-nextjs-client.ts
+++ b/packages/nextjs/src/client/sitecore-nextjs-client.ts
@@ -18,7 +18,6 @@ import {
   DesignLibraryRenderPreviewData,
   EditingPreviewData,
 } from '@sitecore-content-sdk/content/editing';
-import { EDITING_PARAMS_HEADER } from '../editing/constants';
 import { getSiteRewriteData, normalizeSiteRewrite } from '@sitecore-content-sdk/content/site';
 import {
   getPersonalizedRewriteData,
@@ -27,14 +26,7 @@ import {
 import { ComponentMap } from '@sitecore-content-sdk/react';
 import { StaticParams } from './models';
 import { SitecoreConfig } from '../config';
-
-type PreviewDataWithAuth<T> = T & {
-  /**
-   * The authorization header value to use for the request.
-   * Provided only in Pages Router Preview mode.
-   */
-  authorization?: string;
-};
+import { EDITING_PARAMS_HEADER } from '../editing/constants';
 
 /**
  * Init options for Sitecore Client that allows you to override services too
@@ -108,12 +100,10 @@ export class SitecoreNextjsClient extends SitecoreClient {
     designLibData: PreviewData,
     fetchOptions?: FetchOptions
   ): Promise<Page> {
-    const merged = this.mergePreviewAuthorization<DesignLibraryRenderPreviewData>(
-      designLibData,
+    return super.getDesignLibraryData(
+      designLibData as DesignLibraryRenderPreviewData,
       fetchOptions
     );
-
-    return super.getDesignLibraryData(merged.previewData, merged.fetchOptions);
   }
 
   /**
@@ -122,37 +112,7 @@ export class SitecoreNextjsClient extends SitecoreClient {
    * @param {FetchOptions} [fetchOptions] Additional fetch fetch options to override GraphQL requests (like retries and fetch)
    */
   async getPreview(previewData: PreviewData, fetchOptions?: FetchOptions): Promise<Page | null> {
-    const merged = this.mergePreviewAuthorization<EditingPreviewData>(previewData, fetchOptions);
-
-    return super.getPreview(merged.previewData, merged.fetchOptions);
-  }
-
-  /**
-   * **NOTE**: App Router only.
-   * 
-   * Builds the inputs for the Preview mode based on incoming request headers.
-   *
-   * - Reads editing preview data from the `x-sitecore-editing-params` header.
-   * - Reads the `authorization` header from the request and merges it as
-   *   `Authorization` into `fetchOptions.headers`. The request value takes
-   *   precedence over any `Authorization` (case-insensitive) supplied via
-   *   `extra.headers`; existing case-variant keys are removed so the result
-   *   never contains duplicates. An empty `Authorization` is never emitted.
-   *
-   * Other headers present on the input are ignored. Non-`headers` fields of
-   * `extra` are preserved as-is. Extra headers are merged into `fetchOptions.headers`.
-   * @param {Headers} headers - The headers from the incoming request.
-   * @param {FetchOptions} [extra] - Optional base fetch options to merge with.
-   * @returns The `previewData` and `fetchOptions` to forward
-   */
-  getPreviewInputs(
-    headers: Headers,
-    extra?: FetchOptions
-  ): { previewData: PreviewData; fetchOptions: FetchOptions } {
-    const previewData = this.parsePreviewDataFromHeader(headers);
-    const fetchOptions = this.mergeAuthorizationHeader(headers, extra);
-
-    return { previewData, fetchOptions };
+    return super.getPreview(previewData as EditingPreviewData, fetchOptions);
   }
 
   /**
@@ -255,54 +215,11 @@ export class SitecoreNextjsClient extends SitecoreClient {
     return componentProps;
   }
 
-  protected getComponentPropsService(): ComponentPropsService {
-    return new ComponentPropsService();
-  }
+  getPreviewData(headers: Headers): PreviewData {
+    const packed = headers.get(EDITING_PARAMS_HEADER) ?? '';
 
-  /**
-   * **NOTE**: Pages Router only.
-   *
-   * Merges the authorization header from the preview data into the fetch options.
-   * The `authorization` field is always stripped from the returned preview data
-   * to avoid leaking it back into request payloads.
-   *
-   * The value stashed in preview data takes precedence over any caller-supplied
-   * `Authorization` header. Existing `Authorization` keys are removed
-   * case-insensitively before the merged value is set, so the result never
-   * contains duplicate keys.
-   * @param {PreviewData} previewData - The preview data to merge the authorization header from.
-   * @param {FetchOptions} [fetchOptions] - The fetch options to merge the authorization header into.
-   * @returns The preview data and fetch options with the authorization header merged.
-   */
-  private mergePreviewAuthorization<T extends object>(
-    previewData: PreviewData,
-    fetchOptions?: FetchOptions
-  ): { previewData: T; fetchOptions?: FetchOptions } {
-    if (!previewData || typeof previewData !== 'object') {
-      return { previewData: previewData as unknown as T, fetchOptions };
-    }
-
-    const { authorization, ...rest } = previewData as PreviewDataWithAuth<T>;
-
-    if (!authorization) {
-      return { previewData: rest as T, fetchOptions };
-    }
-
-    const mergedHeaders = this.applyAuthorizationHeader(fetchOptions?.headers, authorization);
-
-    return { previewData: rest as T, fetchOptions: { ...fetchOptions, headers: mergedHeaders } };
-  }
-
-  /**
-   * Reads and JSON-parses the editing preview data propagated via
-   * `EDITING_PARAMS_HEADER`. Returns an empty object when the header is
-   * missing or its value is not valid JSON.
-   * @param {Headers} headers - The incoming request headers.
-   * @returns {PreviewData} The parsed preview data, or an empty object.
-   */
-  private parsePreviewDataFromHeader(headers: Headers): PreviewData {
-    const packed = headers.get(EDITING_PARAMS_HEADER);
     if (!packed) return {} as PreviewData;
+
     try {
       return JSON.parse(packed) as PreviewData;
     } catch {
@@ -310,46 +227,7 @@ export class SitecoreNextjsClient extends SitecoreClient {
     }
   }
 
-  /**
-   * Builds `FetchOptions` by merging the `Authorization` header from the
-   * incoming request headers into `extra`. The request value takes precedence
-   * over any caller-supplied `Authorization` header (case-insensitive). An
-   * empty `Authorization` is never emitted.
-   * @param {Headers} headers - The incoming request headers.
-   * @param {FetchOptions} [extra] - Optional base fetch options to merge with.
-   * @returns {FetchOptions} The merged fetch options.
-   */
-  private mergeAuthorizationHeader(headers: Headers, extra?: FetchOptions): FetchOptions {
-    const authorization = headers.get('authorization');
-    const mergedHeaders = this.applyAuthorizationHeader(extra?.headers, authorization);
-
-    return { ...extra, headers: mergedHeaders };
-  }
-
-  /**
-   * Returns a shallow-cloned headers record with `Authorization` set to
-   * `authorization` (when truthy). Any pre-existing `Authorization` key is
-   * removed case-insensitively to avoid emitting both `authorization` and
-   * `Authorization` in the same record.
-   * @param {Record<string, string> | undefined} headers - Existing headers, if any.
-   * @param {string | null | undefined} authorization - The authorization value to apply, or null/undefined to leave headers unchanged.
-   * @returns {Record<string, string>} The merged headers.
-   */
-  private applyAuthorizationHeader(
-    headers: Record<string, string> | undefined,
-    authorization: string | null | undefined
-  ): Record<string, string> {
-    const merged: Record<string, string> = { ...((headers ?? {}) as Record<string, string>) };
-    if (!authorization) return merged;
-
-    for (const key of Object.keys(merged)) {
-      if (key.toLowerCase() === 'authorization') {
-        delete merged[key];
-      }
-    }
-
-    merged.Authorization = authorization;
-
-    return merged;
+  protected getComponentPropsService(): ComponentPropsService {
+    return new ComponentPropsService();
   }
 }

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -227,7 +227,6 @@ describe('EditingRenderMiddleware', () => {
       version: 'latest',
       mode: 'edit',
       layoutKind: 'shared',
-      authorization: defaultAuthHeader,
     });
 
     expect(res.send).to.have.been.calledOnce;
@@ -269,7 +268,6 @@ describe('EditingRenderMiddleware', () => {
       version: undefined,
       mode: 'edit',
       layoutKind: undefined,
-      authorization: defaultAuthHeader,
     });
   });
 
@@ -302,7 +300,6 @@ describe('EditingRenderMiddleware', () => {
       version: undefined,
       mode: 'edit',
       layoutKind: undefined,
-      authorization: defaultAuthHeader,
     });
 
     expect(res.status).to.be.calledOnceWith(200);
@@ -341,7 +338,6 @@ describe('EditingRenderMiddleware', () => {
       version: 'latest',
       mode: 'edit',
       layoutKind: 'shared',
-      authorization: defaultAuthHeader,
     });
 
     expect(res.status).to.be.calledOnceWith(200);
@@ -382,7 +378,6 @@ describe('EditingRenderMiddleware', () => {
       version: 'latest',
       mode: 'edit',
       layoutKind: 'shared',
-      authorization: defaultAuthHeader,
     });
 
     expect(res.status).to.be.calledOnceWith(200);
@@ -485,7 +480,6 @@ describe('EditingRenderMiddleware', () => {
         version: 'latest',
         mode: 'edit',
         layoutKind: 'shared',
-        authorization: defaultAuthHeader,
       });
     });
 
@@ -527,7 +521,6 @@ describe('EditingRenderMiddleware', () => {
         customParam1: 'value1',
         customParam2: 'value2',
         stringParam: 'string-value',
-        authorization: defaultAuthHeader,
       });
     });
 
@@ -589,7 +582,6 @@ describe('EditingRenderMiddleware', () => {
         mode: 'edit',
         layoutKind: 'shared',
         requiredParam: 'required-value',
-        authorization: defaultAuthHeader,
       });
       expect(res.status).to.have.been.calledWith(200);
     });
@@ -639,7 +631,6 @@ describe('EditingRenderMiddleware', () => {
         prefixedParam1: 'value1',
         prefixedParam2: 'value2',
         requiredParam: 'required-value',
-        authorization: defaultAuthHeader,
       });
     });
 
@@ -704,7 +695,6 @@ describe('EditingRenderMiddleware', () => {
         version: 'latest',
         mode: 'edit',
         layoutKind: 'shared',
-        authorization: defaultAuthHeader,
       });
       expect(res.status).to.have.been.calledWith(200);
     });
@@ -748,7 +738,6 @@ describe('EditingRenderMiddleware', () => {
         numberParam: '123',
         booleanParam: 'true',
         arrayParam: ['val1', 'val2'],
-        authorization: defaultAuthHeader,
       });
     });
 
@@ -1031,7 +1020,6 @@ describe('EditingRenderMiddleware', () => {
         version: 'latest',
         mode: 'preview',
         layoutKind: 'final',
-        authorization: defaultAuthHeader,
       });
 
       expect(res.setHeader).to.have.been.calledWith('Access-Control-Allow-Origin', allowedOrigin);

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -169,7 +169,6 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
         ...previewDataParams,
         ...allowedQueryParams,
         variantIds: previewDataParams.variantIds?.split(','),
-        authorization: headers.authorization,
       },
       {
         maxAge: 3,

--- a/packages/nextjs/src/editing/utils.test.ts
+++ b/packages/nextjs/src/editing/utils.test.ts
@@ -1033,6 +1033,27 @@ describe('editing/utils', () => {
       expect(timestamp).to.be.at.least(beforeTime);
       expect(timestamp).to.be.at.most(afterTime);
     });
+
+    it('should handle 403 response without throwing', async () => {
+      const mock403Response = {
+        data: {
+          html: '<html><body>403 Forbidden</body></html>',
+        },
+      };
+
+      const error = {
+        response: {
+          status: 403,
+          ...mock403Response,
+        },
+      };
+
+      mockDataFetcher.get.rejects(error);
+
+      const result = await getEditingRequestHtml(requestUrl, {}, {}, [], mockDataFetcher as any);
+
+      expect(result).to.equal('<html><body>403 Forbidden</body></html>');
+    });
   });
 
   describe('isDesignLibraryPreviewData', () => {

--- a/packages/nextjs/src/editing/utils.ts
+++ b/packages/nextjs/src/editing/utils.ts
@@ -261,14 +261,16 @@ export const getEditingRequestHtml = async (
     .catch((err) => {
       // We need to handle not found error provided by Vercel
       // for `fallback: false` pages
-      if (err.response.status === 404) {
+      // Or preview content is not found or access is denied
+      if (err.response.status === 404 || err.response.status === 403) {
         return err.response;
       }
 
       throw err;
     });
 
-  let html = pageRes.data;
+  // pageRes.data.html can be passed by middleware
+  let html = typeof pageRes.data === 'string' ? pageRes.data : pageRes.data?.html || '';
   if (!html || html.length === 0) {
     throw new Error(`Failed to render html for ${requestUrl.toString()}`);
   }

--- a/packages/nextjs/src/proxy/index.ts
+++ b/packages/nextjs/src/proxy/index.ts
@@ -9,6 +9,7 @@ export {
   PersonalizeServiceConfig,
 } from '@sitecore-content-sdk/content/personalize';
 export { BotTrackingProxy, BotTrackingProxyConfig } from './bot-tracking-proxy';
+export { PreviewProxy, PreviewProxyConfig } from './preview-proxy';
 export {
   RedirectsService,
   RedirectsServiceConfig,

--- a/packages/nextjs/src/proxy/preview-proxy.test.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.test.ts
@@ -1,0 +1,238 @@
+/* eslint-disable no-unused-expressions */
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import { NextRequest, NextResponse } from 'next/server';
+import { SITE_KEY } from '@sitecore-content-sdk/content/site';
+import { EDITING_PARAMS_HEADER } from '../editing/constants';
+import { PreviewProxy } from './preview-proxy';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+const createClientStub = () => ({
+  getPreview: sinon.stub(),
+  getPage: sinon.stub(),
+});
+
+const createRequest = (props: Record<string, any> = {}) => {
+  const req = {
+    nextUrl: {
+      pathname: '/about',
+      locale: undefined,
+      defaultLocale: undefined,
+      clone() {
+        return Object.assign({}, req.nextUrl);
+      },
+      ...(props.nextUrl || {}),
+    },
+    headers: {
+      get(key: string) {
+        const headers: Record<string, string | undefined> = {
+          host: 'foo.net',
+          ...(props.headerValues || {}),
+        };
+        return headers[key] ?? null;
+      },
+    },
+    cookies: {
+      get(cookieName: string) {
+        const cookies: Record<string, string | undefined> = {
+          ...(props.cookieValues || {}),
+        };
+        const value = cookies[cookieName];
+        return value === undefined ? undefined : { value };
+      },
+    },
+  } as unknown as NextRequest;
+
+  return req;
+};
+
+const createResponse = (props: Record<string, any> = {}) => {
+  const headerStore: Record<string, string> = { ...(props.headerValues || {}) };
+
+  const res = {
+    headers: {
+      get(key: string) {
+        return headerStore[key] ?? null;
+      },
+      set(key: string, value: string) {
+        headerStore[key] = value;
+      },
+    },
+  } as unknown as NextResponse;
+
+  return res;
+};
+
+describe('PreviewProxy', () => {
+  const sandbox = sinon.createSandbox();
+  let clientStub: ReturnType<typeof createClientStub>;
+  let proxy: PreviewProxy;
+  const originalSitecoreEnv = process.env.SITECORE;
+
+  beforeEach(() => {
+    clientStub = createClientStub();
+    proxy = new PreviewProxy({ client: clientStub as any });
+    sandbox.stub(console, 'log');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    if (originalSitecoreEnv === undefined) {
+      delete process.env.SITECORE;
+    } else {
+      process.env.SITECORE = originalSitecoreEnv;
+    }
+  });
+
+  describe('when SITECORE env is not set (external host)', () => {
+    beforeEach(() => {
+      delete process.env.SITECORE;
+    });
+
+    it('should return the response unchanged without invoking the authorization', async () => {
+      const req = createRequest();
+      const res = createResponse();
+
+      const result = await proxy.handle(req, res);
+
+      expect(result).to.equal(res);
+      expect(clientStub.getPreview).to.not.have.been.called;
+      expect(clientStub.getPage).to.not.have.been.called;
+    });
+  });
+
+  describe('when SITECORE env is set (internal editing host)', () => {
+    beforeEach(() => {
+      process.env.SITECORE = 'true';
+    });
+
+    describe('preview branch (EDITING_PARAMS_HEADER present)', () => {
+      const editingOptions = {
+        site: 'my-site',
+        itemId: 'item-id',
+        language: 'en',
+        mode: 'preview',
+      };
+
+      it('should parse the header and call getPreview with Authorization forwarded', async () => {
+        const req = createRequest({
+          headerValues: {
+            [EDITING_PARAMS_HEADER]: JSON.stringify(editingOptions),
+            Authorization: 'Bearer abc',
+          },
+        });
+        const res = createResponse();
+        clientStub.getPreview.resolves({} as any);
+
+        const result = await proxy.handle(req, res);
+
+        expect(clientStub.getPreview).to.have.been.calledOnceWithExactly(editingOptions, {
+          headers: { Authorization: 'Bearer abc' },
+        });
+        expect(clientStub.getPage).to.not.have.been.called;
+        expect(result).to.equal(res);
+      });
+
+      it('should forward an empty Authorization when the header is absent', async () => {
+        const req = createRequest({
+          headerValues: {
+            [EDITING_PARAMS_HEADER]: JSON.stringify(editingOptions),
+          },
+        });
+        const res = createResponse();
+        clientStub.getPreview.resolves({} as any);
+
+        await proxy.handle(req, res);
+
+        expect(clientStub.getPreview).to.have.been.calledOnceWithExactly(editingOptions, {
+          headers: { Authorization: '' },
+        });
+      });
+
+      it('should respond with 403 when getPreview resolves null', async () => {
+        const req = createRequest({
+          headerValues: {
+            [EDITING_PARAMS_HEADER]: JSON.stringify(editingOptions),
+            Authorization: 'Bearer abc',
+          },
+        });
+        const res = createResponse();
+        clientStub.getPreview.resolves(null);
+
+        const fakeForbidden = { status: 403 } as unknown as NextResponse;
+        const jsonStub = sandbox.stub(NextResponse, 'json').returns(fakeForbidden);
+
+        const result = await proxy.handle(req, res);
+
+        expect(jsonStub).to.have.been.calledOnceWithExactly(
+          { error: 'Preview content is not found or access is denied' },
+          { status: 403 }
+        );
+        expect(result).to.equal(fakeForbidden);
+      });
+
+      it('should skip and return response unchanged when editing mode is not preview', async () => {
+        const editEditingOptions = { ...editingOptions, mode: 'edit' };
+        const req = createRequest({
+          headerValues: {
+            [EDITING_PARAMS_HEADER]: JSON.stringify(editEditingOptions),
+            Authorization: 'Bearer abc',
+          },
+        });
+        const res = createResponse();
+
+        const result = await proxy.handle(req, res);
+
+        expect(result).to.equal(res);
+        expect(clientStub.getPreview).to.not.have.been.called;
+        expect(clientStub.getPage).to.not.have.been.called;
+      });
+    });
+
+    describe('path branch (EDITING_PARAMS_HEADER absent)', () => {
+      it('should call getPage with pathname, site cookie, locale and Authorization header', async () => {
+        const req = createRequest({
+          nextUrl: { pathname: '/about', locale: 'de-DE' },
+          headerValues: { Authorization: 'Bearer xyz' },
+          cookieValues: { [SITE_KEY]: 'my-site' },
+        });
+        const res = createResponse();
+        clientStub.getPage.resolves({} as any);
+
+        const result = await proxy.handle(req, res);
+
+        expect(clientStub.getPage).to.have.been.calledOnceWithExactly(
+          '/about',
+          { site: 'my-site', locale: 'de-DE' },
+          { headers: { Authorization: 'Bearer xyz' } }
+        );
+        expect(clientStub.getPreview).to.not.have.been.called;
+        expect(result).to.equal(res);
+      });
+
+      it('should respond with 403 when getPage resolves null', async () => {
+        const req = createRequest({
+          nextUrl: { pathname: '/about', locale: 'en' },
+          headerValues: { Authorization: 'Bearer abc' },
+          cookieValues: { [SITE_KEY]: 'my-site' },
+        });
+        const res = createResponse();
+        clientStub.getPage.resolves(null);
+
+        const fakeForbidden = { status: 403 } as unknown as NextResponse;
+        const jsonStub = sandbox.stub(NextResponse, 'json').returns(fakeForbidden);
+
+        const result = await proxy.handle(req, res);
+
+        expect(jsonStub).to.have.been.calledOnceWithExactly(
+          { error: 'Preview content is not found or access is denied' },
+          { status: 403 }
+        );
+        expect(result).to.equal(fakeForbidden);
+      });
+    });
+  });
+});

--- a/packages/nextjs/src/proxy/preview-proxy.test.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.test.ts
@@ -168,7 +168,7 @@ describe('PreviewProxy', () => {
         const result = await proxy.handle(req, res);
 
         expect(jsonStub).to.have.been.calledOnceWithExactly(
-          { error: 'Preview content is not found or access is denied' },
+          { html: 'Preview content is not found or access is denied' },
           { status: 403 }
         );
         expect(result).to.equal(fakeForbidden);
@@ -228,7 +228,7 @@ describe('PreviewProxy', () => {
         const result = await proxy.handle(req, res);
 
         expect(jsonStub).to.have.been.calledOnceWithExactly(
-          { error: 'Preview content is not found or access is denied' },
+          { html: 'Preview content is not found or access is denied' },
           { status: 403 }
         );
         expect(result).to.equal(fakeForbidden);

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -12,6 +12,7 @@ export class PreviewProxy extends ProxyBase {
   protected client: SitecoreClient;
 
   constructor(config: PreviewProxyConfig) {
+    // PreviewProxy does not need site resolution
     super({ ...config, sites: [] });
     this.client = config.client;
   }
@@ -53,12 +54,6 @@ export class PreviewProxy extends ProxyBase {
         }
       );
     }
-
-    console.log('EditingOptions:', editingOptions);
-    console.log('AuthHeader:', authHeader);
-    console.log('PageData:', pageData);
-    console.log('IsPreview by PREVIEW_KEY Header:', req.cookies.get(PREVIEW_KEY)?.value);
-    console.log('IsSitecore:', process.env.SITECORE);
 
     // Preview content is not found or access is denied
     if (!pageData) {

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -42,6 +42,7 @@ export class PreviewProxy extends ProxyBase {
     
     let pageData: Page | null = null;
 
+    // Scenario when the request is coming from /api/editing/render endpoint
     if (editingOptions) {
       pageData = await this.client.getPreview(editingOptions, {
         headers: {
@@ -49,6 +50,7 @@ export class PreviewProxy extends ProxyBase {
         },
       });
     } else {
+      // Scenario when the page is requested using direct path or navigation is performed
       pageData = await this.client.getPage(
         req.nextUrl.pathname,
         {

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -5,6 +5,7 @@ import { SitecoreClient } from '../client';
 import { EDITING_PARAMS_HEADER } from '../editing/constants';
 import { Page } from '@sitecore-content-sdk/content/client';
 import { SITE_KEY } from '@sitecore-content-sdk/content/site';
+import debug from '../debug';
 
 /**
  * Configuration for PreviewProxy
@@ -14,6 +15,7 @@ export type PreviewProxyConfig = { client: SitecoreClient };
 
 /**
  * Proxy for preview requests. Acts as a gateway for preview requests.
+ * Currently it only supports internal editing hosts.
  * @public
  */
 export class PreviewProxy extends ProxyBase {
@@ -35,11 +37,14 @@ export class PreviewProxy extends ProxyBase {
     const authHeader = req.headers.get('Authorization') ?? '';
     let editingOptions: EditingOptions | null = previewParams ? JSON.parse(previewParams) : null;
 
+    debug.editing('preview proxy start');
+
     // Process only preview requests (e.g. non editing or design studio)
     if (editingOptions && editingOptions.mode !== 'preview') {
+      debug.editing('preview proxy skipped (mode is not preview)');
       return res;
     }
-    
+
     let pageData: Page | null = null;
 
     // Scenario when the request is coming from /api/editing/render endpoint
@@ -67,11 +72,14 @@ export class PreviewProxy extends ProxyBase {
 
     // Preview content is not found or access is denied
     if (!pageData) {
+      debug.editing('preview content is not found or access is denied');
       return NextResponse.json(
-        { error: 'Preview content is not found or access is denied' },
+        { html: 'Preview content is not found or access is denied' },
         { status: 403 }
       );
     }
+
+    debug.editing('preview proxy end');
 
     return res;
   };

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -15,7 +15,7 @@ export type PreviewProxyConfig = { client: SitecoreClient };
 
 /**
  * Proxy for preview requests. Acts as a gateway for preview requests.
- * Currently it only supports internal editing hosts.
+ * Currently it only supports internal editing hosts deployed on Sitecore AI.
  * @public
  */
 export class PreviewProxy extends ProxyBase {

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -1,13 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ProxyBase } from './proxy';
-import { PREVIEW_KEY, EditingOptions } from '@sitecore-content-sdk/content/editing';
+import { EditingOptions } from '@sitecore-content-sdk/content/editing';
 import { SitecoreClient } from '../client';
 import { EDITING_PARAMS_HEADER } from '../editing/constants';
 import { Page } from '@sitecore-content-sdk/content/client';
 import { SITE_KEY } from '@sitecore-content-sdk/content/site';
 
+/**
+ * Configuration for PreviewProxy
+ * @public
+ */
 export type PreviewProxyConfig = { client: SitecoreClient };
 
+/**
+ * Proxy for preview requests. Acts as a gateway for preview requests.
+ * @public
+ */
 export class PreviewProxy extends ProxyBase {
   protected client: SitecoreClient;
 

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ProxyBase } from './proxy';
+import { PREVIEW_KEY, EditingOptions } from '@sitecore-content-sdk/content/editing';
+import { SitecoreClient } from '../client';
+import { EDITING_PARAMS_HEADER } from '../editing/constants';
+import { Page } from '@sitecore-content-sdk/content/client';
+import { SITE_KEY } from '@sitecore-content-sdk/content/site';
+
+export type PreviewProxyConfig = { client: SitecoreClient };
+
+export class PreviewProxy extends ProxyBase {
+  protected client: SitecoreClient;
+
+  constructor(config: PreviewProxyConfig) {
+    super({ ...config, sites: [] });
+    this.client = config.client;
+  }
+
+  handle = async (req: NextRequest, res: NextResponse): Promise<NextResponse> => {
+    // Run only in internal editing host
+    if (!process.env.SITECORE) {
+      return res;
+    }
+
+    const previewParams = req.headers.get(EDITING_PARAMS_HEADER);
+    const authHeader = req.headers.get('Authorization') ?? '';
+    let editingOptions: EditingOptions | null = previewParams ? JSON.parse(previewParams) : null;
+
+    // Process only preview requests (e.g. non editing or design studio)
+    if (editingOptions && editingOptions.mode !== 'preview') {
+      return res;
+    }
+    
+    let pageData: Page | null = null;
+
+    if (editingOptions) {
+      pageData = await this.client.getPreview(editingOptions, {
+        headers: {
+          Authorization: authHeader,
+        },
+      });
+    } else {
+      pageData = await this.client.getPage(
+        req.nextUrl.pathname,
+        {
+          site: req.cookies.get(SITE_KEY)?.value,
+          locale: this.getLanguage(req),
+        },
+        {
+          headers: {
+            Authorization: authHeader,
+          },
+        }
+      );
+    }
+
+    console.log('EditingOptions:', editingOptions);
+    console.log('AuthHeader:', authHeader);
+    console.log('PageData:', pageData);
+    console.log('IsPreview by PREVIEW_KEY Header:', req.cookies.get(PREVIEW_KEY)?.value);
+    console.log('IsSitecore:', process.env.SITECORE);
+
+    // Preview content is not found or access is denied
+    if (!pageData) {
+      return NextResponse.json(
+        { error: 'Preview content is not found or access is denied' },
+        { status: 403 }
+      );
+    }
+
+    return res;
+  };
+}

--- a/packages/nextjs/src/proxy/proxy.test.ts
+++ b/packages/nextjs/src/proxy/proxy.test.ts
@@ -734,4 +734,24 @@ describe('defineProxy', () => {
     expect(result.headers.get('m1')).to.equal('true');
     expect(result.headers.get('m2')).to.equal('true');
   });
+
+  it('should short-circuit the chain once a proxy returns a 403 response', async () => {
+    const forbidden = { status: 403 } as unknown as NextResponse;
+
+    const gateProxy: ProxyHandler = {
+      handle: sinon.stub().resolves(forbidden),
+    };
+    const downstreamProxy: ProxyHandler = {
+      handle: sinon.stub().resolves({ status: 200 } as unknown as NextResponse),
+    };
+
+    const req = {} as NextRequest;
+    const res = { status: 200 } as unknown as NextResponse;
+
+    const result = await defineProxy(gateProxy, downstreamProxy).exec(req, res);
+
+    expect(gateProxy.handle).to.have.been.calledOnce;
+    expect(downstreamProxy.handle).to.not.have.been.called;
+    expect(result).to.equal(forbidden);
+  });
 });

--- a/packages/nextjs/src/proxy/proxy.ts
+++ b/packages/nextjs/src/proxy/proxy.ts
@@ -285,7 +285,14 @@ export const defineProxy = (...proxies: ProxyHandler[]) => {
       const start = Date.now();
 
       const proxyResponse = await proxies.reduce(
-        (p, proxy) => p.then((res) => proxy.handle(req, res)),
+        (p, proxy) =>
+          p.then((res) => {
+            // Short-circuit the remaining proxies once a previous one
+            // denied the request (e.g. PreviewProxy returning 403).
+            if (res.status === 403) return res;
+
+            return proxy.handle(req, res);
+          }),
         Promise.resolve(response)
       );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Taking a step back from the previous approach, we will try to handle authorization of preview requests at the proxy level. This should work for both the Pages Router and the App Router.

Currently, the only way to authorize preview requests is through the layout request.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
