### PR TITLE
[nextjs] [Pages Router] Pass editing params via header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Our versioning strategy is as follows:
 
 * `[nextjs]` `[App Router]` searchParams empty on statically generated pages when Draft Mode is enabled (Vercel only) ([#448](https://github.com/Sitecore/content-sdk/pull/448))
   - `searchParams` are not expected to be accessible in `draftMode` (this is a known Next.js issue). By design, preview data should be passed via request headers. To support this, we introduced the `client.getPreviewData` helper method. At the same time, preview data continues to be available via searchParams for backward compatibility. See more details in 'What's New' section of the release notes.
-* `[nextjs]` `[Internal Host]` Preview allows users to access pages without proper permissions ([#448](https://github.com/Sitecore/content-sdk/pull/448))([#455](https://github.com/Sitecore/content-sdk/pull/455))
+* `[nextjs]` `[Internal Host]` Preview allows users to access pages without proper permissions ([#448](https://github.com/Sitecore/content-sdk/pull/448))([#455](https://github.com/Sitecore/content-sdk/pull/455))([#456](https://github.com/Sitecore/content-sdk/pull/456))
   - App Router & Pages Router: Import and use `PreviewProxy` to gate preview requests. See more details in 'What's New' section of the release notes.
 * Preview mode shows unpublishable content ([#410](https://github.com/Sitecore/content-sdk/pull/410))([416](https://github.com/Sitecore/content-sdk/pull/416))
 * `[core] [content]` Fix GraphQL client factory ignoring custom `fetch` and related options ([#418](https://github.com/Sitecore/content-sdk/pull/418))

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -16,6 +16,7 @@ import { spy } from 'sinon';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import {
+  EDITING_PARAMS_HEADER,
   QUERY_PARAM_VERCEL_PROTECTION_BYPASS,
   QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE,
 } from './constants';
@@ -799,6 +800,68 @@ describe('EditingRenderMiddleware', () => {
     );
     expect(fetchRequestHeaders).to.have.property('authorization', 'yes');
     expect(fetchRequestHeaders).to.not.have.property('otherHeader');
+  });
+
+  it('should propagate previewData as JSON in EDITING_PARAMS_HEADER', async () => {
+    const req = mockRequest({ query });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    const fetcherGetStub = sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+    await handler(req, res);
+
+    const fetchRequestHeaders = fetcherGetStub.getCall(0).args[1]?.headers;
+
+    expect(fetchRequestHeaders).to.have.property(EDITING_PARAMS_HEADER);
+
+    const editingParams = JSON.parse(fetchRequestHeaders![EDITING_PARAMS_HEADER]);
+    expect(editingParams).to.deep.equal({
+      site: 'website',
+      itemId: '{11111111-1111-1111-1111-111111111111}',
+      language: 'en',
+      variantIds: ['dev'],
+      version: 'latest',
+      mode: 'edit',
+      layoutKind: 'shared',
+    });
+  });
+
+  it('should include allowed query params in EDITING_PARAMS_HEADER previewData', async () => {
+    const customQuery = {
+      ...query,
+      customParam1: 'value1',
+      stringParam: 'string-value',
+      notAllowed: 'shouldNotBeIncluded',
+    };
+    const req = mockRequest({ query: customQuery });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware({
+      allowedQueryParams: [{ name: 'customParam1' }, 'stringParam'],
+    });
+    const handler = middleware.getHandler();
+
+    const fetcherGetStub = sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+    await handler(req, res);
+
+    const fetchRequestHeaders = fetcherGetStub.getCall(0).args[1]?.headers;
+
+    expect(fetchRequestHeaders).to.have.property(EDITING_PARAMS_HEADER);
+
+    const editingParams = JSON.parse(fetchRequestHeaders![EDITING_PARAMS_HEADER]);
+    expect(editingParams).to.include({
+      customParam1: 'value1',
+      stringParam: 'string-value',
+    });
+    expect(editingParams).to.not.have.property('notAllowed');
   });
 
   it('should return 200 if internal request successful', async () => {

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -24,6 +24,7 @@ import {
   getAllowedQueryParams,
 } from './utils';
 import type { AllowedQueryParams } from './types';
+import { EDITING_PARAMS_HEADER } from './constants';
 
 /**
  * Configuration for the Editing Render Middleware.
@@ -163,17 +164,15 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
     }
 
     const previewDataParams = mapEditingParams(query as { [key: string]: string });
+    const previewData = {
+      ...previewDataParams,
+      ...allowedQueryParams,
+      variantIds: previewDataParams.variantIds?.split(','),
+    };
 
-    res.setPreviewData(
-      {
-        ...previewDataParams,
-        ...allowedQueryParams,
-        variantIds: previewDataParams.variantIds?.split(','),
-      },
-      {
-        maxAge: 3,
-      }
-    );
+    res.setPreviewData(previewData, {
+      maxAge: 3,
+    });
 
     // Set Preview mode identifier cookie, if the page is rendered in Sitecore Preview mode
     if (mode === LayoutServicePageState.Preview) {
@@ -202,7 +201,10 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
       const propagatedQsParams = getQueryParamsForPropagation(query);
 
       // Get headers to propagate on subsequent requests
-      const propagatedHeaders = getHeadersForPropagation(headers);
+      const propagatedHeaders = {
+        ...getHeadersForPropagation(headers),
+        [EDITING_PARAMS_HEADER]: JSON.stringify(previewData),
+      };
       const html = await getEditingRequestHtml(
         requestUrl,
         propagatedQsParams,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Besides preview data cookie pass preview parameters via headers as we can't access preview data from proxy via cookies
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
