### PR TITLE
[Design Studio] Support Atom-based code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ Our versioning strategy is as follows:
   - Introduced the ability to create a callback registry ([#422](https://github.com/Sitecore/content-sdk/pull/422))
   - Introduce the component layout Document contract and ability to render it; set up Design Studio integration ([#423](https://github.com/Sitecore/content-sdk/pull/423))
   - Introduce Zod Schemas for Content SDK Fields ([#450](https://github.com/Sitecore/content-sdk/pull/450))
-  - Introduce `library-atoms` mode for design library ([#452](https://github.com/Sitecore/content-sdk/pull/452))
+  - Introduce `low-code` mode for design library ([#452](https://github.com/Sitecore/content-sdk/pull/452))
+  - Support Atom-based code generation ([#465](https://github.com/Sitecore/content-sdk/pull/465))
+
 
 
 ### 🐛 Bug Fixes

--- a/packages/content/api/content-sdk-content.api.md
+++ b/packages/content/api/content-sdk-content.api.md
@@ -265,7 +265,7 @@ export type DesignLibraryAtomsError = 'render' | 'atoms-missing';
 
 // @public
 export enum DesignLibraryMode {
-    Atoms = "library-atoms",
+    LowCode = "library-low-code",
     Metadata = "library-metadata",
     Normal = "library"
 }
@@ -966,7 +966,7 @@ export type PageMode = {
     name: PageModeName;
     designLibrary: {
         isVariantGeneration: boolean;
-        isAtomsMode?: boolean;
+        isLowCode: boolean;
     };
     isNormal: boolean;
     isPreview: boolean;

--- a/packages/content/src/client/sitecore-client.test.ts
+++ b/packages/content/src/client/sitecore-client.test.ts
@@ -365,6 +365,7 @@ describe('SitecoreClient', () => {
           isDesignLibrary: false,
           designLibrary: {
             isVariantGeneration: false,
+            isLowCode: false,
           },
         },
       });
@@ -409,6 +410,7 @@ describe('SitecoreClient', () => {
           isDesignLibrary: false,
           designLibrary: {
             isVariantGeneration: false,
+            isLowCode: false,
           },
         },
       });
@@ -607,6 +609,7 @@ describe('SitecoreClient', () => {
           isDesignLibrary: false,
           designLibrary: {
             isVariantGeneration: false,
+            isLowCode: false,
           },
         },
       });
@@ -652,6 +655,7 @@ describe('SitecoreClient', () => {
             isDesignLibrary: false,
             designLibrary: {
               isVariantGeneration: false,
+              isLowCode: false,
             },
           },
         });
@@ -699,6 +703,7 @@ describe('SitecoreClient', () => {
             isDesignLibrary: false,
             designLibrary: {
               isVariantGeneration: false,
+              isLowCode: false,
             },
           },
         });
@@ -886,6 +891,7 @@ describe('SitecoreClient', () => {
           isDesignLibrary: false,
           designLibrary: {
             isVariantGeneration: false,
+            isLowCode: false,
           },
         },
       });
@@ -937,6 +943,7 @@ describe('SitecoreClient', () => {
           isDesignLibrary: false,
           designLibrary: {
             isVariantGeneration: false,
+            isLowCode: false,
           },
         },
       });
@@ -1111,6 +1118,7 @@ describe('SitecoreClient', () => {
           isEditing: false,
           designLibrary: {
             isVariantGeneration: false,
+            isLowCode: false,
           },
         },
       });
@@ -1172,6 +1180,7 @@ describe('SitecoreClient', () => {
           isEditing: true,
           designLibrary: {
             isVariantGeneration: true,
+            isLowCode: false,
           },
         },
       });
@@ -1261,7 +1270,7 @@ describe('SitecoreClient', () => {
         isDesignLibrary: false,
         designLibrary: {
           isVariantGeneration: false,
-          isAtomsMode: false,
+          isLowCode: false,
         },
       });
 
@@ -1273,7 +1282,7 @@ describe('SitecoreClient', () => {
         isDesignLibrary: false,
         designLibrary: {
           isVariantGeneration: false,
-          isAtomsMode: false,
+          isLowCode: false,
         },
       });
 
@@ -1285,7 +1294,7 @@ describe('SitecoreClient', () => {
         isDesignLibrary: false,
         designLibrary: {
           isVariantGeneration: false,
-          isAtomsMode: false,
+          isLowCode: false,
         },
       });
 
@@ -1297,7 +1306,7 @@ describe('SitecoreClient', () => {
         isDesignLibrary: true,
         designLibrary: {
           isVariantGeneration: false,
-          isAtomsMode: false,
+          isLowCode: false,
         },
       });
 
@@ -1305,7 +1314,7 @@ describe('SitecoreClient', () => {
         name: DesignLibraryMode.Metadata,
         designLibrary: {
           isVariantGeneration: false,
-          isAtomsMode: false,
+          isLowCode: false,
         },
         isNormal: false,
         isPreview: false,
@@ -1317,7 +1326,7 @@ describe('SitecoreClient', () => {
         name: DesignLibraryMode.Normal,
         designLibrary: {
           isVariantGeneration: false,
-          isAtomsMode: false,
+          isLowCode: false,
         },
         isNormal: false,
         isPreview: false,
@@ -1325,15 +1334,15 @@ describe('SitecoreClient', () => {
         isDesignLibrary: true,
       });
 
-      expect(sitecoreClient['getPageMode'](DesignLibraryMode.Atoms)).to.deep.equal({
-        name: DesignLibraryMode.Atoms,
+      expect(sitecoreClient['getPageMode'](DesignLibraryMode.LowCode)).to.deep.equal({
+        name: DesignLibraryMode.LowCode,
         isNormal: false,
         isPreview: false,
         isEditing: false,
         isDesignLibrary: true,
         designLibrary: {
           isVariantGeneration: false,
-          isAtomsMode: true,
+          isLowCode: true,
         },
       });
 
@@ -1345,7 +1354,7 @@ describe('SitecoreClient', () => {
         isDesignLibrary: false,
         designLibrary: {
           isVariantGeneration: false,
-          isAtomsMode: false,
+          isLowCode: false,
         },
       });
     });

--- a/packages/content/src/client/sitecore-client.ts
+++ b/packages/content/src/client/sitecore-client.ts
@@ -75,9 +75,9 @@ export type PageMode = {
      */
     isVariantGeneration: boolean;
     /**
-     * Whether the page is in atoms editing mode
+     * Whether the page is in low code component editing mode
      */
-    isAtomsMode?: boolean;
+    isLowCode: boolean;
   };
   /**
    * Whether the page is in normal mode
@@ -751,7 +751,7 @@ export class SitecoreClient implements BaseSitecoreClient {
       isPreview: false,
       isEditing: false,
       isDesignLibrary: false,
-      designLibrary: { isVariantGeneration: false, isAtomsMode: false },
+      designLibrary: { isVariantGeneration: false, isLowCode: false },
     };
 
     switch (mode) {
@@ -775,9 +775,9 @@ export class SitecoreClient implements BaseSitecoreClient {
         pageMode.isDesignLibrary = true;
         pageMode.isEditing = true;
         break;
-      case DesignLibraryMode.Atoms:
+      case DesignLibraryMode.LowCode:
         pageMode.isDesignLibrary = true;
-        pageMode.designLibrary.isAtomsMode = true;
+        pageMode.designLibrary.isLowCode = true;
         break;
 
       default:

--- a/packages/content/src/editing/models.ts
+++ b/packages/content/src/editing/models.ts
@@ -82,8 +82,8 @@ export enum DesignLibraryMode {
   Normal = 'library',
   /** Metadata mode */
   Metadata = 'library-metadata',
-  /** Atoms mode */
-  Atoms = 'library-atoms',
+  /** Low code mode */
+  LowCode = 'library-low-code',
 }
 
 /**

--- a/packages/nextjs/src/components/DesignLibrary/DesignLibraryApp.test.tsx
+++ b/packages/nextjs/src/components/DesignLibrary/DesignLibraryApp.test.tsx
@@ -18,7 +18,7 @@ use(sinonChai);
 
 describe('<DesignLibraryApp />', () => {
   let DesignLibraryStub: sinon.SinonStub;
-  let DesignLibraryAtomsStub: sinon.SinonStub;
+  let DesignLibraryLowCodeComponentStub: sinon.SinonStub;
   let DesignLibraryServerStub: sinon.SinonStub;
   let DesignLibraryApp: any;
   const sandbox = sinon.createSandbox();
@@ -28,9 +28,9 @@ describe('<DesignLibraryApp />', () => {
       .stub()
       .returns(<div data-testid="design-library-client">Client Component Rendered</div>);
 
-    DesignLibraryAtomsStub = sandbox
+    DesignLibraryLowCodeComponentStub = sandbox
       .stub()
-      .returns(<div data-testid="design-library-atoms">Atoms Component Rendered</div>);
+      .returns(<div data-testid="design-library-low-code">Low Code Component Rendered</div>);
 
     DesignLibraryServerStub = sandbox
       .stub()
@@ -40,7 +40,7 @@ describe('<DesignLibraryApp />', () => {
     const module = proxyquire('./DesignLibraryApp', {
       '@sitecore-content-sdk/react': {
         DesignLibrary: DesignLibraryStub,
-        DesignLibraryAtoms: DesignLibraryAtomsStub,
+        DesignLibraryLowCodeComponent: DesignLibraryLowCodeComponentStub,
       },
       './DesignLibraryServer': {
         DesignLibraryServer: DesignLibraryServerStub,
@@ -57,15 +57,15 @@ describe('<DesignLibraryApp />', () => {
   const modeLibrary: PageMode = {
     name: DesignLibraryMode.Normal,
     isDesignLibrary: true,
-    designLibrary: { isVariantGeneration: false, isAtomsMode: false },
+    designLibrary: { isVariantGeneration: false, isLowCode: false },
     isNormal: false,
     isPreview: false,
     isEditing: true,
   };
 
-  const modeLibraryAtoms: PageMode = {
+  const modeLibraryLowCode: PageMode = {
     ...modeLibrary,
-    designLibrary: { ...modeLibrary.designLibrary, isAtomsMode: true },
+    designLibrary: { ...modeLibrary.designLibrary, isLowCode: true },
   };
 
   const ClientComponent: React.FC<{ [prop: string]: unknown }> = () => <div>Client Component</div>;
@@ -126,13 +126,13 @@ describe('<DesignLibraryApp />', () => {
     render(awaitedDesignLibraryServer);
 
     expect(DesignLibraryStub).to.have.been.calledOnce;
-    expect(DesignLibraryAtomsStub).to.not.have.been.called;
+    expect(DesignLibraryLowCodeComponentStub).to.not.have.been.called;
     expect(DesignLibraryServerStub).to.not.have.been.called;
   });
 
-  it('should render DesignLibraryAtoms when isAtomsMode is true', () => {
+  it('should render DesignLibraryLowCodeComponent when isLowCode is true', () => {
     const layoutData: LayoutServiceData = getTestLayoutData().layoutData;
-    const page = getPage(layoutData, modeLibraryAtoms);
+    const page = getPage(layoutData, modeLibraryLowCode);
     const componentMap = createComponentMap('ContentBlock', 'client');
 
     const awaitedDesignLibraryServer = DesignLibraryApp({
@@ -144,7 +144,7 @@ describe('<DesignLibraryApp />', () => {
 
     render(awaitedDesignLibraryServer);
 
-    expect(DesignLibraryAtomsStub).to.have.been.calledOnce;
+    expect(DesignLibraryLowCodeComponentStub).to.have.been.calledOnce;
     expect(DesignLibraryStub).to.not.have.been.called;
     expect(DesignLibraryServerStub).to.not.have.been.called;
   });

--- a/packages/nextjs/src/components/DesignLibrary/DesignLibraryApp.tsx
+++ b/packages/nextjs/src/components/DesignLibrary/DesignLibraryApp.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { EDITING_COMPONENT_PLACEHOLDER } from '@sitecore-content-sdk/content/layout';
 import { DesingLibraryAppProps } from './models';
 import { DesignLibraryServer } from './DesignLibraryServer';
-import { DesignLibrary, DesignLibraryAtoms } from '@sitecore-content-sdk/react';
+import { DesignLibrary, DesignLibraryLowCodeComponent } from '@sitecore-content-sdk/react';
 
 /**
  * Design Library component intended to be used by the NextJs app router application
@@ -11,7 +11,7 @@ import { DesignLibrary, DesignLibraryAtoms } from '@sitecore-content-sdk/react';
  * delegates to the appropriate rendering implementation:
  * - Client components are rendered using the `DesignLibrary` component
  * - Server components are rendered using the `DesignLibraryServer` component
- * - Atoms mode components are rendered using the `DesignLibraryAtoms` component
+ * - Low code components are rendered using the `DesignLibraryLowCodeComponent` component
  * @param {DesingLibraryAppProps} props - The properties for the Design Library App.
  * @public
  */
@@ -23,15 +23,15 @@ export const DesignLibraryApp = ({
   const { route } = page.layout.sitecore;
   if (!route) return null;
 
-  const isAtomsMode = page.mode.designLibrary.isAtomsMode;
+  const isLowCode = page.mode.designLibrary.isLowCode;
   const rendering = route?.placeholders[EDITING_COMPONENT_PLACEHOLDER]?.[0];
   const component = componentMap.get(rendering?.componentName || '');
   const isClient = component && component.componentType === 'client';
 
   return (
     <>
-      {isAtomsMode ? (
-        <DesignLibraryAtoms />
+      {isLowCode ? (
+        <DesignLibraryLowCodeComponent />
       ) : isClient ? (
         <DesignLibrary />
       ) : (

--- a/packages/react/api/content-sdk-react.api.md
+++ b/packages/react/api/content-sdk-react.api.md
@@ -233,9 +233,6 @@ export { DefaultRetryStrategy }
 // @public
 export const DesignLibrary: () => React_2.JSX.Element | null;
 
-// @internal
-export const DesignLibraryAtoms: () => React_2.JSX.Element;
-
 // Warning: (ae-forgotten-export) The symbol "DesignLibraryErrorBoundaryProps" needs to be exported by the entry point api-surface.d.ts
 //
 // @internal
@@ -255,6 +252,9 @@ export class DesignLibraryErrorBoundary extends React_2.Component<DesignLibraryE
         hasError: boolean;
     };
 }
+
+// @internal
+export const DesignLibraryLowCodeComponent: () => React_2.JSX.Element;
 
 export { DictionaryPhrases }
 

--- a/packages/react/src/components/DesignLibrary/DesignLibrary.test.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibrary.test.tsx
@@ -21,13 +21,18 @@ import {
   DesignLibraryStatus,
   getDesignLibraryStatusEvent,
   DesignLibraryMode,
+  getDesignLibraryAtomsRegistryEvent,
+  AtomInfo,
 } from '@sitecore-content-sdk/content/editing';
 import { __mockDependencies } from './DesignLibrary';
 import {
   DesignLibraryPreviewError,
   getDesignLibraryErrorEvent,
 } from '@sitecore-content-sdk/content/codegen';
-import { after } from 'node:test';
+import { z } from 'zod';
+import * as atomRegistryUtils from '../../atoms/atom-registry-utils';
+import * as callbackRegistryUtils from '../../atoms/callback-registry-utils';
+import { AtomMetadata, CallbackMetadata } from '../../atoms/types';
 import * as rscUtils from '#rsc-env';
 
 before(() => {
@@ -37,9 +42,6 @@ before(() => {
 });
 
 describe('<DesignLibrary />', () => {
-  after(() => {
-    sandbox.restore();
-  });
   const sandbox = sinon.createSandbox();
   before(() => {
     sandbox.replace(rscUtils, 'rsc', false as any);
@@ -57,10 +59,19 @@ describe('<DesignLibrary />', () => {
   };
 
   // Modes
+  const defaultDesignLibraryPageMode: PageMode = {
+    name: DesignLibraryMode.Normal,
+    isDesignLibrary: true,
+    designLibrary: { isVariantGeneration: false, isLowCode: false },
+    isNormal: false,
+    isPreview: false,
+    isEditing: false,
+  };
+
   const modeLibraryMetadata: PageMode = {
     name: DesignLibraryMode.Metadata,
     isDesignLibrary: true,
-    designLibrary: { isVariantGeneration: false },
+    designLibrary: { isVariantGeneration: false, isLowCode: false },
     isNormal: false,
     isPreview: false,
     isEditing: true,
@@ -69,7 +80,7 @@ describe('<DesignLibrary />', () => {
   const modeLibrary_Gen: PageMode = {
     name: DesignLibraryMode.Normal,
     isDesignLibrary: true,
-    designLibrary: { isVariantGeneration: true },
+    designLibrary: { isVariantGeneration: true, isLowCode: false },
     isNormal: false,
     isPreview: false,
     isEditing: false,
@@ -78,13 +89,16 @@ describe('<DesignLibrary />', () => {
   const modeLibraryMetadata_Gen: PageMode = {
     name: DesignLibraryMode.Metadata,
     isDesignLibrary: true,
-    designLibrary: { isVariantGeneration: true },
+    designLibrary: { isVariantGeneration: true, isLowCode: false },
     isNormal: false,
     isPreview: false,
     isEditing: true,
   };
 
-  const getPage = (layout?: LayoutServiceData, pageMode: PageMode = modeLibrary): Page => ({
+  const getPage = (
+    layout?: LayoutServiceData,
+    pageMode: PageMode = defaultDesignLibraryPageMode
+  ): Page => ({
     locale: 'en',
     layout: layout || { sitecore: { context: {}, route: null } },
     mode: pageMode,
@@ -124,11 +138,63 @@ describe('<DesignLibrary />', () => {
       default: [{ module: 'react', exports: [{ name: 'default', value: React }] }],
     });
 
+  const mockedAtoms: AtomMetadata[] = [
+    {
+      name: 'Button',
+      type: 'atom',
+      description: 'A button component',
+      component: () => React.createElement('button', null, 'Button'),
+      props: z.object({
+        label: z.string(),
+      }),
+    },
+    {
+      name: 'Text',
+      type: 'atom',
+      description: 'A text component',
+      component: () => React.createElement('div', null, 'Text'),
+      props: z.object({
+        content: z.string(),
+      }),
+    },
+  ];
+
+  const mockedCallbacks: CallbackMetadata[] = [
+    {
+      name: 'trackSelection',
+      description: 'Track selection callback',
+      callbackFn: () => {},
+    },
+  ];
+
+  const mockedSerializedAtoms: AtomInfo[] = [
+    {
+      name: 'Button',
+      type: 'atom',
+      description: 'A button component',
+      props: { label: { type: 'string' } },
+      allowedChildren: [],
+    },
+    {
+      name: 'Text',
+      type: 'atom',
+      description: 'A text component',
+      props: { content: { type: 'string' } },
+      allowedChildren: [],
+    },
+  ];
+
+  const mockedSerializedCallbacks: Record<string, { description: string }> = {
+    trackSelection: { description: 'Track selection callback' },
+  };
+
   const unsubscribeSpy = sandbox.spy();
   let addComponentPreviewHandlerSpy: sinon.SinonStub;
   let postToDesignLibrarySpy: sinon.SinonStub;
   let sendErrorEventSpy: sinon.SinonStub;
   let callbackEvent: any = null;
+  let serializeAtomsStub: sinon.SinonStub;
+  let serializeCallbacksStub: sinon.SinonStub;
 
   const RENDER_ID = 'test-content';
   const PLACEHOLDER_GUID = '00000000-0000-0000-0000-000000000000';
@@ -204,6 +270,7 @@ describe('<DesignLibrary />', () => {
       isDesignLibrary: false,
       designLibrary: {
         isVariantGeneration: false,
+        isLowCode: false,
       },
       isNormal: false,
       isPreview: false,
@@ -225,7 +292,7 @@ describe('<DesignLibrary />', () => {
     const modeLibrary: PageMode = {
       name: DesignLibraryMode.Normal,
       isDesignLibrary: true,
-      designLibrary: { isVariantGeneration: false },
+      designLibrary: { isVariantGeneration: false, isLowCode: false },
       isNormal: false,
       isPreview: false,
       isEditing: false,
@@ -423,6 +490,18 @@ describe('<DesignLibrary />', () => {
       });
 
       postMessageSpy.resetHistory();
+
+      serializeAtomsStub = sandbox
+        .stub(atomRegistryUtils, 'serializeAtoms')
+        .callsFake((atoms) => (!atoms?.length ? [] : mockedSerializedAtoms));
+      serializeCallbacksStub = sandbox
+        .stub(callbackRegistryUtils, 'serializeCallbacks')
+        .callsFake((callbacks) => (!callbacks?.length ? {} : mockedSerializedCallbacks));
+    });
+
+    afterEach(() => {
+      serializeAtomsStub.restore();
+      serializeCallbacksStub.restore();
     });
 
     it('fires component:ready on mount', () => {
@@ -634,6 +713,68 @@ describe('<DesignLibrary />', () => {
         ).to.be.true;
       });
     });
+
+    it('posts empty atoms registry event when atomRegistry is not provided on SitecoreProvider', async () => {
+      const page = getPage(getTestLayoutData().layoutData, modeLibrary_Gen);
+      const expectedRegistryEvent = getDesignLibraryAtomsRegistryEvent([], {});
+
+      render(
+        <SitecoreProvider
+          componentMap={components}
+          api={api}
+          page={page}
+          loadImportMap={defaultImportMap}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>
+      );
+
+      await waitFor(() => {
+        expect(
+          postMessageSpy
+            .getCalls()
+            .some((c) => JSON.stringify(c.args[0]) === JSON.stringify(expectedRegistryEvent))
+        ).to.be.true;
+      });
+
+      sinon.assert.calledWith(serializeAtomsStub, []);
+      sinon.assert.calledWith(serializeCallbacksStub, []);
+    });
+
+    it('posts atoms registry event with serialized atoms and callbacks when atomRegistry is provided', async () => {
+      const page = getPage(getTestLayoutData().layoutData, modeLibrary_Gen);
+      const expectedRegistryEvent = getDesignLibraryAtomsRegistryEvent(
+        mockedSerializedAtoms,
+        mockedSerializedCallbacks
+      );
+
+      render(
+        <SitecoreProvider
+          componentMap={components}
+          api={api}
+          page={page}
+          loadImportMap={defaultImportMap}
+          atomRegistry={{
+            atoms: mockedAtoms,
+            callbacks: mockedCallbacks,
+          }}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>
+      );
+
+      await waitFor(() => {
+        const postedRegistryEvent = postMessageSpy
+          .getCalls()
+          .map((call) => call.args[0])
+          .find((event) => event?.name === 'atom:registry');
+
+        expect(postedRegistryEvent).to.deep.equal(expectedRegistryEvent);
+      });
+
+      sinon.assert.calledWith(serializeAtomsStub, mockedAtoms);
+      sinon.assert.calledWith(serializeCallbacksStub, mockedCallbacks);
+    });
   });
 
   describe('?mode=library-metadata&generation=variant and isVariantGeneration=true', () => {
@@ -647,6 +788,20 @@ describe('<DesignLibrary />', () => {
         postToDesignLibrary: postToDesignLibrarySpy,
         sendErrorEvent: sendErrorEventSpy,
       });
+
+      postMessageSpy.resetHistory();
+
+      serializeAtomsStub = sandbox
+        .stub(atomRegistryUtils, 'serializeAtoms')
+        .callsFake((atoms) => (!atoms?.length ? [] : mockedSerializedAtoms));
+      serializeCallbacksStub = sandbox
+        .stub(callbackRegistryUtils, 'serializeCallbacks')
+        .callsFake((callbacks) => (!callbacks?.length ? {} : mockedSerializedCallbacks));
+    });
+
+    afterEach(() => {
+      serializeAtomsStub.restore();
+      serializeCallbacksStub.restore();
     });
 
     const expectedGeneratedParts = [
@@ -690,6 +845,69 @@ describe('<DesignLibrary />', () => {
       await waitFor(() => expectContains(rendered.baseElement.innerHTML, expectedGeneratedParts));
 
       await waitFor(() => expectStatus(postMessageSpy, DesignLibraryStatus.RENDERED, RENDER_ID));
+    });
+
+    it('posts empty atoms registry event when atomRegistry is not provided on SitecoreProvider', async () => {
+      const page = getPage(getTestLayoutData().layoutData, modeLibraryMetadata_Gen);
+      const expectedRegistryEvent = getDesignLibraryAtomsRegistryEvent([], {});
+
+      render(
+        <SitecoreProvider
+          componentMap={components}
+          api={api}
+          page={page}
+          loadImportMap={defaultImportMap}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>
+      );
+
+      await waitFor(() => {
+        const postedRegistryEvent = postMessageSpy
+          .getCalls()
+          .map((call) => call.args[0])
+          .find((event) => event?.name === 'atom:registry');
+
+        expect(postedRegistryEvent).to.deep.equal(expectedRegistryEvent);
+      });
+
+      sinon.assert.calledWith(serializeAtomsStub, []);
+      sinon.assert.calledWith(serializeCallbacksStub, []);
+    });
+
+    it('posts atoms registry event with serialized atoms and callbacks when atomRegistry is provided', async () => {
+      const page = getPage(getTestLayoutData().layoutData, modeLibraryMetadata_Gen);
+      const expectedRegistryEvent = getDesignLibraryAtomsRegistryEvent(
+        mockedSerializedAtoms,
+        mockedSerializedCallbacks
+      );
+
+      render(
+        <SitecoreProvider
+          componentMap={components}
+          api={api}
+          page={page}
+          loadImportMap={defaultImportMap}
+          atomRegistry={{
+            atoms: mockedAtoms,
+            callbacks: mockedCallbacks,
+          }}
+        >
+          <DesignLibrary />
+        </SitecoreProvider>
+      );
+
+      await waitFor(() => {
+        const postedRegistryEvent = postMessageSpy
+          .getCalls()
+          .map((call) => call.args[0])
+          .find((event) => event?.name === 'atom:registry');
+
+        expect(postedRegistryEvent).to.deep.equal(expectedRegistryEvent);
+      });
+
+      sinon.assert.calledWith(serializeAtomsStub, mockedAtoms);
+      sinon.assert.calledWith(serializeCallbacksStub, mockedCallbacks);
     });
   });
 

--- a/packages/react/src/components/DesignLibrary/DesignLibrary.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibrary.tsx
@@ -10,6 +10,7 @@ import {
   DesignLibraryStatus,
   getDesignLibraryStatusEvent,
   addComponentUpdateHandler,
+  getDesignLibraryAtomsRegistryEvent,
 } from '@sitecore-content-sdk/content/editing';
 import * as codegen from '@sitecore-content-sdk/content/codegen';
 import * as editing from '@sitecore-content-sdk/content/editing';
@@ -18,6 +19,8 @@ import { Placeholder, PlaceholderMetadata } from '../Placeholder';
 import { DesignLibraryErrorBoundary } from './DesignLibraryErrorBoundary';
 import { DynamicComponent } from './models';
 import { ErrorComponent } from '../ErrorBoundary';
+import { serializeAtoms } from '../../atoms/atom-registry-utils';
+import { serializeCallbacks } from '../../atoms/callback-registry-utils';
 
 let {
   getDesignLibraryImportMapEvent,
@@ -48,7 +51,7 @@ export const __mockDependencies = (mocks: any) => {
  * @public
  */
 export const DesignLibrary = () => {
-  const { page, loadImportMap } = useSitecore();
+  const { page, loadImportMap, atomRegistry } = useSitecore();
   const route = page.layout.sitecore.route;
   const rendering = route?.placeholders[EDITING_COMPONENT_PLACEHOLDER]?.[0];
   const uid = rendering?.uid;
@@ -139,6 +142,12 @@ export const DesignLibrary = () => {
       const importMapEvent = getDesignLibraryImportMapEvent(uid, importMap);
       postToDesignLibrary(importMapEvent);
 
+      const serializedAtoms = serializeAtoms(atomRegistry?.atoms ?? []);
+      const serializedCallbacks = serializeCallbacks(atomRegistry?.callbacks ?? []);
+
+      const atomRegistryEvent = getDesignLibraryAtomsRegistryEvent(serializedAtoms, serializedCallbacks);
+      postToDesignLibrary(atomRegistryEvent);
+
       const propsEvent = getDesignLibraryComponentPropsEvent(
         uid,
         propsState.fields,
@@ -152,7 +161,7 @@ export const DesignLibrary = () => {
       cancelled = true;
       unsubscribe && unsubscribe();
     };
-  }, [isDesignLibrary, isVariantGeneration, uid, loadImportMap, propsState]);
+  }, [isDesignLibrary, isVariantGeneration, uid, loadImportMap, propsState, atomRegistry]);
 
   return (
     <main>

--- a/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.test.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.test.tsx
@@ -8,7 +8,7 @@ import sinonChai from 'sinon-chai';
 
 chaiUse(sinonChai);
 import { render, waitFor } from '@testing-library/react';
-import { DesignLibraryAtoms, __mockDependencies } from './DesignLibraryAtoms';
+import { DesignLibraryLowCodeComponent, __mockDependencies } from './DesignLibraryLowCodeComponent';
 import { SitecoreProvider } from '../SitecoreProvider';
 import {
   DesignLibraryStatus,
@@ -23,7 +23,7 @@ import { AtomMetadata } from '../../atoms/types';
 import { z } from 'zod';
 import type { ImportMapImport } from './models';
 
-describe('<DesignLibraryAtoms />', () => {
+describe('<DesignLibraryLowCodeComponent />', () => {
   const sandbox = sinon.createSandbox();
 
   /** Minimal stubs so `SitecoreProvider` matches its public contract in tests */
@@ -146,7 +146,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -166,7 +166,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -185,7 +185,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -207,7 +207,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: [], callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -229,7 +229,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -253,7 +253,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -294,7 +294,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -339,7 +339,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -377,7 +377,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -402,7 +402,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -424,7 +424,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -444,7 +444,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -463,7 +463,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -485,7 +485,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -513,7 +513,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -563,7 +563,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: customCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -581,7 +581,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: [] }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 
@@ -605,7 +605,7 @@ describe('<DesignLibraryAtoms />', () => {
         page={page}
         atomRegistry={{ atoms: mockAtoms, callbacks: mockCallbacks }}
       >
-        <DesignLibraryAtoms />
+        <DesignLibraryLowCodeComponent />
       </SitecoreProvider>
     );
 

--- a/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.tsx
@@ -30,15 +30,15 @@ export const __mockDependencies = (mocks: any) => {
 };
 
 /**
- * Design Library Atoms component.
+ * Design Library Low Code component.
  *
- * Facilitates the communication between the Design Studio and the Rendering Host when in atom rendering mode.
+ * Facilitates the communication between the Design Studio and the Rendering Host when previewing a low code component built with the Atoms.
  * - On mount, it unfolds and serializes the atoms registry and callback registry and sends it to the Design Studio via the `getDesignLibraryAtomsRegistryEvent`.
  * - Receives Component model data updates via document update handler and renders the low code component
  * based on component model data and the available atoms using createView.
  * @internal
  */
-export const DesignLibraryAtoms = () => {
+export const DesignLibraryLowCodeComponent = () => {
   const { atomRegistry } = useSitecore();
   const [currentDocument, setCurrentDocument] = useState<Document | null>(null);
   const [renderKey, setRenderKey] = useState(0);
@@ -85,7 +85,7 @@ export const DesignLibraryAtoms = () => {
 
   return (
     <DesignLibraryErrorBoundary
-      uid={currentDocument?.name ?? 'design-library-atoms'}
+      uid={currentDocument?.name ?? 'design-library-low-code-component'}
       renderKey={renderKey}
     >
       {ViewComponent ? <ViewComponent {...(currentDocument?.props ?? {})} /> : null}

--- a/packages/react/src/components/DesignLibrary/index.ts
+++ b/packages/react/src/components/DesignLibrary/index.ts
@@ -1,4 +1,4 @@
 export { DesignLibrary } from './DesignLibrary';
-export { DesignLibraryAtoms } from './DesignLibraryAtoms';
+export { DesignLibraryLowCodeComponent } from './DesignLibraryLowCodeComponent';
 export { DesignLibraryErrorBoundary } from './DesignLibraryErrorBoundary';
 export { DynamicComponent, ImportMapImport } from './models';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -85,7 +85,7 @@ export {
 } from './components/FEaaS';
 export {
   DesignLibrary,
-  DesignLibraryAtoms,
+  DesignLibraryLowCodeComponent,
   DesignLibraryErrorBoundary,
   DynamicComponent,
   ImportMapImport,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
We initially introduced preview support for low-code components. This PR extends that capability to cover scenarios where customers generate atoms or components (e.g., via AI) that depend on those atoms.

* **Rename preview mode**
Renamed the low-code preview mode from `library-atoms` to `library-low-code` to improve clarity and avoid ambiguity (contract was agreed).
* **Extend code generation events**
In addition to the existing importMap event, this change introduces the atomRegistry event (already used in low-code preview) to support code generation scenarios.
* **Support optional registries**
`atomsRegistry` and `callbackRegistry` are optional. To ensure consistent behavior, events are now always emitted, even when these registries are not used (empty values are provided in such cases).

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
