### PR TITLE
[content] Fix personalize hide component does not work properly in edit in case of nested personalization

### DIFF
--- a/.changeset/curvy-berries-sin.md
+++ b/.changeset/curvy-berries-sin.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/content': patch
+---
+
+Personalize hide component does not work properly in edit in case of nested personalization

--- a/packages/content/src/personalize/layout-personalizer.test.ts
+++ b/packages/content/src/personalize/layout-personalizer.test.ts
@@ -167,8 +167,15 @@ describe('layout-personalizer', () => {
           uid: 'root-uid',
           componentName: 'RootComponent',
           dataSource: 'root-datasource',
-          placeholders: {
-            main: [nestedHiddenComponent],
+          experiences: {
+            mountain_bike_audience: {
+              uid: 'root-uid',
+              componentName: 'RootComponent',
+              dataSource: 'root-variant-datasource',
+              placeholders: {
+                main: [nestedHiddenComponent],
+              },
+            },
           },
         };
 
@@ -183,7 +190,7 @@ describe('layout-personalizer', () => {
           {
             uid: 'root-uid',
             componentName: 'RootComponent',
-            dataSource: 'root-datasource',
+            dataSource: 'root-variant-datasource',
             placeholders: {
               main: [
                 {
@@ -215,9 +222,16 @@ describe('layout-personalizer', () => {
         const rootComponent = {
           uid: 'root-uid',
           componentName: 'RootComponent',
-          dataSource: 'root-datasource',
-          placeholders: {
-            main: [nestedHiddenComponent],
+          dataSource: 'root-default-datasource',
+          experiences: {
+            mountain_bike_audience: {
+              uid: 'root-uid',
+              componentName: 'RootComponent',
+              dataSource: 'root-variant-datasource',
+              placeholders: {
+                nested: [nestedHiddenComponent],
+              },
+            },
           },
         };
 
@@ -232,9 +246,9 @@ describe('layout-personalizer', () => {
           {
             uid: 'root-uid',
             componentName: 'RootComponent',
-            dataSource: 'root-datasource',
+            dataSource: 'root-variant-datasource',
             placeholders: {
-              main: [],
+              nested: [],
             },
           },
         ]);

--- a/packages/content/src/personalize/layout-personalizer.test.ts
+++ b/packages/content/src/personalize/layout-personalizer.test.ts
@@ -148,6 +148,97 @@ describe('layout-personalizer', () => {
           },
         ]);
       });
+
+      it('should handle nested hidden components in edit mode', () => {
+        const nestedHiddenComponent = {
+          uid: 'nested-hidden-uid',
+          componentName: 'NestedComponent',
+          dataSource: 'nested-datasource',
+          experiences: {
+            mountain_bike_audience: {
+              uid: 'nested-hidden-uid',
+              componentName: null,
+              dataSource: null,
+            },
+          },
+        };
+
+        const rootComponent = {
+          uid: 'root-uid',
+          componentName: 'RootComponent',
+          dataSource: 'root-datasource',
+          placeholders: {
+            main: [nestedHiddenComponent],
+          },
+        };
+
+        const variant = 'mountain_bike_audience';
+        const personalizedPlaceholderResult = personalizePlaceholder(
+          [rootComponent],
+          [variant],
+          true
+        );
+
+        expect(personalizedPlaceholderResult).to.deep.equal([
+          {
+            uid: 'root-uid',
+            componentName: 'RootComponent',
+            dataSource: 'root-datasource',
+            placeholders: {
+              main: [
+                {
+                  uid: 'nested-hidden-uid',
+                  componentName: HIDDEN_RENDERING_NAME,
+                  dataSource: 'nested-datasource',
+                  experiences: {},
+                },
+              ],
+            },
+          },
+        ]);
+      });
+
+      it('should filter out hidden nested components when not in edit mode', () => {
+        const nestedHiddenComponent = {
+          uid: 'nested-hidden-uid',
+          componentName: 'NestedComponent',
+          dataSource: 'nested-datasource',
+          experiences: {
+            mountain_bike_audience: {
+              uid: 'nested-hidden-uid',
+              componentName: null,
+              dataSource: null,
+            },
+          },
+        };
+
+        const rootComponent = {
+          uid: 'root-uid',
+          componentName: 'RootComponent',
+          dataSource: 'root-datasource',
+          placeholders: {
+            main: [nestedHiddenComponent],
+          },
+        };
+
+        const variant = 'mountain_bike_audience';
+        const personalizedPlaceholderResult = personalizePlaceholder(
+          [rootComponent],
+          [variant],
+          false
+        );
+
+        expect(personalizedPlaceholderResult).to.deep.equal([
+          {
+            uid: 'root-uid',
+            componentName: 'RootComponent',
+            dataSource: 'root-datasource',
+            placeholders: {
+              main: [],
+            },
+          },
+        ]);
+      });
     });
 
     describe('with multiple variant Ids', () => {

--- a/packages/content/src/personalize/layout-personalizer.ts
+++ b/packages/content/src/personalize/layout-personalizer.ts
@@ -127,7 +127,8 @@ export function personalizeComponent(
     if (component.placeholders) {
       component.placeholders[placeholder] = personalizePlaceholder(
         component.placeholders[placeholder],
-        variantIds
+        variantIds,
+        isEditing
       );
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix nested personalization with hide component personalization not working properly in editing mode, by properly passing `isEditing` in `personalizeComponent` function


## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - configure nested personalization in pages with the inner personalization to be hide/show - e.g. personalized container, inside of it personalized hide/show Title component; when component should be hidden the proper 'This component is hidden' message should be shown in pages app, editing mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
