### PR TITLE
[Render NCC wrapper] Create an SXA component in RH to fetch NCC layout from external host and pass it to render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Our versioning strategy is as follows:
   - Introduce Zod Schemas for Content SDK Fields ([#450](https://github.com/Sitecore/content-sdk/pull/450))
   - Introduce `low-code` mode for design library ([#452](https://github.com/Sitecore/content-sdk/pull/452))
   - Support Atom-based code generation ([#465](https://github.com/Sitecore/content-sdk/pull/465))
-
+  - Create an SXA component in RH to fetch NCC layout from external host and pass it to render ([#478](https://github.com/Sitecore/content-sdk/pull/478))
 
 
 ### 🐛 Bug Fixes

--- a/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.test.tsx
+++ b/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.test.tsx
@@ -16,6 +16,7 @@ describe('StudioComponentServerWrapper', () => {
   let StudioComponentWrapperStub: SinonStub;
   let consoleWarnStub: SinonStub;
   let consoleErrorStub: SinonStub;
+  let resolveEdgeUrlStub: SinonStub;
 
   const sampleDocument: Document = {
     name: 'hero',
@@ -31,6 +32,7 @@ describe('StudioComponentServerWrapper', () => {
       .returns(React.createElement('div', { 'data-test': 'wrapper' }));
     consoleWarnStub = sandbox.stub(console, 'warn');
     consoleErrorStub = sandbox.stub(console, 'error');
+    resolveEdgeUrlStub = sandbox.stub().returns('https://edge.example.com');
 
     module = proxyquire('./StudioComponentServerWrapper', {
       '@sitecore-content-sdk/core': {
@@ -40,6 +42,9 @@ describe('StudioComponentServerWrapper', () => {
             this.get = fetcherGetStub;
           }
         },
+      },
+      '@sitecore-content-sdk/core/tools': {
+        resolveEdgeUrl: resolveEdgeUrlStub,
       },
       '@sitecore-content-sdk/content': {
         debug: { layout: undefined },
@@ -143,32 +148,6 @@ describe('StudioComponentServerWrapper', () => {
 
       const calledUrl: string = fetcherGetStub.firstCall.args[0];
       expect(calledUrl).to.include('/mms/components/hero/default');
-    });
-
-    it('returns null and errors when SITECORE_EDGE_PLATFORM_HOSTNAME is not set', async () => {
-      delete process.env.SITECORE_EDGE_PLATFORM_HOSTNAME;
-
-      const result = await StudioComponentServerWrapper({
-        componentRef: 'components/hero/default',
-      });
-
-      expect(result).to.be.null;
-      expect(consoleErrorStub).to.have.been.calledWithMatch(
-        'StudioComponentService: failed to resolve component'
-      );
-    });
-
-    it('returns null and errors when SITECORE_EDGE_PLATFORM_HOSTNAME is not a valid URL', async () => {
-      process.env.SITECORE_EDGE_PLATFORM_HOSTNAME = 'not-a-url';
-
-      const result = await StudioComponentServerWrapper({
-        componentRef: 'components/hero/default',
-      });
-
-      expect(result).to.be.null;
-      expect(consoleErrorStub).to.have.been.calledWithMatch(
-        'StudioComponentService: failed to resolve component'
-      );
     });
   });
 

--- a/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.test.tsx
+++ b/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.test.tsx
@@ -1,0 +1,217 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import { expect } from 'chai';
+import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
+import proxyquire from 'proxyquire';
+import type { Document } from '@sitecore-content-sdk/content/atoms';
+
+describe('StudioComponentServerWrapper', () => {
+  let sandbox: SinonSandbox;
+
+  let module: any;
+  let StudioComponentServerWrapper: any;
+
+  let fetcherGetStub: SinonStub;
+  let StudioComponentWrapperStub: SinonStub;
+  let consoleWarnStub: SinonStub;
+  let consoleErrorStub: SinonStub;
+
+  const sampleDocument: Document = {
+    name: 'hero',
+    root: { id: 'r', type: 'Box' },
+  };
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+
+    fetcherGetStub = sandbox.stub().resolves({ data: JSON.stringify(sampleDocument) });
+    StudioComponentWrapperStub = sandbox
+      .stub()
+      .returns(React.createElement('div', { 'data-test': 'wrapper' }));
+    consoleWarnStub = sandbox.stub(console, 'warn');
+    consoleErrorStub = sandbox.stub(console, 'error');
+
+    module = proxyquire('./StudioComponentServerWrapper', {
+      '@sitecore-content-sdk/core': {
+        NativeDataFetcher: class {
+          get: SinonStub;
+          constructor() {
+            this.get = fetcherGetStub;
+          }
+        },
+      },
+      '@sitecore-content-sdk/content': {
+        debug: { layout: undefined },
+      },
+      './StudioComponentWrapper': {
+        StudioComponentWrapper: StudioComponentWrapperStub,
+      },
+    });
+
+    StudioComponentServerWrapper = module.StudioComponentServerWrapper;
+
+    process.env.SITECORE_EDGE_PLATFORM_HOSTNAME = 'https://edge.example.com';
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    delete process.env.SITECORE_EDGE_PLATFORM_HOSTNAME;
+  });
+
+  describe('early returns', () => {
+    it('returns null when componentRef is empty string', async () => {
+      const result = await StudioComponentServerWrapper({ componentRef: '' });
+      expect(result).to.be.null;
+    });
+
+    it('returns null when componentRef is undefined', async () => {
+      const result = await StudioComponentServerWrapper({ componentRef: undefined as any });
+      expect(result).to.be.null;
+    });
+
+    it('returns null when no path can be extracted from componentRef', async () => {
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'some/path/variant1',
+        fieldNames: 'nonexistent',
+      });
+      // 'nonexistent' does not match 'variant1' and there is no 'default' segment
+      expect(result).to.be.null;
+      expect(consoleWarnStub).to.have.been.calledWithMatch(
+        'StudioComponentServerWrapper: failed to extract path'
+      );
+    });
+  });
+
+  describe('path extraction (extractVariantPathFromComponentRef)', () => {
+    it('uses the path whose last segment matches fieldNames', async () => {
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'org/components/hero/mobile | org/components/hero/desktop',
+        fieldNames: 'desktop',
+      });
+
+      expect(result).to.not.be.null;
+      // Ensure fetcher was called with the desktop path
+      const calledUrl: string = fetcherGetStub.firstCall.args[0];
+      expect(calledUrl).to.include('desktop');
+    });
+
+    it('falls back to the "default" variant when fieldNames does not match', async () => {
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'org/components/hero/default | org/components/hero/mobile',
+        fieldNames: 'desktop',
+      });
+
+      expect(result).to.not.be.null;
+      const calledUrl: string = fetcherGetStub.firstCall.args[0];
+      expect(calledUrl).to.include('default');
+    });
+
+    it('uses "default" fieldNames when fieldNames prop is omitted', async () => {
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'org/components/hero/default',
+      });
+
+      expect(result).to.not.be.null;
+      const calledUrl: string = fetcherGetStub.firstCall.args[0];
+      expect(calledUrl).to.include('default');
+    });
+
+    it('returns null and warns when no path matches and no default exists', async () => {
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'org/components/hero/mobile',
+        fieldNames: 'desktop',
+      });
+
+      expect(result).to.be.null;
+      expect(consoleWarnStub).to.have.been.calledWithMatch(
+        'StudioComponentServerWrapper: failed to extract path'
+      );
+    });
+  });
+
+  describe('fetchDocument — URL construction', () => {
+    it('prepends /mms/ to a relative path that starts with /', async () => {
+      await StudioComponentServerWrapper({ componentRef: '/components/hero/default' });
+
+      const calledUrl: string = fetcherGetStub.firstCall.args[0];
+      expect(calledUrl).to.include('/mms/components/hero/default');
+    });
+
+    it('prepends /mms/ to a relative path without a leading /', async () => {
+      await StudioComponentServerWrapper({ componentRef: 'components/hero/default' });
+
+      const calledUrl: string = fetcherGetStub.firstCall.args[0];
+      expect(calledUrl).to.include('/mms/components/hero/default');
+    });
+
+    it('returns null and errors when SITECORE_EDGE_PLATFORM_HOSTNAME is not set', async () => {
+      delete process.env.SITECORE_EDGE_PLATFORM_HOSTNAME;
+
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'components/hero/default',
+      });
+
+      expect(result).to.be.null;
+      expect(consoleErrorStub).to.have.been.calledWithMatch(
+        'StudioComponentService: failed to resolve component'
+      );
+    });
+
+    it('returns null and errors when SITECORE_EDGE_PLATFORM_HOSTNAME is not a valid URL', async () => {
+      process.env.SITECORE_EDGE_PLATFORM_HOSTNAME = 'not-a-url';
+
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'components/hero/default',
+      });
+
+      expect(result).to.be.null;
+      expect(consoleErrorStub).to.have.been.calledWithMatch(
+        'StudioComponentService: failed to resolve component'
+      );
+    });
+  });
+
+  describe('fetchDocument — fetch errors', () => {
+    it('returns null and errors when fetcher.get throws', async () => {
+      fetcherGetStub.rejects(new Error('network error'));
+
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'components/hero/default',
+      });
+
+      expect(result).to.be.null;
+      expect(consoleErrorStub).to.have.been.calledWithMatch(
+        'StudioComponentService: failed to fetch component layout'
+      );
+    });
+
+    it('returns null and errors when response body is not valid JSON', async () => {
+      fetcherGetStub.resolves({ data: 'not-json{{' });
+
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'components/hero/default',
+      });
+
+      expect(result).to.be.null;
+      expect(consoleErrorStub).to.have.been.calledWithMatch(
+        'StudioComponentService: failed to parse component layout response'
+      );
+    });
+  });
+
+  describe('successful render', () => {
+    it('renders StudioComponentWrapper with the fetched document', async () => {
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'components/hero/default',
+      });
+
+      // The server wrapper returns a React element (JSX), not a rendered output.
+      // Assert the element type and props directly.
+      expect(result).to.not.be.null;
+      expect(result.type).to.equal(StudioComponentWrapperStub);
+      expect(result.props.document).to.deep.equal(sampleDocument);
+    });
+  });
+});
+

--- a/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.test.tsx
+++ b/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.test.tsx
@@ -161,7 +161,7 @@ describe('StudioComponentServerWrapper', () => {
 
       expect(result).to.be.null;
       expect(consoleErrorStub).to.have.been.calledWithMatch(
-        'StudioComponentService: failed to fetch component layout'
+        'StudioComponentServerWrapper: failed to fetch component layout'
       );
     });
 
@@ -174,7 +174,34 @@ describe('StudioComponentServerWrapper', () => {
 
       expect(result).to.be.null;
       expect(consoleErrorStub).to.have.been.calledWithMatch(
-        'StudioComponentService: failed to parse component layout response'
+        'StudioComponentServerWrapper: failed to parse component layout response'
+      );
+    });
+  });
+
+  describe('fetchDocument — path validation', () => {
+    it('returns null and warns when path is empty', async () => {
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'org/components/hero/nonexistent',
+        fieldNames: 'nonexistent',
+      });
+
+      expect(result).to.be.null;
+      expect(consoleWarnStub).to.have.been.calledWithMatch(
+        'StudioComponentServerWrapper: missing component reference path'
+      );
+    });
+
+    it('returns null and errors when URL resolution fails', async () => {
+      resolveEdgeUrlStub.throws(new Error('invalid hostname'));
+
+      const result = await StudioComponentServerWrapper({
+        componentRef: 'components/hero/default',
+      });
+
+      expect(result).to.be.null;
+      expect(consoleErrorStub).to.have.been.calledWithMatch(
+        'StudioComponentServerWrapper: failed to resolve component from'
       );
     });
   });

--- a/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.tsx
+++ b/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.tsx
@@ -4,6 +4,7 @@ import { StudioComponentServerWrapperProps } from './models';
 import { NativeDataFetcher, NativeDataFetcherResponse } from '@sitecore-content-sdk/core';
 import { debug } from '@sitecore-content-sdk/content';
 import { Document } from '@sitecore-content-sdk/content/atoms';
+import { resolveEdgeUrl } from '@sitecore-content-sdk/core/tools';
 
 /**
  * Server component for Studio (NCC) components. Fetches the component layout
@@ -80,7 +81,7 @@ async function fetchDocument(path: string): Promise<Document | null> {
       ? `/${MMS_COMPONENT_PATH_PREFIX}${path}`
       : `/${MMS_COMPONENT_PATH_PREFIX}/${path}`;
 
-    const hostURL = resolveHostURL();
+    const hostURL = resolveEdgeUrl();
 
     url = new URL(pathWithMmsPrefix, hostURL).toString();
   } catch (err) {
@@ -107,28 +108,6 @@ async function fetchDocument(path: string): Promise<Document | null> {
       err
     );
     return null;
-  }
-}
-
-/**
- * Resolve the host URL for StudioComponentService.
- * @returns resolved URL
- */
-function resolveHostURL(): URL {
-  const hostConfig = process.env.SITECORE_EDGE_PLATFORM_HOSTNAME;
-  if (!hostConfig)
-    throw new Error(
-      'StudioComponentService: a host must be configured to resolve a relative component reference. ' +
-        'Set the SITECORE_EDGE_PLATFORM_HOSTNAME environment variable.'
-    );
-
-  try {
-    return new URL(hostConfig);
-  } catch {
-    throw new Error(
-      `StudioComponentService: invalid host URL "${hostConfig}". ` +
-        'Set the SITECORE_EDGE_PLATFORM_HOSTNAME environment variable.'
-    );
   }
 }
 

--- a/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.tsx
+++ b/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.tsx
@@ -71,7 +71,7 @@ const MMS_COMPONENT_PATH_PREFIX = 'mms';
  */
 async function fetchDocument(path: string): Promise<Document | null> {
   if (!path) {
-    console.warn('StudioComponentService: missing component reference path');
+    console.warn('StudioComponentServerWrapper: missing component reference path');
     return null;
   }
 
@@ -85,7 +85,7 @@ async function fetchDocument(path: string): Promise<Document | null> {
 
     url = new URL(pathWithMmsPrefix, hostURL).toString();
   } catch (err) {
-    console.error(`StudioComponentService: failed to resolve component from "${path}"`, err);
+    console.error(`StudioComponentServerWrapper: failed to resolve component from "${path}"`, err);
     return null;
   }
 
@@ -94,7 +94,10 @@ async function fetchDocument(path: string): Promise<Document | null> {
     const fetcher = new NativeDataFetcher({ debugger: debug.layout });
     response = await fetcher.get(url);
   } catch (error) {
-    console.error(`StudioComponentService: failed to fetch component layout from ${url}`, error);
+    console.error(
+      `StudioComponentServerWrapper: failed to fetch component layout from ${url}`,
+      error
+    );
     return null;
   }
 
@@ -104,7 +107,7 @@ async function fetchDocument(path: string): Promise<Document | null> {
     return document;
   } catch (err) {
     console.error(
-      `StudioComponentService: failed to parse component layout response from ${url}`,
+      `StudioComponentServerWrapper: failed to parse component layout response from ${url}`,
       err
     );
     return null;

--- a/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.tsx
+++ b/packages/react/src/atoms/Wrapper/StudioComponentServerWrapper.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { StudioComponentWrapper } from './StudioComponentWrapper';
+import { StudioComponentServerWrapperProps } from './models';
+import { NativeDataFetcher, NativeDataFetcherResponse } from '@sitecore-content-sdk/core';
+import { debug } from '@sitecore-content-sdk/content';
+import { Document } from '@sitecore-content-sdk/content/atoms';
+
+/**
+ * Server component for Studio (NCC) components. Fetches the component layout
+ * `Document` from MMS server-side and renders the client `StudioComponentWrapper`.
+ * @param {StudioComponentServerWrapperProps} props incoming props
+ * @returns rendered `StudioComponentWrapper`
+ * @internal
+ */
+export const StudioComponentServerWrapper = async (props: StudioComponentServerWrapperProps) => {
+  const componentRef = props.componentRef || '';
+  if (!componentRef) return null;
+
+  const path = extractVariantPathFromComponentRef(componentRef, props.fieldNames);
+  if (!path) return null;
+
+  const document = await fetchDocument(path);
+  if (!document) return null;
+
+  return <StudioComponentWrapper document={document} />;
+};
+
+/**
+ * Extracts the variant path from a component reference.
+ * @param {string} componentRef The component reference string.
+ * @param {string} fieldNames The field names to extract the variant path for.
+ * @returns {string} The variant path.
+ * @internal
+ */
+function extractVariantPathFromComponentRef(
+  componentRef: string,
+  fieldNames: string = 'default'
+): string | null {
+  const paths = componentRef.split('|').reduce((acc, part) => {
+    const path = part.trim();
+    const segments = path.split('/');
+    const variant = segments[segments.length - 1];
+
+    acc.set(variant, path);
+
+    return acc;
+  }, new Map<string, string>());
+
+  const path = paths.get(fieldNames) || paths.get('default') || null;
+
+  if (!path) {
+    console.warn(
+      `StudioComponentServerWrapper: failed to extract path from ComponentRef "${componentRef}" with fieldNames "${fieldNames}". ` +
+        'Ensure the ComponentRef is in the expected format and that the correct fieldNames are provided.'
+    );
+  }
+
+  return path;
+}
+
+/**
+ * Prefix for MMS component paths in componentRef. The final URL will be resolved as `${host}/${MMS_COMPONENT_PATH_PREFIX}/${path}`.
+ */
+const MMS_COMPONENT_PATH_PREFIX = 'mms';
+
+/**
+ * Fetch a Studio component layout `Document` by reference.
+ * @param {string} path extracted component reference (path) from `params.ComponentRef`
+ * @returns {Promise<Document | null>} the resolved component layout, or `null` on missing path, fetch failure, or un-parseable body.
+ */
+async function fetchDocument(path: string): Promise<Document | null> {
+  if (!path) {
+    console.warn('StudioComponentService: missing component reference path');
+    return null;
+  }
+
+  let url: string;
+  try {
+    const pathWithMmsPrefix = path.startsWith('/')
+      ? `/${MMS_COMPONENT_PATH_PREFIX}${path}`
+      : `/${MMS_COMPONENT_PATH_PREFIX}/${path}`;
+
+    const hostURL = resolveHostURL();
+
+    url = new URL(pathWithMmsPrefix, hostURL).toString();
+  } catch (err) {
+    console.error(`StudioComponentService: failed to resolve component from "${path}"`, err);
+    return null;
+  }
+
+  let response: NativeDataFetcherResponse<string>;
+  try {
+    const fetcher = new NativeDataFetcher({ debugger: debug.layout });
+    response = await fetcher.get(url);
+  } catch (error) {
+    console.error(`StudioComponentService: failed to fetch component layout from ${url}`, error);
+    return null;
+  }
+
+  try {
+    const document: Document = JSON.parse(response.data);
+
+    return document;
+  } catch (err) {
+    console.error(
+      `StudioComponentService: failed to parse component layout response from ${url}`,
+      err
+    );
+    return null;
+  }
+}
+
+/**
+ * Resolve the host URL for StudioComponentService.
+ * @returns resolved URL
+ */
+function resolveHostURL(): URL {
+  const hostConfig = process.env.SITECORE_EDGE_PLATFORM_HOSTNAME;
+  if (!hostConfig)
+    throw new Error(
+      'StudioComponentService: a host must be configured to resolve a relative component reference. ' +
+        'Set the SITECORE_EDGE_PLATFORM_HOSTNAME environment variable.'
+    );
+
+  try {
+    return new URL(hostConfig);
+  } catch {
+    throw new Error(
+      `StudioComponentService: invalid host URL "${hostConfig}". ` +
+        'Set the SITECORE_EDGE_PLATFORM_HOSTNAME environment variable.'
+    );
+  }
+}
+

--- a/packages/react/src/atoms/Wrapper/StudioComponentWrapper.test.tsx
+++ b/packages/react/src/atoms/Wrapper/StudioComponentWrapper.test.tsx
@@ -1,0 +1,156 @@
+/* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable no-unused-expressions */
+import React from 'react';
+import sinon from 'sinon';
+import { expect, use as chaiUse } from 'chai';
+import sinonChai from 'sinon-chai';
+
+chaiUse(sinonChai);
+import { render } from '@testing-library/react';
+import { z } from 'zod';
+import { StudioComponentWrapper } from './StudioComponentWrapper';
+import { SitecoreProvider } from '../../components/SitecoreProvider';
+import type { Document } from '@sitecore-content-sdk/content/atoms';
+import type { AtomMetadata } from '../types';
+import type { ImportMapImport } from '../../components/DesignLibrary/models';
+
+/**
+ * Minimal error boundary to catch React render errors without crashing the test.
+ */
+class ErrorBoundary extends React.Component<
+  React.PropsWithChildren<{ onError?: (err: Error) => void }>,
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  componentDidCatch(err: Error) {
+    this.props.onError?.(err);
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+describe('<StudioComponentWrapper />', () => {
+  const sandbox = sinon.createSandbox();
+  const apiStub = {} as any;
+  const emptyComponentMap = new Map();
+  const loadImportMapStub = async (): Promise<ImportMapImport> => ({} as ImportMapImport);
+
+  const Box: React.FC<React.PropsWithChildren<Record<string, unknown>>> = (props) =>
+    React.createElement('div', { 'data-test': 'box', ...props }, props.children);
+
+  const atoms: AtomMetadata[] = [
+    {
+      name: 'Box',
+      type: 'atom',
+      description: 'Container',
+      component: Box as React.ComponentType<unknown>,
+      props: z.object({}),
+    },
+  ];
+
+  const sampleDoc: Document = {
+    name: 'hero',
+    root: { id: 'r', type: 'Box' },
+  };
+
+  const getPage = () => ({
+    locale: 'en',
+    layout: { sitecore: { context: {}, route: null } },
+    mode: {
+      name: 'normal',
+      isDesignLibrary: false,
+      designLibrary: { isVariantGeneration: false },
+      isNormal: true,
+      isPreview: false,
+      isEditing: false,
+    },
+  });
+
+  const renderInProvider = (ui: React.ReactNode) =>
+    render(
+      <SitecoreProvider
+        api={apiStub}
+        componentMap={emptyComponentMap}
+        loadImportMap={loadImportMapStub}
+        page={getPage() as any}
+        atomRegistry={{ atoms, callbacks: [] }}
+      >
+        {ui}
+      </SitecoreProvider>
+    );
+
+  const renderWithoutAtomRegistry = (ui: React.ReactNode) =>
+    render(
+      <SitecoreProvider
+        api={apiStub}
+        componentMap={emptyComponentMap}
+        loadImportMap={loadImportMapStub}
+        page={getPage() as any}
+      >
+        {ui}
+      </SitecoreProvider>
+    );
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('renders nothing when document is null', () => {
+    const { container } = renderInProvider(<StudioComponentWrapper document={null} />);
+    expect(container.innerHTML).to.equal('');
+  });
+
+  it('renders nothing when document is undefined', () => {
+    const { container } = renderInProvider(<StudioComponentWrapper document={undefined} />);
+    expect(container.innerHTML).to.equal('');
+  });
+
+  it('renders the component-layout view when document is provided', () => {
+    const { container } = renderInProvider(<StudioComponentWrapper document={sampleDoc} />);
+    expect(container.querySelector('[data-test="box"]')).to.exist;
+  });
+
+  it('renders nothing safely when atomRegistry is absent from the provider and document is null', () => {
+    const { container } = renderWithoutAtomRegistry(<StudioComponentWrapper document={null} />);
+    expect(container.innerHTML).to.equal('');
+  });
+
+  it('throws when document references an atom type not present in the registry', () => {
+    const docWithUnknownAtom: Document = { name: 'test', root: { id: 'x', type: 'UnknownAtom' } };
+    let caughtError: Error | undefined;
+
+    // Suppress the expected React error boundary console output
+    const consoleErrorStub = sandbox.stub(console, 'error');
+
+    render(
+      <SitecoreProvider
+        api={apiStub}
+        componentMap={emptyComponentMap}
+        loadImportMap={loadImportMapStub}
+        page={getPage() as any}
+        atomRegistry={{ atoms, callbacks: [] }}
+      >
+        <ErrorBoundary
+          onError={(err) => {
+            caughtError = err;
+          }}
+        >
+          <StudioComponentWrapper document={docWithUnknownAtom} />
+        </ErrorBoundary>
+      </SitecoreProvider>
+    );
+
+    consoleErrorStub.restore();
+
+    expect(caughtError).to.be.instanceOf(Error);
+    expect(caughtError!.message).to.include('UnknownAtom');
+  });
+});
+

--- a/packages/react/src/atoms/Wrapper/StudioComponentWrapper.tsx
+++ b/packages/react/src/atoms/Wrapper/StudioComponentWrapper.tsx
@@ -1,0 +1,30 @@
+'use client';
+import React, { JSX, useMemo } from 'react';
+import { createView } from '../component-layout';
+import { getAtomMap } from '../atom-registry-utils';
+import { useSitecore } from '../../components/SitecoreProvider';
+import { StudioComponentWrapperProps } from './models';
+
+/**
+ * Client component that renders a pre-fetched Studio (NCC) component layout.
+ *
+ * Expects `document` to be provided (fetched server-side by
+ * `StudioComponentServerWrapper` or from DesignLibraryLowCodeComponent). Renders `null` when no layout is available.
+ * @param {StudioComponentWrapperProps} props component props
+ * @internal
+ */
+export const StudioComponentWrapper = (props: StudioComponentWrapperProps): JSX.Element | null => {
+  const { atomRegistry } = useSitecore();
+  const atomMap = useMemo(() => getAtomMap(atomRegistry?.atoms ?? []), [atomRegistry?.atoms]);
+
+  const ViewComponent = useMemo(() => {
+    if (!props.document) return null;
+
+    return createView(props.document, atomMap, atomRegistry?.callbacks);
+  }, [props.document, atomMap, atomRegistry?.callbacks]);
+
+  if (!ViewComponent) return null;
+
+  return <ViewComponent />;
+};
+

--- a/packages/react/src/atoms/Wrapper/index.ts
+++ b/packages/react/src/atoms/Wrapper/index.ts
@@ -1,0 +1,4 @@
+export { StudioComponentWrapper } from './StudioComponentWrapper';
+export { StudioComponentServerWrapper } from './StudioComponentServerWrapper';
+export { StudioComponentParams, StudioComponentServerWrapperProps } from './models';
+

--- a/packages/react/src/atoms/Wrapper/index.ts
+++ b/packages/react/src/atoms/Wrapper/index.ts
@@ -1,4 +1,8 @@
 export { StudioComponentWrapper } from './StudioComponentWrapper';
 export { StudioComponentServerWrapper } from './StudioComponentServerWrapper';
-export { StudioComponentParams, StudioComponentServerWrapperProps } from './models';
+export {
+  StudioComponentParams,
+  StudioComponentServerWrapperProps,
+  StudioComponentWrapperProps,
+} from './models';
 

--- a/packages/react/src/atoms/Wrapper/models.ts
+++ b/packages/react/src/atoms/Wrapper/models.ts
@@ -1,0 +1,34 @@
+import type { Document } from '@sitecore-content-sdk/content/atoms';
+
+/**
+ * Rendering parameters injected by the layout service for Studio components.
+ * The `ComponentRef$` field on the rendering is copied into params with the `$` stripped.
+ * @internal
+ */
+export type StudioComponentParams = {
+  /**
+   * Identifier or relative/absolute path to the Studio component layout JSON in MMS.
+   */
+  componentRef?: string;
+};
+
+/**
+ * Props accepted by the RSC `StudioComponentServerWrapper`.
+ * @internal
+ */
+export type StudioComponentServerWrapperProps = {
+  /**
+   * Pipe separated relative paths to the Studio component layout JSON in MMS with the last segment as the variant name. The path matching `FieldNames` will be used, or `default` if no match.
+   */
+  componentRef: string;
+  fieldNames?: string;
+};
+
+/**
+ * Props accepted by the `StudioComponentWrapper` used to render a Studio component layout on the client. Expects a pre-fetched `document` containing the component layout data.
+ * @internal
+ */
+export type StudioComponentWrapperProps = {
+  document?: Document | null;
+};
+

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -87,8 +87,9 @@ export {
   StudioComponentWrapper,
   StudioComponentWrapper as StudioComponentClientWrapper,
   StudioComponentServerWrapper,
-  StudioComponentParams,
-  StudioComponentServerWrapperProps,
+  type StudioComponentParams,
+  type StudioComponentServerWrapperProps,
+  type StudioComponentWrapperProps,
 } from './atoms/Wrapper';
 export {
   DesignLibrary,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -84,6 +84,13 @@ export {
   BYOCServerWrapper,
 } from './components/FEaaS';
 export {
+  StudioComponentWrapper,
+  StudioComponentWrapper as StudioComponentClientWrapper,
+  StudioComponentServerWrapper,
+  StudioComponentParams,
+  StudioComponentServerWrapperProps,
+} from './atoms/Wrapper';
+export {
   DesignLibrary,
   DesignLibraryLowCodeComponent,
   DesignLibraryErrorBoundary,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
