### PR TITLE
[Pages Router] Set auth token in proxy and api route for preview protection

### DIFF
--- a/.changeset/seven-chicken-laugh.md
+++ b/.changeset/seven-chicken-laugh.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/nextjs': patch
+---
+
+[Pages Router] Set auth token in proxy and api route for preview protection

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -778,6 +778,13 @@ export { PlaceholderData }
 export { PlaceholdersData }
 
 // @public
+export const PREVIEW_COOKIES: {
+    PREVIEW_DATA: string;
+    PRERENDER_BYPASS: string;
+    PREVIEW_TOKEN: string;
+};
+
+// @public
 export class PreviewProxy extends ProxyBase {
     constructor(config: PreviewProxyConfig);
     // (undocumented)

--- a/packages/nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.test.ts
@@ -770,7 +770,7 @@ describe('EditingRenderMiddleware', () => {
     });
   });
 
-  it('should issue intrnal request propagating allowed headers', async () => {
+  it('should issue internal request propagating allowed headers', async () => {
     const req = mockRequest({
       query,
       headers: {
@@ -895,6 +895,29 @@ describe('EditingRenderMiddleware', () => {
     await handler(req, res);
 
     expect(res.setHeader).to.have.been.calledWith('Set-Cookie', []);
+    expect(res.status).to.be.calledOnceWith(200);
+  });
+
+  it('should set authorization token cookie to the response', async () => {
+    const req = mockRequest({ query, headers: { authorization: 'token-value' } });
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    sinon
+      .stub(middleware['dataFetcher'], 'get')
+      .resolves({ status: 200, statusText: 'success', data: '<div>some html</div>' });
+
+    await handler(req, res);
+
+    const setCookieCalls = (res.setHeader as sinon.SinonStub)
+      .getCalls()
+      .filter((call) => call.args[0] === 'Set-Cookie');
+    const lastSetCookie = setCookieCalls[1]?.args[1];
+    expect(lastSetCookie).to.deep.include(
+      'sc_preview_token=token-value; Path=/; HttpOnly; SameSite=None; Secure'
+    );
     expect(res.status).to.be.calledOnceWith(200);
   });
 

--- a/packages/nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/nextjs/src/editing/editing-render-middleware.ts
@@ -22,6 +22,7 @@ import {
   getCSPHeader,
   resolveServerUrl,
   getAllowedQueryParams,
+  PREVIEW_COOKIES,
 } from './utils';
 import type { AllowedQueryParams } from './types';
 import { EDITING_PARAMS_HEADER } from './constants';
@@ -201,7 +202,7 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
       const propagatedQsParams = getQueryParamsForPropagation(query);
 
       // Get headers to propagate on subsequent requests
-      const propagatedHeaders = {
+      const propagatedHeaders: Record<string, string> = {
         ...getHeadersForPropagation(headers),
         [EDITING_PARAMS_HEADER]: JSON.stringify(previewData),
       };
@@ -218,6 +219,12 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
         const filteredCookies = cleanupNextPreviewCookies(cookies);
         filteredCookies && res.setHeader('Set-Cookie', filteredCookies);
       }
+
+      // Add authorization token cookie to the response to support navigation.
+      res.setHeader('Set-Cookie', [
+        ...(res.getHeader('Set-Cookie') as string[]),
+        `${PREVIEW_COOKIES.PREVIEW_TOKEN}=${propagatedHeaders.authorization}; Path=/; HttpOnly; SameSite=None; Secure`,
+      ]);
 
       debug.editing('editing render middleware end in %dms: %o', Date.now() - startTimestamp, {
         status: 200,

--- a/packages/nextjs/src/editing/index.ts
+++ b/packages/nextjs/src/editing/index.ts
@@ -4,6 +4,7 @@ export {
   EditingRenderMiddlewareConfig,
 } from './editing-render-middleware';
 export {
+  PREVIEW_COOKIES,
   isDesignLibraryPreviewData,
   getQueryParamsForPropagation,
   getHeadersForPropagation,

--- a/packages/nextjs/src/editing/utils.ts
+++ b/packages/nextjs/src/editing/utils.ts
@@ -119,12 +119,14 @@ export const getAllowedQueryParams = (
 };
 
 /**
- * Next.js preview cookies enum
+ * Preview cookies constants referenced within the sdk
+ * @public
  */
-export const enum PreviewCookies {
-  PREVIEW_DATA = '__next_preview_data',
-  PRERENDER_BYPASS = '__prerender_bypass',
-}
+export const PREVIEW_COOKIES = {
+  PREVIEW_DATA: '__next_preview_data',
+  PRERENDER_BYPASS: '__prerender_bypass',
+  PREVIEW_TOKEN: 'sc_preview_token',
+};
 
 /**
  * Filters out Next.js preview cookies from a cookie string or array
@@ -141,8 +143,8 @@ export const cleanupNextPreviewCookies = (cookies: string | string[] | null) => 
   // Filter out Next.js preview cookies
   const filteredCookies = cookies.filter(
     (cookie: string) =>
-      !new RegExp(`^${PreviewCookies.PREVIEW_DATA}=`).test(cookie) &&
-      !new RegExp(`^${PreviewCookies.PRERENDER_BYPASS}=`).test(cookie)
+      !new RegExp(`^${PREVIEW_COOKIES.PREVIEW_DATA}=`).test(cookie) &&
+      !new RegExp(`^${PREVIEW_COOKIES.PRERENDER_BYPASS}=`).test(cookie)
   );
   return filteredCookies;
 };

--- a/packages/nextjs/src/proxy/preview-proxy.test.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.test.ts
@@ -6,6 +6,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SITE_KEY } from '@sitecore-content-sdk/content/site';
 import { EDITING_PARAMS_HEADER } from '../editing/constants';
 import { PreviewProxy } from './preview-proxy';
+import { PREVIEW_COOKIES } from '../editing/utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -51,6 +52,7 @@ const createRequest = (props: Record<string, any> = {}) => {
 
 const createResponse = (props: Record<string, any> = {}) => {
   const headerStore: Record<string, string> = { ...(props.headerValues || {}) };
+  const cookieStore: Record<string, string> = { ...(props.cookieValues || {}) };
 
   const res = {
     headers: {
@@ -61,6 +63,22 @@ const createResponse = (props: Record<string, any> = {}) => {
         headerStore[key] = value;
       },
     },
+    cookies: {
+      // eslint-disable-next-line no-unused-vars
+      set(key: string, value: string, _attributes?: Record<string, unknown>) {
+        cookieStore[key] = value;
+      },
+      get(key: string) {
+        return { value: cookieStore[key] };
+      },
+    },
+    json: sinon.stub().callsFake((body, options) => {
+      return {
+        headers: options?.headers,
+        status: options?.status,
+        body,
+      };
+    }),
   } as unknown as NextResponse;
 
   return res;
@@ -174,8 +192,8 @@ describe('PreviewProxy', () => {
         expect(result).to.equal(fakeForbidden);
       });
 
-      it('should skip and return response unchanged when editing mode is not preview', async () => {
-        const editEditingOptions = { ...editingOptions, mode: 'edit' };
+      it('should skip and return response unchanged when mode is not preview or edit', async () => {
+        const editEditingOptions = { ...editingOptions, mode: 'normal' };
         const req = createRequest({
           headerValues: {
             [EDITING_PARAMS_HEADER]: JSON.stringify(editEditingOptions),
@@ -189,6 +207,50 @@ describe('PreviewProxy', () => {
         expect(result).to.equal(res);
         expect(clientStub.getPreview).to.not.have.been.called;
         expect(clientStub.getPage).to.not.have.been.called;
+      });
+
+      it('should set authorization token cookie to the response', async () => {
+        const req = createRequest({
+          headerValues: {
+            [EDITING_PARAMS_HEADER]: JSON.stringify(editingOptions),
+            Authorization: 'Bearer abc',
+          },
+        });
+        const res = createResponse();
+        clientStub.getPreview.resolves({} as any);
+
+        const result = await proxy.handle(req, res);
+
+        expect(result.cookies.get(PREVIEW_COOKIES.PREVIEW_TOKEN)?.value).to.equal('Bearer abc');
+        expect(result).to.equal(res);
+      });
+
+      it('should handle 403 response from getPreview', async () => {
+        const req = createRequest({
+          headerValues: {
+            [EDITING_PARAMS_HEADER]: JSON.stringify(editingOptions),
+            Authorization: 'Bearer abc',
+          },
+        });
+        const res = createResponse();
+
+        clientStub.getPreview.rejects({ response: { status: 403 } });
+
+        sandbox.stub(NextResponse, 'json').callsFake((body, options) => {
+          return {
+            headers: options?.headers,
+            status: options?.status,
+            body,
+          } as unknown as NextResponse;
+        });
+
+        const result = await proxy.handle(req, res);
+
+        expect(result.status).to.equal(403);
+        expect(result.body).to.deep.equal({
+          html: 'Preview content is not found or access is denied',
+        });
+        expect(clientStub.getPreview).to.have.been.calledOnce;
       });
     });
 
@@ -232,6 +294,46 @@ describe('PreviewProxy', () => {
           { status: 403 }
         );
         expect(result).to.equal(fakeForbidden);
+      });
+
+      it('should set authorization token cookie to the response', async () => {
+        const req = createRequest({
+          nextUrl: { pathname: '/about', locale: 'en' },
+          cookieValues: { [SITE_KEY]: 'my-site', [PREVIEW_COOKIES.PREVIEW_TOKEN]: 'Bearer abc' },
+        });
+
+        const res = createResponse();
+        clientStub.getPage.resolves({} as any);
+
+        const result = await proxy.handle(req, res);
+
+        expect(result.cookies.get(PREVIEW_COOKIES.PREVIEW_TOKEN)?.value).to.equal('Bearer abc');
+        expect(result).to.equal(res);
+      });
+
+      it('should handle 403 response from getPage', async () => {
+        const req = createRequest({
+          nextUrl: { pathname: '/about', locale: 'en' },
+          cookieValues: { [SITE_KEY]: 'my-site', [PREVIEW_COOKIES.PREVIEW_TOKEN]: 'Bearer abc' },
+        });
+        const res = createResponse();
+        clientStub.getPage.rejects({ response: { status: 403 } });
+
+        sandbox.stub(NextResponse, 'json').callsFake((body, options) => {
+          return {
+            headers: options?.headers,
+            status: options?.status,
+            body,
+          } as unknown as NextResponse;
+        });
+
+        const result = await proxy.handle(req, res);
+
+        expect(result.status).to.equal(403);
+        expect(result.body).to.deep.equal({
+          html: 'Preview content is not found or access is denied',
+        });
+        expect(clientStub.getPage).to.have.been.calledOnce;
       });
     });
   });

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -45,7 +45,7 @@ export class PreviewProxy extends ProxyBase {
 
     debug.editing('preview proxy start');
 
-    // Process only preview requests (e.g. non editing or design studio)
+    // Process only preview/editing requests
     if (editingOptions && !['preview', 'edit'].includes(editingOptions.mode)) {
       debug.editing('preview proxy skipped (mode is not preview or edit)');
       return res;

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ProxyBase } from './proxy';
 import { EditingOptions } from '@sitecore-content-sdk/content/editing';
-import { SitecoreClient } from '../client';
-import { EDITING_PARAMS_HEADER } from '../editing/constants';
 import { Page } from '@sitecore-content-sdk/content/client';
 import { SITE_KEY } from '@sitecore-content-sdk/content/site';
+import { SitecoreClient } from '../client';
+import { EDITING_PARAMS_HEADER } from '../editing/constants';
+import { PREVIEW_COOKIES } from '../editing/utils';
 import debug from '../debug';
+import { ProxyBase } from './proxy';
 
 /**
  * Configuration for PreviewProxy
@@ -34,14 +35,19 @@ export class PreviewProxy extends ProxyBase {
     }
 
     const previewParams = req.headers.get(EDITING_PARAMS_HEADER);
-    const authHeader = req.headers.get('Authorization') ?? '';
+    // 1. Authorization header comes from the editing render endpoint
+    // 2. Token comes from cookies when navigating to the preview page
+    const authHeader =
+      req.headers.get('Authorization') ||
+      req.cookies.get(PREVIEW_COOKIES.PREVIEW_TOKEN)?.value ||
+      '';
     let editingOptions: EditingOptions | null = previewParams ? JSON.parse(previewParams) : null;
 
     debug.editing('preview proxy start');
 
     // Process only preview requests (e.g. non editing or design studio)
-    if (editingOptions && editingOptions.mode !== 'preview') {
-      debug.editing('preview proxy skipped (mode is not preview)');
+    if (editingOptions && !['preview', 'edit'].includes(editingOptions.mode)) {
+      debug.editing('preview proxy skipped (mode is not preview or edit)');
       return res;
     }
 
@@ -49,25 +55,35 @@ export class PreviewProxy extends ProxyBase {
 
     // Scenario when the request is coming from /api/editing/render endpoint
     if (editingOptions) {
-      pageData = await this.client.getPreview(editingOptions, {
-        headers: {
-          Authorization: authHeader,
-        },
-      });
-    } else {
-      // Scenario when the page is requested using direct path or navigation is performed
-      pageData = await this.client.getPage(
-        req.nextUrl.pathname,
-        {
-          site: req.cookies.get(SITE_KEY)?.value,
-          locale: this.getLanguage(req),
-        },
-        {
+      pageData = await this.client
+        .getPreview(editingOptions, {
           headers: {
             Authorization: authHeader,
           },
-        }
-      );
+        })
+        .catch((error) => {
+          debug.editing('preview proxy failed to get preview: %o', error);
+          return null;
+        });
+    } else {
+      // Scenario when the page is requested using direct path or navigation is performed
+      pageData = await this.client
+        .getPage(
+          req.nextUrl.pathname,
+          {
+            site: req.cookies.get(SITE_KEY)?.value,
+            locale: this.getLanguage(req),
+          },
+          {
+            headers: {
+              Authorization: authHeader,
+            },
+          }
+        )
+        .catch((error) => {
+          debug.editing('preview proxy failed to get page: %o', error);
+          return null;
+        });
     }
 
     // Preview content is not found or access is denied
@@ -78,6 +94,13 @@ export class PreviewProxy extends ProxyBase {
         { status: 403 }
       );
     }
+
+    res.cookies.set(PREVIEW_COOKIES.PREVIEW_TOKEN, authHeader, {
+      secure: true,
+      httpOnly: true,
+      sameSite: 'none',
+      path: '/',
+    });
 
     debug.editing('preview proxy end');
 

--- a/packages/nextjs/src/proxy/proxy.ts
+++ b/packages/nextjs/src/proxy/proxy.ts
@@ -5,7 +5,7 @@ import {
   createGraphQLClientFactory,
   GraphQLClientOptions,
 } from '@sitecore-content-sdk/content/client';
-import { PreviewCookies } from '../editing/utils';
+import { PREVIEW_COOKIES } from '../editing/utils';
 import debug from '../debug';
 
 export const REWRITE_HEADER_NAME = 'x-sc-rewrite';
@@ -108,8 +108,8 @@ export abstract class ProxyBase extends ProxyHandler {
    */
   protected isPreview(req: NextRequest) {
     return !!(
-      req.cookies.get(PreviewCookies.PRERENDER_BYPASS)?.value ||
-      req.cookies.get(PreviewCookies.PREVIEW_DATA)?.value
+      req.cookies.get(PREVIEW_COOKIES.PRERENDER_BYPASS)?.value ||
+      req.cookies.get(PREVIEW_COOKIES.PREVIEW_DATA)?.value
     );
   }
 

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.test.ts
@@ -145,7 +145,7 @@ describe('createEditingRenderRouteHandlers', () => {
           version: query.sc_version,
           layoutKind: query.sc_layoutKind,
         })),
-        PreviewCookies: {
+        PREVIEW_COOKIES: {
           PREVIEW_DATA: '__next_preview_data',
           PRERENDER_BYPASS: '__prerender_bypass',
         },

--- a/packages/nextjs/src/route-handler/editing-render-route-handler.ts
+++ b/packages/nextjs/src/route-handler/editing-render-route-handler.ts
@@ -20,7 +20,7 @@ import {
   getRequiredEditingParamsList,
   getCSPHeader,
   resolveServerUrl,
-  PreviewCookies,
+  PREVIEW_COOKIES,
   getAllowedQueryParams,
 } from '../editing/utils';
 import { EDITING_PARAMS_HEADER } from '../editing/constants';
@@ -199,8 +199,8 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
 
     const cookieStore = await getNextCookies();
     cookieStore.set(
-      PreviewCookies.PRERENDER_BYPASS,
-      cookieStore.get(PreviewCookies.PRERENDER_BYPASS)?.value || '',
+      PREVIEW_COOKIES.PRERENDER_BYPASS,
+      cookieStore.get(PREVIEW_COOKIES.PRERENDER_BYPASS)?.value || '',
       {
         httpOnly: true,
         path: '/',
@@ -359,8 +359,8 @@ export const createEditingRenderRouteHandlers = (options: EditingHandlerOptions)
     // add prerender bypass cookie to forwarded request in order to enable draft mode
     const cookieStore = await getNextCookies();
     const reqCookie = req.headers.get('cookie') || '';
-    const prerenderBypassCookie = `${PreviewCookies.PRERENDER_BYPASS}=${
-      cookieStore.get(PreviewCookies.PRERENDER_BYPASS)?.value || ''
+    const prerenderBypassCookie = `${PREVIEW_COOKIES.PRERENDER_BYPASS}=${
+      cookieStore.get(PREVIEW_COOKIES.PRERENDER_BYPASS)?.value || ''
     }`;
     const forwardCookie = reqCookie
       ? `${reqCookie}; ${prerenderBypassCookie}`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivationt
Set preview token in API route and proxy to support both render and navigation scenarios.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
