### PR TITLE
[nextjs] Pass sc_previewMode, sc_site when performing authorization in PreviewProxy

### DIFF
--- a/.changeset/thirty-hats-smoke.md
+++ b/.changeset/thirty-hats-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/nextjs': patch
+---
+
+Pass sc_previewMode, sc_site when performing authorization in PreviewProxy

--- a/packages/nextjs/src/proxy/preview-proxy.test.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.test.ts
@@ -269,7 +269,7 @@ describe('PreviewProxy', () => {
         expect(clientStub.getPage).to.have.been.calledOnceWithExactly(
           '/about',
           { site: 'my-site', locale: 'de-DE' },
-          { headers: { Authorization: 'Bearer xyz' } }
+          { headers: { Authorization: 'Bearer xyz', sc_previewMode: 'true', sc_site: 'my-site' } }
         );
         expect(clientStub.getPreview).to.not.have.been.called;
         expect(result).to.equal(res);

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -66,17 +66,21 @@ export class PreviewProxy extends ProxyBase {
           return null;
         });
     } else {
+      const site = req.cookies.get(SITE_KEY)?.value as string;
+
       // Scenario when the page is requested using direct path or navigation is performed
       pageData = await this.client
         .getPage(
           req.nextUrl.pathname,
           {
-            site: req.cookies.get(SITE_KEY)?.value,
+            site,
             locale: this.getLanguage(req),
           },
           {
             headers: {
               Authorization: authHeader,
+              sc_previewMode: 'true',
+              sc_site: site
             },
           }
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Pass sc_previewMode, sc_site when performing authorization in PreviewProxy
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
