### PR TITLE
[nextjs] Check sc_site search parameter in PreviewProxy as a fallback when cookie is missing

### DIFF
--- a/.changeset/whole-falcons-shout.md
+++ b/.changeset/whole-falcons-shout.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/nextjs': patch
+---
+
+Check sc_site search parameter in PreviewProxy as a fallback when cookie is missing

--- a/packages/nextjs/src/proxy/preview-proxy.test.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.test.ts
@@ -25,6 +25,11 @@ const createRequest = (props: Record<string, any> = {}) => {
       clone() {
         return Object.assign({}, req.nextUrl);
       },
+      searchParams: {
+        get(key: string) {
+          return props.searchParams?.[key];
+        },
+      },
       ...(props.nextUrl || {}),
     },
     headers: {
@@ -270,6 +275,32 @@ describe('PreviewProxy', () => {
           '/about',
           { site: 'my-site', locale: 'de-DE' },
           { headers: { Authorization: 'Bearer xyz', sc_previewMode: 'true', sc_site: 'my-site' } }
+        );
+        expect(clientStub.getPreview).to.not.have.been.called;
+        expect(result).to.equal(res);
+      });
+
+      it('should call getPage with pathname, site query string, locale and Authorization header', async () => {
+        const req = createRequest({
+          nextUrl: { pathname: '/about', locale: 'de-DE' },
+          headerValues: { Authorization: 'Bearer xyz' },
+          searchParams: { [SITE_KEY]: 'my-site' },
+        });
+        const res = createResponse();
+        clientStub.getPage.resolves({} as any);
+
+        const result = await proxy.handle(req, res);
+
+        expect(clientStub.getPage).to.have.been.calledOnceWithExactly(
+          '/about',
+          { site: 'my-site', locale: 'de-DE' },
+          {
+            headers: {
+              Authorization: 'Bearer xyz',
+              sc_previewMode: 'true',
+              sc_site: 'my-site',
+            },
+          }
         );
         expect(clientStub.getPreview).to.not.have.been.called;
         expect(result).to.equal(res);

--- a/packages/nextjs/src/proxy/preview-proxy.ts
+++ b/packages/nextjs/src/proxy/preview-proxy.ts
@@ -66,7 +66,7 @@ export class PreviewProxy extends ProxyBase {
           return null;
         });
     } else {
-      const site = req.cookies.get(SITE_KEY)?.value as string;
+      const site = req.cookies.get(SITE_KEY)?.value || req.nextUrl.searchParams.get(SITE_KEY) || '';
 
       // Scenario when the page is requested using direct path or navigation is performed
       pageData = await this.client
@@ -80,7 +80,7 @@ export class PreviewProxy extends ProxyBase {
             headers: {
               Authorization: authHeader,
               sc_previewMode: 'true',
-              sc_site: site
+              sc_site: site,
             },
           }
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Check sc_site search parameter in PreviewProxy as a fallback when cookie is missing
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
