### PR TITLE
[nextjs] 500 Internal Server Error occurs in Pages editor when Server error page is opened

### DIFF
--- a/.changeset/modern-impalas-write.md
+++ b/.changeset/modern-impalas-write.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/nextjs': patch
+---
+
+500 Internal Server Error occurs in Pages editor when Server error page is opened

--- a/packages/nextjs/src/editing/utils.test.ts
+++ b/packages/nextjs/src/editing/utils.test.ts
@@ -966,7 +966,7 @@ describe('editing/utils', () => {
     it('should throw error for non-404 fetch failures', async () => {
       const error = {
         response: {
-          status: 500,
+          status: 503,
         },
       };
 
@@ -1053,6 +1053,27 @@ describe('editing/utils', () => {
       const result = await getEditingRequestHtml(requestUrl, {}, {}, [], mockDataFetcher as any);
 
       expect(result).to.equal('<html><body>403 Forbidden</body></html>');
+    });
+
+    it('should handle 500 response without throwing', async () => {
+      const mock500Response = {
+        data: {
+          html: '<html><body>500 Internal Server Error</body></html>',
+        },
+      };
+
+      const error = {
+        response: {
+          status: 500,
+          ...mock500Response,
+        },
+      };
+
+      mockDataFetcher.get.rejects(error);
+
+      const result = await getEditingRequestHtml(requestUrl, {}, {}, [], mockDataFetcher as any);
+
+      expect(result).to.equal('<html><body>500 Internal Server Error</body></html>');
     });
   });
 

--- a/packages/nextjs/src/editing/utils.ts
+++ b/packages/nextjs/src/editing/utils.ts
@@ -264,7 +264,11 @@ export const getEditingRequestHtml = async (
       // We need to handle not found error provided by Vercel
       // for `fallback: false` pages
       // Or preview content is not found or access is denied
-      if (err.response.status === 404 || err.response.status === 403) {
+      if (
+        err.response.status === 404 ||
+        err.response.status === 403 ||
+        err.response.status === 500
+      ) {
         return err.response;
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Added 500 status to the group of explicitly handled error that return the err.response object. 

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
