### PR TITLE
[content] Fix fallback sitemapindex

### DIFF
--- a/.changeset/forty-planets-thank.md
+++ b/.changeset/forty-planets-thank.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/content': patch
+---
+
+[content] Fix fallback URL in Sitemapindex

--- a/packages/content/src/client/sitecore-client.test.ts
+++ b/packages/content/src/client/sitecore-client.test.ts
@@ -1553,7 +1553,9 @@ describe('SitecoreClient', () => {
 
       expect(sitemapXmlServiceStub.fetchSitemaps.called).to.be.true;
       expect(result).to.include('<?xml version="1.0" encoding="UTF-8"?>');
-      expect(result).to.include('<sitemapindex xmlns="http://sitemaps.org/schemas/sitemap/0.9">');
+      expect(result).to.include(
+        '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+      );
 
       absoluteSitemapPaths.forEach((path) => {
         const fileName = path.split('/').pop();

--- a/packages/content/src/client/sitecore-client.ts
+++ b/packages/content/src/client/sitecore-client.ts
@@ -672,7 +672,7 @@ export class SitecoreClient implements BaseSitecoreClient {
     }
 
     return `<?xml version="1.0" encoding="UTF-8"?>
-      <sitemapindex xmlns="http://sitemaps.org/schemas/sitemap/0.9">
+      <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
       ${sitemaps
         .map((item: string) => {
           const parseUrl = item.split('/');


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fixes the invalid format of schema URL in fallback sitemap markup.

## Testing Details
- [x] Unit Test Adjusted
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
