### PR TITLE
[nextjs] Add PartialDesignDynamicPlaceholder to App Router and Pages Router templates

### DIFF
--- a/.changeset/partial-design-placeholder-templates.md
+++ b/.changeset/partial-design-placeholder-templates.md
@@ -1,0 +1,5 @@
+---
+'create-content-sdk-app': patch
+---
+
+[create-content-sdk] Add PartialDesignDynamicPlaceholder to App Router and Pages Router templates for SitecoreAI partial designs

--- a/.changeset/partial-design-placeholder-templates.md
+++ b/.changeset/partial-design-placeholder-templates.md
@@ -2,4 +2,4 @@
 'create-content-sdk-app': patch
 ---
 
-[create-content-sdk] Add PartialDesignDynamicPlaceholder to App Router and Pages Router templates for SitecoreAI partial designs
+[create-content-sdk-app] Add PartialDesignDynamicPlaceholder to App Router and Pages Router templates for Sitecore AI partial designs

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/.sitecore/component-map.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/.sitecore/component-map.ts
@@ -2,12 +2,14 @@
 import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
 import { Form } from '@sitecore-content-sdk/nextjs';
 // end of built-in components
+import * as PartialDesignDynamicPlaceholder from 'src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder';
 
 // Components must be registered within the map to match the string key with component name in Sitecore
 export const componentMap = new Map<string, NextjsContentSdkComponent>([
   ['BYOCWrapper', BYOCWrapper],
   ['FEaaSWrapper', FEaaSWrapper],
   ['Form', { ...Form, componentType: 'client' }],
+  ['PartialDesignDynamicPlaceholder', { ...PartialDesignDynamicPlaceholder }],
 ]);
 
 export default componentMap;

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder.tsx
@@ -1,0 +1,19 @@
+import { JSX } from 'react';
+import { AppPlaceholder } from '@sitecore-content-sdk/nextjs';
+import componentMap from '.sitecore/component-map';
+import { ComponentWithContextProps } from 'lib/component-props';
+
+/**
+ * Renders a dynamic placeholder for SXA partial designs.
+ * The placeholder key is provided via the rendering parameter `sig`.
+ */
+const PartialDesignDynamicPlaceholder = (props: ComponentWithContextProps): JSX.Element => (
+  <AppPlaceholder
+    name={props.rendering?.params?.sig || ''}
+    rendering={props.rendering}
+    page={props.page}
+    componentMap={componentMap}
+  />
+);
+
+export default PartialDesignDynamicPlaceholder;

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder.tsx
@@ -4,7 +4,7 @@ import componentMap from '.sitecore/component-map';
 import { ComponentWithContextProps } from 'lib/component-props';
 
 /**
- * Renders a dynamic placeholder for SXA partial designs.
+ * Renders a dynamic placeholder for partial designs.
  * The placeholder key is provided via the rendering parameter `sig`.
  */
 const PartialDesignDynamicPlaceholder = (props: ComponentWithContextProps): JSX.Element => (

--- a/packages/create-content-sdk-app/src/templates/nextjs/.sitecore/component-map.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs/.sitecore/component-map.ts
@@ -2,12 +2,14 @@
 import { BYOCWrapper, NextjsContentSdkComponent, FEaaSWrapper } from '@sitecore-content-sdk/nextjs';
 import { Form } from '@sitecore-content-sdk/nextjs';
 // end of built-in components
+import * as PartialDesignDynamicPlaceholder from 'src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder';
 
 // Components must be registered within the map to match the string key with component name in Sitecore
 export const componentMap = new Map<string, NextjsContentSdkComponent>([
   ['BYOCWrapper', BYOCWrapper],
   ['FEaaSWrapper', FEaaSWrapper],
   ['Form', Form],
+  ['PartialDesignDynamicPlaceholder', { ...PartialDesignDynamicPlaceholder }],
 ]);
 
 export default componentMap;

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder.tsx
@@ -3,7 +3,7 @@ import { Placeholder } from '@sitecore-content-sdk/nextjs';
 import { ComponentProps } from 'lib/component-props';
 
 /**
- * Renders a dynamic placeholder for SXA partial designs.
+ * Renders a dynamic placeholder for partial designs.
  * The placeholder key is provided via the rendering parameter `sig`.
  */
 const PartialDesignDynamicPlaceholder = (props: ComponentProps): JSX.Element => (

--- a/packages/create-content-sdk-app/src/templates/nextjs/src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder.tsx
+++ b/packages/create-content-sdk-app/src/templates/nextjs/src/components/partial-design-dynamic-placeholder/PartialDesignDynamicPlaceholder.tsx
@@ -1,0 +1,13 @@
+import { JSX } from 'react';
+import { Placeholder } from '@sitecore-content-sdk/nextjs';
+import { ComponentProps } from 'lib/component-props';
+
+/**
+ * Renders a dynamic placeholder for SXA partial designs.
+ * The placeholder key is provided via the rendering parameter `sig`.
+ */
+const PartialDesignDynamicPlaceholder = (props: ComponentProps): JSX.Element => (
+  <Placeholder name={props.rendering?.params?.sig || ''} rendering={props.rendering} />
+);
+
+export default PartialDesignDynamicPlaceholder;


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR adds the previously missing `PartialDesignDynamicPlaceholder` component to the App Router and Pages Router templates (including component-map registration), aligned with XMCloud Starter Implementation, so scaffolded apps support SitecoreAI partial designs.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
