### PR TITLE
Add CLI npm repository metadata

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,11 @@
     "url": "https://doc.sitecore.com/xmc/en/developers/content-sdk/index.html"
   },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Sitecore/content-sdk.git",
+    "directory": "packages/cli"
+  },
   "homepage": "https://doc.sitecore.com/xmc/en/developers/content-sdk/index.html",
   "bugs": {
     "url": "https://github.com/sitecore/content-sdk/issues"


### PR DESCRIPTION
## Summary

Add standard npm `repository` metadata to `packages/cli/package.json`.

The published `@sitecore-content-sdk/cli@2.1.0` package already exposes `homepage` and `bugs` links, but `npm view @sitecore-content-sdk/cli@2.1.0 name version homepage repository bugs --json` does not return a `repository` field. This change adds the GitHub repository URL and package directory in the standard npm manifest shape for monorepo packages.

## Validation

- `npm view @sitecore-content-sdk/cli@2.1.0 name version homepage repository bugs --json`
- `node -e "const p=require('./packages/cli/package.json'); if(!p.repository || p.repository.type!=='git' || !p.repository.url.includes('Sitecore/content-sdk') || p.repository.directory!=='packages/cli') throw new Error('repository metadata mismatch'); console.log('sitecore metadata check passed');"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts` from `packages/cli`

## Scope

Manifest metadata only. No runtime code, dependency, or lockfile changes.
