### PR TITLE
[Angular CSDK] Fix editing frames not applied correctly, dictionary not being used

### DIFF
--- a/packages/angular/src/components/default-empty-text-field.component.ts
+++ b/packages/angular/src/components/default-empty-text-field.component.ts
@@ -5,6 +5,6 @@ import { Component } from '@angular/core';
  */
 @Component({
   selector: '[sc-default-empty-text-field-editing-placeholder]',
-  template: '[No text in field]',
+  template: '<span>[No text in field]</span>',
 })
 export class DefaultEmptyFieldEditingComponent {}

--- a/packages/angular/src/components/default-empty-text-field.component.ts
+++ b/packages/angular/src/components/default-empty-text-field.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
  * Default component that will be rendered in pages when field is empty; applies for text, richtext, date and link fields.
  */
 @Component({
-  selector: '[sc-default-empty-text-field-editing-placeholder]',
-  template: '<span>[No text in field]</span>',
+  selector: 'span[sc-default-empty-text-field-editing-placeholder]',
+  template: '[No text in field]',
 })
 export class DefaultEmptyFieldEditingComponent {}

--- a/packages/angular/src/components/field-directives/base-field.directive.ts
+++ b/packages/angular/src/components/field-directives/base-field.directive.ts
@@ -1,11 +1,9 @@
 import {
   EmbeddedViewRef,
-  EnvironmentInjector,
   Renderer2,
   TemplateRef,
   Type,
   ViewContainerRef,
-  createComponent,
   effect,
   inject,
   type Signal,
@@ -52,7 +50,6 @@ export abstract class BaseFieldDirective<TField> {
   protected readonly templateRef = inject(TemplateRef<unknown>);
   protected readonly renderer = inject(Renderer2);
   protected readonly context = inject(SitecoreContextService, { optional: true });
-  private readonly envInjector = inject(EnvironmentInjector);
 
   /** Embedded view created by the latest successful render; cleared on each tick. */
   protected viewRef?: EmbeddedViewRef<unknown>;
@@ -113,12 +110,7 @@ export abstract class BaseFieldDirective<TField> {
     if (tpl) {
       this.viewContainer.createEmbeddedView(tpl);
     } else {
-      const hostEl = this.renderer.createElement('span') as HTMLElement;
-      const ref = createComponent(this.defaultEmptyComponent, {
-        hostElement: hostEl,
-        environmentInjector: this.envInjector,
-      });
-      this.viewContainer.insert(ref.hostView);
+      this.viewContainer.createComponent(this.defaultEmptyComponent);
     }
     this.renderEditingChrome(MetadataKind.Close);
   }

--- a/packages/angular/src/i18n/sitecore-translate-loader.ts
+++ b/packages/angular/src/i18n/sitecore-translate-loader.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { TranslateLoader } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
 import { SitecoreContextService } from '../lib/sitecore-context.service';
+import debug from '../debug';
 
 /**
  * `ngx-translate` loader using Sitecore dictionary from {@link SitecoreContextService}.
@@ -19,6 +20,7 @@ export class SitecoreTranslateLoader implements TranslateLoader {
    */
   getTranslation(): Observable<Record<string, string>> {
     const dictionary = this.context.dictionary();
+    debug.dictionary('ngx translate uses dictionary', dictionary);
     return of(dictionary ?? {});
   }
 }

--- a/packages/create-content-sdk-app/src/templates/angular/src/app/app.config.ts
+++ b/packages/create-content-sdk-app/src/templates/angular/src/app/app.config.ts
@@ -15,7 +15,7 @@ import scConfig from '../../sitecore.config';
 import { getClient } from '../content-sdk/client/sitecore-client';
 import { LOADERS } from '../content-sdk/loaders';
 import { componentMap } from '.sitecore/component-map';
-import { TranslateLoader } from '@ngx-translate/core';
+import { provideTranslateLoader, provideTranslateService } from '@ngx-translate/core';
 
 /**
  * Client hydration is disabled so that RouterLink and other directives attach correctly
@@ -37,7 +37,9 @@ export const appConfig: ApplicationConfig = {
     provideLoaderRegistry(LOADERS),
     ClientPreLoaderDataService,
     { provide: SITECORE_COMPONENT_MAP, useValue: componentMap },
-    { provide: TranslateLoader, useClass: SitecoreTranslateLoader },
+    provideTranslateService({
+      loader: provideTranslateLoader(SitecoreTranslateLoader),
+    }),
     // provides locale aware serializer for csdk and angular router links
     { provide: UrlSerializer, useClass: LocaleUrlSerializer },
   ],

--- a/packages/create-content-sdk-app/src/templates/angular/src/app/app.ts
+++ b/packages/create-content-sdk-app/src/templates/angular/src/app/app.ts
@@ -1,6 +1,7 @@
-import { Component, signal } from '@angular/core';
+import { Component, effect, inject, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { ScEditingScriptsComponent } from '@sitecore-content-sdk/angular';
+import { ScEditingScriptsComponent, SitecoreContextService } from '@sitecore-content-sdk/angular';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-root',
@@ -10,4 +11,14 @@ import { ScEditingScriptsComponent } from '@sitecore-content-sdk/angular';
 })
 export class App {
   protected readonly title = signal('angular-sample');
+  private context = signal(inject(SitecoreContextService));
+
+  constructor(translate: TranslateService) {
+    effect(() => {
+      const lang = this.context().page()?.locale;
+      if (lang) {
+        translate.use(lang);
+      }
+    });
+  }
 }

--- a/packages/create-content-sdk-app/src/templates/angular/src/app/app.ts
+++ b/packages/create-content-sdk-app/src/templates/angular/src/app/app.ts
@@ -11,11 +11,11 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class App {
   protected readonly title = signal('angular-sample');
-  private context = signal(inject(SitecoreContextService));
+  private context = inject(SitecoreContextService);
 
   constructor(translate: TranslateService) {
     effect(() => {
-      const lang = this.context().page()?.locale;
+      const lang = this.context.page()?.locale;
       if (lang) {
         translate.use(lang);
       }

--- a/packages/create-content-sdk-app/src/templates/angular/src/app/components/container.component.ts
+++ b/packages/create-content-sdk-app/src/templates/angular/src/app/components/container.component.ts
@@ -23,11 +23,13 @@ const mediaUrlPattern = /mediaurl="([^"]*)"/i;
 
     <ng-template #containerInner>
       <div class="component-content" [ngStyle]="backgroundStyle()">
-        <div class="row">
-          @if (placeholderName()) {
-          <sc-placeholder [name]="placeholderName()!" [rendering]="rendering()!"></sc-placeholder>
-          }
-        </div>
+        @if (placeholderName()) {
+        <sc-placeholder
+          class="row"
+          [name]="placeholderName()!"
+          [rendering]="rendering()!"
+        ></sc-placeholder>
+        }
       </div>
     </ng-template>
   `,

--- a/packages/create-content-sdk-app/src/templates/angular/src/app/components/promo.component.ts
+++ b/packages/create-content-sdk-app/src/templates/angular/src/app/components/promo.component.ts
@@ -58,31 +58,29 @@ function promoProductJsonLd(
     '[attr.id]': 'renderingId()',
   },
   template: `
-    <article itemscope itemtype="https://schema.org/Product">
-      <div class="component-content">
-        <div class="field-promoicon" itemprop="image">
-          <img *scImage="promoIcon()" alt="" />
-        </div>
-        <div class="promo-text" itemprop="description">
-          <div class="field-promotext">
-            @if (promoText(); as primaryRichText) {
-            <div *scRichText="primaryRichText"></div>
-            }
-          </div>
-          @if (promoText2(); as secondaryRichText) {
-          <div class="field-promotext">
-            <div *scRichText="secondaryRichText"></div>
-          </div>
-          }
-          <div class="field-promolink">
-            <a *scLink="promoLink()"></a>
-          </div>
-        </div>
-        @if (jsonLd()) {
-        <app-structured-data [scriptId]="jsonLdScriptId()" [data]="jsonLd()" />
-        }
+    <div class="component-content" itemscope itemtype="https://schema.org/Product">
+      <div class="field-promoicon" itemprop="image">
+        <img *scImage="promoIcon()" alt="" />
       </div>
-    </article>
+      <div class="promo-text" itemprop="description">
+        <div class="field-promotext">
+          @if (promoText(); as primaryRichText) {
+          <div *scRichText="primaryRichText"></div>
+          }
+        </div>
+        @if (promoText2(); as secondaryRichText) {
+        <div class="field-promotext">
+          <div *scRichText="secondaryRichText"></div>
+        </div>
+        }
+        <div class="field-promolink">
+          <a *scLink="promoLink()"></a>
+        </div>
+      </div>
+      @if (jsonLd()) {
+      <app-structured-data [scriptId]="jsonLdScriptId()" [data]="jsonLd()" />
+      }
+    </div>
   `,
 })
 export class PromoComponent extends SxaComponent {

--- a/packages/create-content-sdk-app/src/templates/angular/src/app/components/promo.component.ts
+++ b/packages/create-content-sdk-app/src/templates/angular/src/app/components/promo.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed } from '@angular/core';
+import { Component, Directive, computed } from '@angular/core';
 import {
   ImageField,
   LinkField,
@@ -18,96 +18,131 @@ interface PromoFields {
   PromoLink?: LinkField;
 }
 
-function promoImageSrc(fields: Record<string, unknown>): string | undefined {
-  const icon = fields.PromoIcon as ImageField | undefined;
-  const src = icon?.value?.src;
-  return typeof src === 'string' ? src : undefined;
-}
+const PROMO_HOST = {
+  '[attr.class]': "('component promo ' + styles().trim())",
+  '[attr.id]': 'renderingId()',
+  'attr.itemscope': '',
+  'attr.itemtype': 'https://schema.org/Product',
+} as const;
 
-/** Maps Promo / Promo-WithText layout fields to Product JSON-LD. */
-function promoProductJsonLd(
-  fields: Record<string, unknown>,
-  link: LinkField | undefined,
-  primaryText: TextField | undefined,
-  secondaryText: TextField | undefined
-) {
-  const descriptionHtml =
-    [primaryText?.value, secondaryText?.value]
-      .filter((segment) => segment != null && String(segment).length > 0)
-      .map((segment) => String(segment))
-      .join(' ') || undefined;
-
-  return buildProductJsonLd({
-    name:
-      link?.value?.title || (primaryText?.value != null ? String(primaryText.value) : undefined),
-    descriptionHtml,
-    url: link?.value?.href,
-    image: promoImageSrc(fields),
-  });
-}
-
-/**
- * Promo Default and Promo With Text share one implementation: optional `PromoText2` drives the
- * second rich-text column and merged JSON-LD description.
- */
-@Component({
-  selector: 'app-promo',
-  imports: [ScRichTextDirective, ScImageDirective, ScLinkDirective, StructuredDataComponent],
-  host: {
-    '[attr.class]': "('component promo ' + styles().trim())",
-    '[attr.id]': 'renderingId()',
-  },
-  template: `
-    <div class="component-content" itemscope itemtype="https://schema.org/Product">
-      <div class="field-promoicon" itemprop="image">
-        <img *scImage="promoIcon()" alt="" />
-      </div>
-      <div class="promo-text" itemprop="description">
-        <div class="field-promotext">
-          @if (promoText(); as primaryRichText) {
-          <div *scRichText="primaryRichText"></div>
-          }
-        </div>
-        @if (promoText2(); as secondaryRichText) {
-        <div class="field-promotext">
-          <div *scRichText="secondaryRichText"></div>
-        </div>
-        }
-        <div class="field-promolink">
-          <a *scLink="promoLink()"></a>
-        </div>
-      </div>
-      @if (jsonLd()) {
-      <app-structured-data [scriptId]="jsonLdScriptId()" [data]="jsonLd()" />
-      }
-    </div>
-  `,
-})
-export class PromoComponent extends SxaComponent {
+@Directive()
+abstract class PromoBase extends SxaComponent {
   readonly promoIcon = computed(() => (this.fields() as PromoFields)?.PromoIcon);
   readonly promoText = computed(() => (this.fields() as PromoFields)?.PromoText);
   readonly promoText2 = computed(() => (this.fields() as PromoFields)?.PromoText2);
   readonly promoLink = computed(() => (this.fields() as PromoFields)?.PromoLink);
 
+  readonly isEmpty = computed(() => this.arePromoFieldsEmpty(this.fields() as PromoFields | undefined));
+
   readonly jsonLd = computed(() => {
     const promoFields = this.fields() as PromoFields;
-    if (
-      promoFields?.PromoIcon == null &&
-      promoFields?.PromoText == null &&
-      promoFields?.PromoText2 == null &&
-      promoFields?.PromoLink == null
-    ) {
+    if (this.arePromoFieldsEmpty(promoFields)) {
       return null;
     }
-    return promoProductJsonLd(
+    return this.buildPromoProductJsonLd(
       promoFields as Record<string, unknown>,
       this.promoLink(),
-      this.promoText(),
-      this.promoText2()
+      this.promoText()
     );
   });
 
   readonly jsonLdScriptId = computed(() => `jsonld-product-${this.renderingId() ?? 'promo'}`);
+
+  protected arePromoFieldsEmpty(fields: PromoFields | undefined): boolean {
+    if (!fields) {
+      return true;
+    }
+    return (
+      fields.PromoIcon == null &&
+      fields.PromoText == null &&
+      fields.PromoText2 == null &&
+      fields.PromoLink == null
+    );
+  }
+
+  private buildPromoProductJsonLd(
+    fields: Record<string, unknown>,
+    link: LinkField | undefined,
+    primaryText: TextField | undefined
+  ) {
+    return buildProductJsonLd({
+      name:
+        link?.value?.title || (primaryText?.value != null ? String(primaryText.value) : undefined),
+      descriptionHtml: primaryText?.value != null ? String(primaryText.value) : undefined,
+      url: link?.value?.href,
+      image: this.promoImageSrc(fields),
+    });
+  }
+
+  private promoImageSrc(fields: Record<string, unknown>): string | undefined {
+    const icon = fields.PromoIcon as ImageField | undefined;
+    const src = icon?.value?.src;
+    return typeof src === 'string' ? src : undefined;
+  }
 }
 
-export { PromoComponent as Default, PromoComponent as WithText };
+@Component({
+  selector: 'app-promo-default',
+  imports: [ScRichTextDirective, ScImageDirective, ScLinkDirective, StructuredDataComponent],
+  host: PROMO_HOST,
+  template: `
+    <div class="component-content">
+      @if (isEmpty()) {
+        <span class="is-empty-hint">Promo</span>
+      } @else {
+        <figure class="field-promoicon" itemprop="image">
+          <img *scImage="promoIcon()" alt="" />
+        </figure>
+        <div class="promo-text" itemprop="description">
+          <div class="field-promotext">
+            @if (promoText(); as primaryRichText) {
+              <div *scRichText="primaryRichText"></div>
+            }
+          </div>
+          <div class="field-promolink">
+            <a *scLink="promoLink()"></a>
+          </div>
+        </div>
+        @if (jsonLd()) {
+          <app-structured-data [scriptId]="jsonLdScriptId()" [data]="jsonLd()" />
+        }
+      }
+    </div>
+  `,
+})
+class PromoDefaultComponent extends PromoBase {}
+
+@Component({
+  selector: 'app-promo-with-text',
+  imports: [ScRichTextDirective, ScImageDirective, StructuredDataComponent],
+  host: PROMO_HOST,
+  template: `
+    <div class="component-content">
+      @if (isEmpty()) {
+        <span class="is-empty-hint">Promo</span>
+      } @else {
+        <figure class="field-promoicon" itemprop="image">
+          <img *scImage="promoIcon()" alt="" />
+        </figure>
+        <div class="promo-text" itemprop="description">
+          <div class="field-promotext">
+            @if (promoText(); as primaryRichText) {
+              <div class="promo-text" *scRichText="primaryRichText"></div>
+            }
+          </div>
+          <div class="field-promotext">
+            @if (promoText2(); as secondaryRichText) {
+              <div class="promo-text" *scRichText="secondaryRichText"></div>
+            }
+          </div>
+        </div>
+        @if (jsonLd()) {
+          <app-structured-data [scriptId]="jsonLdScriptId()" [data]="jsonLd()" />
+        }
+      }
+    </div>
+  `,
+})
+class PromoWithTextComponent extends PromoBase {}
+
+export { PromoDefaultComponent as Default, PromoWithTextComponent as WithText };

--- a/packages/create-content-sdk-app/src/templates/angular/src/assets/main.css
+++ b/packages/create-content-sdk-app/src/templates/angular/src/assets/main.css
@@ -18,15 +18,6 @@ sc-placeholder.row {
   flex-direction: row;
 }
 
-/* Only main page content: let .row lay out col-* siblings */
-#content .component-content > .row > sc-placeholder {
-  display: contents;
-}
-/* Promos: col-* lives on inner <article> */
-#content app-promo {
-  display: contents;
-}
-
 /* Header placeholder layout — xmcloud basic-spa basic/_header.scss (.prod-mode #header; mobile-large = 992px) */
 @media only screen and (max-width: 992px) {
   .prod-mode #header {


### PR DESCRIPTION
Fixes two things, following the QA checkpoint:
- Editing frames not correctly displaying for dynamic placeholder in Pages, in Promo component.
- Dictionary not being utilized when using TranslatePipe from ngx-translate.