### PR TITLE
[nextjs] Remove unused config section from nextjs template to eliminate npm warnings

### DIFF
--- a/.changeset/cleanup-package-json-config.md
+++ b/.changeset/cleanup-package-json-config.md
@@ -1,0 +1,5 @@
+---
+'create-content-sdk-app': patch
+---
+
+Remove unused config section from nextjs template package.json to eliminate npm warnings about unknown CLI config settings.

--- a/packages/create-content-sdk-app/src/templates/nextjs/package.json
+++ b/packages/create-content-sdk-app/src/templates/nextjs/package.json
@@ -3,12 +3,6 @@
   "description": "Application utilizing Content SDK and Next.js",
   "version": "0.1.0",
   "private": true,
-  "config": {
-    "appName": "content-sdk-nextjs",
-    "graphQLEndpointPath": "/sitecore/api/graph/edge",
-    "language": "en",
-    "template": "nextjs"
-  },
   "author": {
     "name": "Sitecore Corporation",
     "url": "https://doc.sitecore.com/xmc/en/developers/content-sdk/index.html"


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

**Problem:**
The `config` section in package.json was legacy metadata that npm interprets as CLI configuration settings. These values were never referenced in code and will be rejected in future npm versions.

**Solution:**
Removed unused `config` section from the nextjs template's `package.json` that was causing npm warnings.

## Testing Details

- [ ] Unit Test Added
- [x] Manual Test/Other
  - Verified no references to config values in codebase
  - Tested `npm run start` in samples/nextjs - no warnings

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)