### PR TITLE
[nextjs] Remove react tsconfig path mapping in dev mode

### DIFF
--- a/.changeset/fix-nextjs-react-tsconfig-path.md
+++ b/.changeset/fix-nextjs-react-tsconfig-path.md
@@ -1,0 +1,5 @@
+---
+'create-content-sdk-app': patch
+---
+
+Remove dev-mode `tsconfig` path mapping for `react` in the Pages Router template so monorepo `yarn watch` samples resolve `@types/react` and `npm run build` no longer fails with missing React declaration files.

--- a/packages/create-content-sdk-app/src/templates/nextjs/tsconfig.json
+++ b/packages/create-content-sdk-app/src/templates/nextjs/tsconfig.json
@@ -7,7 +7,6 @@
       "temp/*": ["src/temp/*"],
       "assets/*": ["src/assets/*"],
       <%_ if (helper.isDev) { _%>
-      "react": ["node_modules/react"],
       "next/*": ["node_modules/next/*"],
       <%_ } _%>
     },


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR removes the dev-mode `tsconfig` paths override for react in the Pages Router template so monorepo yarn watch samples resolve `@types/react` and `npm run build` no longer fails with missing React declaration files.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
