### PR TITLE
[Angular] siteName is not resolved in preview mode

### DIFF
--- a/.changeset/clean-files-fly.md
+++ b/.changeset/clean-files-fly.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/angular': patch
+---
+
+siteName is not resolved in preview mode

--- a/packages/angular/src/server/server-loader-runner.spec.ts
+++ b/packages/angular/src/server/server-loader-runner.spec.ts
@@ -9,6 +9,7 @@ import {
   makeLoaderContext,
   mockScParams,
 } from '../testing/loader-spec-helpers';
+import { LayoutServicePageState } from '@sitecore-content-sdk/content/layout';
 
 describe('ServerLoaderRunner', () => {
   const mockConfig = mockAngularSitecoreConfig();
@@ -56,6 +57,74 @@ describe('ServerLoaderRunner', () => {
       csdkRequestData: undefined,
     });
     expect(result).toEqual({ kind: 'data', data: { title: 'Page' } });
+  });
+
+  it('should use scPreviewData.site as siteName for editing requests (multisite middleware skips /api/*)', async () => {
+    const provider = new ServerLoaderRunner({ page: pageLoader }, mockConfig);
+    await provider.resolve({
+      loaderId: 'page',
+      url: '/about',
+      routeParams: {},
+      query: {},
+      csdkRequestData: {
+        scPreviewData: {
+          site: 'demo',
+          itemId: 'item-1',
+          language: 'en',
+          mode: LayoutServicePageState.Edit,
+          variantIds: ['_default'],
+        },
+      },
+    });
+
+    expect(pageLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scParams: { siteName: 'demo' },
+      })
+    );
+  });
+
+  it('should fall back to defaultSite when scParams.siteName is an empty string', async () => {
+    const provider = new ServerLoaderRunner({ page: pageLoader }, demoConfig);
+    await provider.resolve({
+      loaderId: 'page',
+      url: '/about',
+      routeParams: {},
+      query: {},
+      csdkRequestData: { scParams: { siteName: '' } },
+    });
+
+    expect(pageLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scParams: { siteName: 'demo' },
+      })
+    );
+  });
+
+  it('should fall back to scPreviewData.site when scParams.siteName is an empty string', async () => {
+    const provider = new ServerLoaderRunner({ page: pageLoader }, mockConfig);
+    await provider.resolve({
+      loaderId: 'page',
+      url: '/about',
+      routeParams: {},
+      query: {},
+      csdkRequestData: {
+        scParams: { siteName: '' },
+        scPreviewData: {
+          site: 'demo',
+          itemId: 'item-1',
+          language: 'en',
+          mode: LayoutServicePageState.Edit,
+          variantIds: ['_default'],
+        },
+      },
+    });
+
+    expect(pageLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scParams: { siteName: 'demo' },
+      })
+    );
   });
 
   it('should return cached data without invoking loader', async () => {

--- a/packages/angular/src/server/server-loader-runner.ts
+++ b/packages/angular/src/server/server-loader-runner.ts
@@ -52,13 +52,16 @@ export class ServerLoaderRunner {
       return { kind: 'error', status: 500, message: `No loader registered for id "${loaderId}"` };
     }
 
-    const defaultScParams = {
-      siteName: this.config.defaultSite,
-    };
+    const resolvedScParams = csdkRequestData?.scParams ?? {};
+
+    // Multisite middleware never resolves site for editing requests (it skips `/api/*`
+    // entirely), so the scPreviewData is the only source of the site name here.
+    const siteName =
+      resolvedScParams.siteName || csdkRequestData?.scPreviewData?.site || this.config.defaultSite;
 
     const scParams = {
-      ...defaultScParams,
-      ...(csdkRequestData?.scParams || {}),
+      ...resolvedScParams,
+      siteName,
     };
 
     // ctx carries everything the loader and cache key need; only loaderId travels


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
We have to consider resolving preview siteName in server loader by referencing previewData
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
