### PR TITLE
[nextjs] Short shircuit redirect proxy for correct order of middleware execution

### DIFF
--- a/.changeset/fix-proxy-redirect-short-circuit-jss-8736.md
+++ b/.changeset/fix-proxy-redirect-short-circuit-jss-8736.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/nextjs': patch
+---
+
+Stop the proxy chain once an upstream handler returns a redirect so custom plugins chained after RedirectsProxy cannot override Sitecore redirect responses. Short-circuit on 403, `res.redirected`, or 3xx status codes to support Next.js 16 redirect responses.

--- a/packages/nextjs/src/proxy/proxy.test.ts
+++ b/packages/nextjs/src/proxy/proxy.test.ts
@@ -756,6 +756,107 @@ describe('defineProxy', () => {
     expect(result).to.equal(forbidden);
   });
 
+  it('should short-circuit the chain once a proxy returns a redirect response', async () => {
+    const redirectResponse = {
+      status: 302,
+      redirected: false,
+      url: 'http://localhost:3000/map-redirect-test-page',
+    } as unknown as NextResponse;
+
+    const redirectsProxy: ProxyHandler = {
+      handle: sinon.stub().resolves(redirectResponse),
+    };
+    const downstreamProxy: ProxyHandler = {
+      handle: sinon.stub().resolves({
+        status: 307,
+        redirected: true,
+        url: 'http://localhost:3000/en/redirect-test',
+      } as unknown as NextResponse),
+    };
+
+    const req = {} as NextRequest;
+    const res = { status: 200 } as unknown as NextResponse;
+
+    const result = await defineProxy(redirectsProxy, downstreamProxy).exec(req, res);
+
+    expect(redirectsProxy.handle).to.have.been.calledOnce;
+    expect(downstreamProxy.handle).to.not.have.been.called;
+    expect(result).to.equal(redirectResponse);
+  });
+
+  it('should continue the chain when a proxy returns a rewrite response', async () => {
+    const rewriteResponse = {
+      status: 200,
+      redirected: false,
+      headers: new Headers(),
+    } as unknown as NextResponse;
+
+    const rewriteProxy: ProxyHandler = {
+      handle: sinon.stub().resolves(rewriteResponse),
+    };
+    const downstreamProxy: ProxyHandler = {
+      handle: sinon.stub().callsFake((_req, res) => {
+        res.headers.set('downstream', 'true');
+        return Promise.resolve(res);
+      }),
+    };
+
+    const req = {} as NextRequest;
+    const res = {
+      status: 200,
+      redirected: false,
+      headers: new Headers(),
+    } as unknown as NextResponse;
+
+    const result = await defineProxy(rewriteProxy, downstreamProxy).exec(req, res);
+
+    expect(rewriteProxy.handle).to.have.been.calledOnce;
+    expect(downstreamProxy.handle).to.have.been.calledOnce;
+    expect(result.headers.get('downstream')).to.equal('true');
+  });
+
+  it('should preserve an upstream redirect when a custom redirect proxy is chained last (JSS-8736)', async () => {
+    const sitecoreRedirect = {
+      status: 302,
+      redirected: false,
+      url: 'http://localhost:3000/map-redirect-test-page',
+    } as unknown as NextResponse;
+
+    const redirectsProxy: ProxyHandler = {
+      handle: sinon.stub().resolves(sitecoreRedirect),
+    };
+    const personalizeProxy: ProxyHandler = {
+      handle: sinon.stub().callsFake((_req, res) => Promise.resolve(res)),
+    };
+    const languageRedirectProxy: ProxyHandler = {
+      handle: sinon.stub().resolves({
+        status: 307,
+        redirected: true,
+        url: 'http://localhost:3000/en/redirect-test',
+      } as unknown as NextResponse),
+    };
+
+    const req = {
+      url: 'http://localhost:3000/redirect-test',
+      nextUrl: {
+        locale: 'default',
+        pathname: '/redirect-test',
+        search: '',
+      },
+    } as unknown as NextRequest;
+
+    const result = await defineProxy(
+      redirectsProxy,
+      personalizeProxy,
+      languageRedirectProxy
+    ).exec(req);
+
+    expect(redirectsProxy.handle).to.have.been.calledOnce;
+    expect(personalizeProxy.handle).to.not.have.been.called;
+    expect(languageRedirectProxy.handle).to.not.have.been.called;
+    expect(result).to.equal(sitecoreRedirect);
+  });
+
   it('should pass context to proxies when generateContext is true', async () => {
     const proxiesContext: ProxiesContext = new Map();
     const successfulExecution: { marker: string } & SuccessfulProxyExecution = {

--- a/packages/nextjs/src/proxy/proxy.ts
+++ b/packages/nextjs/src/proxy/proxy.ts
@@ -12,6 +12,12 @@ import { ProxiesContext } from './types';
 export const REWRITE_HEADER_NAME = 'x-sc-rewrite';
 export const LOCALE_HEADER_NAME = 'x-sc-locale';
 
+const REDIRECT_STATUS_MIN = 300;
+const REDIRECT_STATUS_MAX = 399;
+
+const isRedirectStatus = (status: number) =>
+  status >= REDIRECT_STATUS_MIN && status <= REDIRECT_STATUS_MAX;
+
 /**
  * The interface for the Proxy configuration.
  * @public
@@ -307,8 +313,11 @@ export const defineProxy = (...proxies: ProxyHandler[]) => {
         (p, proxy) =>
           p.then((res) => {
             // Short-circuit the remaining proxies once a previous one
-            // denied the request (e.g. PreviewProxy returning 403).
-            if (res.status === 403) return res;
+            // denied the request (e.g. PreviewProxy returning 403) or issued
+            // a redirect (e.g. RedirectsProxy returning 302).
+            // Note: Next.js 16 may leave `redirected` false on redirect responses,
+            // so also check for 3xx status codes.
+            if (res.status === 403 || res.redirected || isRedirectStatus(res.status)) return res;
 
             return proxy.handle(req, res, proxiesContext);
           }),


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR stops `defineProxy` from running downstream handlers once an upstream proxy returns a redirect, so custom plugins chained after `RedirectsProxy` cannot override redirect map responses. Also handles Next.js 16 redirect responses where redirected may be false but status is 3xx.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other => Verified middleware execution is in the correct order now (based on ticket issue reproductio)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
