### PR TITLE
[react] /n newline in Text broken

### DIFF
--- a/.changeset/brave-parrots-buy.md
+++ b/.changeset/brave-parrots-buy.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/react': patch
+---
+
+Fix `Text` with `encode={false}` rendering `[object Object]` at newlines before HTML in Multi-Line Text fields.

--- a/packages/react/src/components/Text.test.tsx
+++ b/packages/react/src/components/Text.test.tsx
@@ -119,6 +119,33 @@ describe('<Text />', () => {
     expect(rendered?.innerHTML).to.contain(field.value);
   });
 
+  it('should render multiline html without object coercion when encoding is disabled', () => {
+    const field = {
+      value: 'Line one\n<a href="#"> Hola </a>',
+    };
+    const rendered = render(<Text field={field} encode={false} />).container.querySelector('span');
+    expect(rendered?.innerHTML).to.equal('Line one<br><a href="#"> Hola </a>');
+    expect(rendered?.innerHTML).to.not.contain('[object Object]');
+    expect(rendered?.querySelector('a')?.getAttribute('href')).to.equal('#');
+  });
+
+  it('should render inline html unchanged when encoding is disabled', () => {
+    const field = {
+      value: 'Line one <a href="#"> Hola </a>',
+    };
+    const rendered = render(<Text field={field} encode={false} />).container.querySelector('span');
+    expect(rendered?.innerHTML).to.equal('Line one <a href="#"> Hola </a>');
+    expect(rendered?.innerHTML).to.not.contain('[object Object]');
+  });
+
+  it('should render multiline plain text with line breaks when encoding is disabled', () => {
+    const field = {
+      value: 'xxx\n\naa\nbbb\ndd',
+    };
+    const rendered = render(<Text field={field} encode={false} />).container.querySelector('span');
+    expect(rendered?.innerHTML).to.equal('xxx<br><br>aa<br>bbb<br>dd');
+  });
+  
   it('should render tag with a tag provided', () => {
     const field = {
       value: 'value',

--- a/packages/react/src/components/Text.tsx
+++ b/packages/react/src/components/Text.tsx
@@ -39,7 +39,7 @@ const TextComponent: React.FC<TextProps> = ({ field, tag, editable = true, encod
     editable = false;
   }
 
-  const value = field.value === undefined ? '' : field.value;
+  const value = field.value ?? '';
 
   let children = null;
   const htmlProps: {

--- a/packages/react/src/components/Text.tsx
+++ b/packages/react/src/components/Text.tsx
@@ -39,27 +39,7 @@ const TextComponent: React.FC<TextProps> = ({ field, tag, editable = true, encod
     editable = false;
   }
 
-  let output: string | number | (ReactElement | string)[] =
-    field.value === undefined ? '' : field.value;
-
-  // when string value isn't formatted, we should format line breaks
-  const splitted = String(output).split('\n');
-
-  if (splitted.length) {
-    const formatted: (ReactElement | string)[] = [];
-
-    splitted.forEach((str, i) => {
-      const isLast = i === splitted.length - 1;
-
-      formatted.push(str);
-
-      if (!isLast) {
-        formatted.push(<br key={i} />);
-      }
-    });
-
-    output = formatted;
-  }
+  const value = field.value === undefined ? '' : field.value;
 
   let children = null;
   const htmlProps: {
@@ -71,9 +51,30 @@ const TextComponent: React.FC<TextProps> = ({ field, tag, editable = true, encod
 
   if (!encode) {
     htmlProps.dangerouslySetInnerHTML = {
-      __html: output,
+      __html: String(value).split('\n').join('<br>'),
     };
   } else {
+    let output: string | number | (ReactElement | string)[] = value;
+
+    // when string value isn't formatted, we should format line breaks
+    const splitted = String(output).split('\n');
+
+    if (splitted.length) {
+      const formatted: (ReactElement | string)[] = [];
+
+      splitted.forEach((str, i) => {
+        const isLast = i === splitted.length - 1;
+
+        formatted.push(str);
+
+        if (!isLast) {
+          formatted.push(<br key={i} />);
+        }
+      });
+
+      output = formatted;
+    }
+
     children = output;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a preview bug where `<Text encode={false} />` on a **Multi-Line Text** field showed literal `[object Object]` (with commas) when the value contained a newline followed by HTML on the next line.

Line one  
`<a href="#"> Hola </a>`

| | Result |
|---|---|
| **Before** | `Line one,[object Object], Hola` — link still clickable, but newline rendered as `[object Object]` |
| **After** | `Line one` + line break + working link text `Hola` |

Same-line HTML (`Line one <a href="#"> Hola </a>`) was unaffected and continues to work.

## Fix
Split the render paths by `encode`:
- **`encode={false}`:** Build a single HTML string from `field.value`, converting newlines to `<br>` tags, then pass it to `dangerouslySetInnerHTML`.
- **`encode={true}` (default):** Unchanged — React children with `<br>` elements for line breaks.


## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

Manual: XM Cloud Pages preview with Multi-Line Text datasource, `encode={false}`, newline before HTML on next line — no `[object Object]`; link renders correctlyt 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
