### PR TITLE
[core] Add changeset to publish escapeRegExp export for nextjs compatibility

### DIFF
--- a/.changeset/core-export-escapeRegExp.md
+++ b/.changeset/core-export-escapeRegExp.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/core': patch
+---
+
+Export `escapeRegExp` from `@sitecore-content-sdk/core/tools` for use by nextjs redirects proxy.


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

After #537, `@sitecore-content-sdk/nextjs` imports `escapeRegExp` from `@sitecore-content-sdk/core/tools`, but the published `@sitecore-content-sdk/core@2.1.1` package does not export it yet.

This causes head apps to fail at build time with:
Export escapeRegExp doesn't exist in target module

The code already exists in `packages/core/src/tools/utils.ts` on `dev` but it just was not included in a core release. This PR adds a changeset so the next core patch publish includes the export.

## Testing Details

- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)