### PR TITLE
[react] Fix component not found when FieldNames is returned as an object

### DIFF
--- a/.changeset/fix-fieldnames-rendering-param-normalization.md
+++ b/.changeset/fix-fieldnames-rendering-param-normalization.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/react': patch
+---
+
+Normalize `FieldNames` rendering params with `getRenderingParamString` before resolving headless/SXA variants, fixing "component not found" errors when Edge returns `DetailedRenderingParams` objects instead of plain strings.

--- a/packages/react/src/components/Placeholder/placeholder-utils.test.tsx
+++ b/packages/react/src/components/Placeholder/placeholder-utils.test.tsx
@@ -431,6 +431,92 @@ describe('placeholder-utils', () => {
       expect(result?.component).to.equal(TestComponent);
     });
 
+    it('should treat empty string FieldNames as default variant', () => {
+      const module: ReactModule = {
+        default: TestComponent,
+      };
+      componentMap.set('TestComponent', module);
+
+      const rendering: ComponentRendering = {
+        componentName: 'TestComponent',
+        uid: 'test-uid',
+        params: {
+          FieldNames: '',
+        },
+      };
+
+      const result = getComponentForRendering(rendering, 'test-placeholder', componentMap);
+
+      expect(result?.component).to.equal(TestComponent);
+      expect(result?.isEmpty).to.be.false;
+    });
+
+    it('should resolve FieldNames from DetailedRenderingParams object', () => {
+      const CustomExport = () => <div>Custom Export</div>;
+      const module: ReactModule = {
+        default: TestComponent,
+        CustomVariant: CustomExport,
+      };
+      componentMap.set('TestComponent', module);
+
+      const rendering: ComponentRendering = {
+        componentName: 'TestComponent',
+        uid: 'test-uid',
+        params: {
+          FieldNames: {
+            Value: { value: 'CustomVariant' },
+          },
+        },
+      };
+
+      const result = getComponentForRendering(rendering, 'test-placeholder', componentMap);
+
+      expect(result?.component).to.equal(CustomExport);
+      expect(result?.isEmpty).to.be.false;
+    });
+
+    it('should treat Default in DetailedRenderingParams object as default variant', () => {
+      const module: ReactModule = {
+        Default: TestComponent,
+      };
+      componentMap.set('TestComponent', module);
+
+      const rendering: ComponentRendering = {
+        componentName: 'TestComponent',
+        uid: 'test-uid',
+        params: {
+          FieldNames: {
+            Value: { value: 'Default' },
+          },
+        },
+      };
+
+      const result = getComponentForRendering(rendering, 'test-placeholder', componentMap);
+
+      expect(result?.component).to.equal(TestComponent);
+      expect(result?.isEmpty).to.be.false;
+    });
+
+    it('should fallback to default export when FieldNames object is unextractable', () => {
+      const module: ReactModule = {
+        default: TestComponent,
+      };
+      componentMap.set('TestComponent', module);
+
+      const rendering: ComponentRendering = {
+        componentName: 'TestComponent',
+        uid: 'test-uid',
+        params: {
+          FieldNames: {},
+        },
+      };
+
+      const result = getComponentForRendering(rendering, 'test-placeholder', componentMap);
+
+      expect(result?.component).to.equal(TestComponent);
+      expect(result?.isEmpty).to.be.false;
+    });
+
     it('should return component directly when it is not a module', () => {
       componentMap.set('TestComponent', TestComponent);
 

--- a/packages/react/src/components/Placeholder/placeholder-utils.tsx
+++ b/packages/react/src/components/Placeholder/placeholder-utils.tsx
@@ -219,7 +219,7 @@ export const getComponentForRendering = (
   }
 
   // Render SXA Rendering Variant if available
-  const exportName = renderingDefinition.params?.FieldNames;
+  const exportName = getRenderingParamString(renderingDefinition.params?.FieldNames);
 
   const renderedComponent =
     exportName && exportName !== DEFAULT_EXPORT_NAME
@@ -229,7 +229,9 @@ export const getComponentForRendering = (
         (component as ComponentType);
 
   if (!renderedComponent) {
-    logUnknownComponentError(exportName !== DEFAULT_EXPORT_NAME ? exportName : undefined);
+    logUnknownComponentError(
+      exportName && exportName !== DEFAULT_EXPORT_NAME ? exportName : undefined
+    );
 
     return {
       component: missingComponentComponent ?? MissingComponent,
@@ -251,4 +253,3 @@ export const getComponentForRendering = (
     isEmpty: false,
   };
 };
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

When the Headless Variant field is left empty in Standard Values, Sitecore may still send `FieldNames` in layout JSON. With `LayoutService.DetailedRenderingParams` enabled, that value can arrive as an object. The placeholder previously used the raw value for named export lookup, which failed and rendered `MissingComponent`.

Other rendering params (`Styles`, `GridParameters`) were already normalized via `getRenderingParamString`; `FieldNames` was the gap. All normal render paths (`AppPlaceholder`, `ClientComponentWrapper`, Design Library preview) flow through `getComponentForRendering`, so this single fix covers them.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
