### PR TITLE
[nextjs] Next.js link prefetch functionality causes a lot of 404 errors in Pages

### DIFF
--- a/.changeset/spotty-corners-sniff.md
+++ b/.changeset/spotty-corners-sniff.md
@@ -2,4 +2,4 @@
 '@sitecore-content-sdk/nextjs': patch
 ---
 
-[nextjs] Export `FieldMetadata` so apps can access component field metadata from the Next.js SDK package.
+Export `FieldMetadata` so apps can access component field metadata from the Next.js SDK package.

--- a/.changeset/spotty-corners-sniff.md
+++ b/.changeset/spotty-corners-sniff.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/nextjs': patch
+---
+
+[nextjs] Export `FieldMetadata` so apps can access component field metadata from the Next.js SDK package.

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -58,6 +58,7 @@ import { FEaaSWrapper as FEaaSWrapper_2 } from '@sitecore-content-sdk/react';
 import { fetchFEaaSComponentServerProps } from '@sitecore-content-sdk/react';
 import { FetchOptions } from '@sitecore-content-sdk/content/client';
 import { Field } from '@sitecore-content-sdk/content/layout';
+import { FieldMetadata } from '@sitecore-content-sdk/content/layout';
 import { File as File_2 } from '@sitecore-content-sdk/react';
 import { FileField } from '@sitecore-content-sdk/react';
 import { Form } from '@sitecore-content-sdk/react';
@@ -534,6 +535,8 @@ export { FEaaSWrapper }
 export { fetchFEaaSComponentServerProps }
 
 export { Field }
+
+export { FieldMetadata }
 
 export { File_2 as File }
 

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -26,6 +26,7 @@ export {
   PlaceholdersData,
   RouteData,
   Field,
+  FieldMetadata,
   Item,
   getChildPlaceholder,
   getFieldValue,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Export `FieldMetadata` from `@sitecore-content-sdk/nextjs` so apps can access component field metadata from the Next.js SDK package.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
