### PR TITLE
[create-content-sdk-app] LocaleProxy missing defaultLanguage config in App Router templates

### DIFF
--- a/.changeset/spicy-peas-rescue.md
+++ b/.changeset/spicy-peas-rescue.md
@@ -2,4 +2,4 @@
 'create-content-sdk-app': patch
 ---
 
-[create-content-sdk-app] Pass `defaultLanguage` from sitecore config to `LocaleProxy` in App Router templates so locale resolution uses the project default instead of hardcoded `en`
+Pass `defaultLanguage` from sitecore config to `LocaleProxy` in App Router templates so locale resolution uses the project default instead of hardcoded `en`

--- a/.changeset/spicy-peas-rescue.md
+++ b/.changeset/spicy-peas-rescue.md
@@ -1,0 +1,5 @@
+---
+'create-content-sdk-app': patch
+---
+
+[create-content-sdk-app] Pass `defaultLanguage` from sitecore config to `LocaleProxy` in App Router templates so locale resolution uses the project default instead of hardcoded `en`

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/src/proxy.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/src/proxy.ts
@@ -37,6 +37,10 @@ export default function proxy(req: NextRequest, event: NextFetchEvent) {
      * List of all supported locales configured in routing.ts
      */
     locales: routing.locales.slice(),
+    /**
+     * Fallback when App Router does not populate nextUrl.locale / defaultLocale
+     */
+    defaultLanguage: scConfig.defaultLanguage,
     // This function determines if the proxy should be turned off on per-request basis.
     // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to disable more.
     // This is an important performance consideration since Next.js Edge proxy runs on every request.

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/src/proxy.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/src/proxy.ts
@@ -38,7 +38,7 @@ export default function proxy(req: NextRequest, event: NextFetchEvent) {
      */
     locales: routing.locales.slice(),
     /**
-     * Fallback when App Router does not populate nextUrl.locale / defaultLocale
+     * Default language to use if no language is identified in the request
      */
     defaultLanguage: scConfig.defaultLanguage,
     // This function determines if the proxy should be turned off on per-request basis.

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/proxy.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/proxy.ts
@@ -37,6 +37,10 @@ export default function proxy(req: NextRequest, event: NextFetchEvent) {
      * List of all supported locales configured in routing.ts
      */
     locales: routing.locales.slice(),
+    /**
+     * Fallback when App Router does not populate nextUrl.locale / defaultLocale
+     */
+    defaultLanguage: scConfig.defaultLanguage,
     // This function determines if the proxy should be turned off on per-request basis.
     // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to disable more.
     // This is an important performance consideration since Next.js Edge proxy runs on every request.

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/proxy.ts
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/src/proxy.ts
@@ -38,7 +38,7 @@ export default function proxy(req: NextRequest, event: NextFetchEvent) {
      */
     locales: routing.locales.slice(),
     /**
-     * Fallback when App Router does not populate nextUrl.locale / defaultLocale
+     * Default language to use if no language is identified in the request
      */
     defaultLanguage: scConfig.defaultLanguage,
     // This function determines if the proxy should be turned off on per-request basis.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pass `defaultLanguage: scConfig.defaultLanguage` to `LocaleProxy` in both App Router templates so locale resolution uses the project default instead of hardcoded `en`

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
