### PR TITLE
[angular] Support time-based preview in render endpoint

### DIFF
--- a/.changeset/hip-meteors-bathe.md
+++ b/.changeset/hip-meteors-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/angular': minor
+---
+
+Support optional `sc_previewTime` on the Angular editing render endpoint for time-based Edge preview.

--- a/packages/angular/src/server/middleware/editing-render-middleware.spec.ts
+++ b/packages/angular/src/server/middleware/editing-render-middleware.spec.ts
@@ -266,4 +266,46 @@ describe('createEditingRenderMiddleware', () => {
     await middleware(req, res, next);
     expect(next).toHaveBeenCalled();
   });
+
+  it('includes previewTime in editing params when sc_previewTime is present in query params', async () => {
+    const middleware = createEditingRenderMiddleware({ editingSecret: 's' });
+    const req: ExpressRequest = {
+      method: 'GET',
+      path: '/api/editing/render',
+      url: '/api/editing/render',
+      body: undefined,
+      query: baseQuery({ sc_previewTime: '2024-12-25T10:00:00Z' }),
+      headers: baseHeaders(),
+    };
+    const res = createMockRes();
+    await middleware(req, res, next);
+
+    const editingReq = req as ExpressEditingRequest;
+    expect(editingReq.scEditing).toHaveProperty('previewTime', '2024-12-25T10:00:00Z');
+    // Verify previewTime is included in the EDITING_PARAMS_HEADER JSON, which flows to Edge GraphQL
+    const editingParams = JSON.parse(editingReq.headers![EDITING_PARAMS_HEADER] as string);
+    expect(editingParams).toHaveProperty('previewTime', '2024-12-25T10:00:00Z');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not include previewTime in editing params when sc_previewTime is absent', async () => {
+    const middleware = createEditingRenderMiddleware({ editingSecret: 's' });
+    const req: ExpressRequest = {
+      method: 'GET',
+      path: '/api/editing/render',
+      url: '/api/editing/render',
+      body: undefined,
+      query: baseQuery(),
+      headers: baseHeaders(),
+    };
+    const res = createMockRes();
+    await middleware(req, res, next);
+
+    const editingReq = req as ExpressEditingRequest;
+    expect(editingReq.scEditing).not.toHaveProperty('previewTime');
+    // Verify previewTime is absent from the EDITING_PARAMS_HEADER JSON
+    const editingParams = JSON.parse(editingReq.headers![EDITING_PARAMS_HEADER] as string);
+    expect(editingParams).not.toHaveProperty('previewTime');
+    expect(next).toHaveBeenCalled();
+  });
 });

--- a/packages/angular/src/server/middleware/editing-render-middleware.ts
+++ b/packages/angular/src/server/middleware/editing-render-middleware.ts
@@ -97,6 +97,7 @@ function buildPreviewData(
     variantId,
     version: query.sc_version,
     layoutKind: query.sc_layoutKind as EditingPreviewData['layoutKind'],
+    ...(query.sc_previewTime && { previewTime: query.sc_previewTime }),
     ...allowedQueryParams,
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Forward optional `sc_previewTime` query parameter from the Angular editing render endpoint into preview data (`previewTime`)
- Pass the value through unchanged so Edge Preview GraphQL can apply calendar-based preview

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
