### PR TITLE
[Atoms] Add fieldType in schema helpers

### DIFF
--- a/.changeset/jss-10018-fieldType.md
+++ b/.changeset/jss-10018-fieldType.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/react': patch
+---
+
+Add `fieldType` metadata to Sitecore field schema helpers so Design Studio can identify field props for binding.

--- a/packages/react/api/content-sdk-react.api.md
+++ b/packages/react/api/content-sdk-react.api.md
@@ -589,6 +589,7 @@ export { PlaceholderProps }
 // @public
 export type PropMeta = {
     control?: string;
+    fieldType?: string;
 };
 
 // @public

--- a/packages/react/src/atoms/field-schemas.test.ts
+++ b/packages/react/src/atoms/field-schemas.test.ts
@@ -32,28 +32,38 @@ describe('field-schemas', () => {
   };
 
   const factories = [
-    { name: 'textFieldSchema', factory: textFieldSchema, control: 'Single-Line Text' },
-    { name: 'richTextFieldSchema', factory: richTextFieldSchema, control: 'Rich Text' },
-    { name: 'dateFieldSchema', factory: dateFieldSchema, control: 'Date' },
-    { name: 'linkFieldSchema', factory: linkFieldSchema, control: 'Link' },
-    { name: 'imageFieldSchema', factory: imageFieldSchema, control: 'Image' },
-    { name: 'fileFieldSchema', factory: fileFieldSchema, control: 'File' },
+    {
+      name: 'textFieldSchema',
+      factory: textFieldSchema,
+      control: 'Single-Line Text',
+      fieldType: 'Text',
+    },
+    {
+      name: 'richTextFieldSchema',
+      factory: richTextFieldSchema,
+      control: 'Rich Text',
+      fieldType: 'RichText',
+    },
+    { name: 'dateFieldSchema', factory: dateFieldSchema, control: 'Date', fieldType: 'Date' },
+    { name: 'linkFieldSchema', factory: linkFieldSchema, control: 'Link', fieldType: 'Link' },
+    { name: 'imageFieldSchema', factory: imageFieldSchema, control: 'Image', fieldType: 'Image' },
+    { name: 'fileFieldSchema', factory: fileFieldSchema, control: 'File', fieldType: 'File' },
   ];
 
-  factories.forEach(({ name, factory, control }) => {
+  factories.forEach(({ name, factory, control, fieldType }) => {
     describe(name, () => {
       it('returns a ZodObject', () => {
         expect(factory()).to.be.instanceOf(z.ZodObject);
       });
 
-      it(`has control hint "${control}"`, () => {
+      it(`has control hint "${control}" and fieldType "${fieldType}"`, () => {
         const meta = getFieldMeta(factory());
-        expect(meta).to.deep.equal({ control });
+        expect(meta).to.deep.equal({ control, fieldType });
       });
 
-      it('preserves control hint when extra shape is provided', () => {
+      it('preserves control and fieldType when extra shape is provided', () => {
         const meta = getFieldMeta(factory({ extra: z.string() }));
-        expect(meta).to.deep.equal({ control });
+        expect(meta).to.deep.equal({ control, fieldType });
       });
 
       it('includes extra shape in the schema', () => {
@@ -193,10 +203,10 @@ describe('field-schemas', () => {
       expect(parsed.success).to.equal(true);
     });
 
-    it('preserves control hint on field schemas', () => {
+    it('preserves control and fieldType on field schemas', () => {
       const props = z.object({ cta: linkFieldSchema() });
       const ctaShape = props.shape.cta as z.ZodType;
-      expect(getFieldMeta(ctaShape)).to.deep.equal({ control: 'Link' });
+      expect(getFieldMeta(ctaShape)).to.deep.equal({ control: 'Link', fieldType: 'Link' });
     });
   });
 });

--- a/packages/react/src/atoms/field-schemas.ts
+++ b/packages/react/src/atoms/field-schemas.ts
@@ -6,7 +6,7 @@ import { withPropMeta } from './schema-utils';
  * Zod schema for a Sitecore Single-Line Text.
  * Mirrors the Sitecore Text component (`Text.tsx` in `@sitecore-content-sdk/react`).
  * @param {z.ZodRawShape} [extra] - Optional additional shape to merge into the schema.
- * @returns A ZodObject with `value?: string | number` and the DS control hint attached.
+ * @returns A ZodObject with `value?: string | number` and DS control/fieldType hints attached.
  * @public
  */
 export const textFieldSchema = (extra?: z.ZodRawShape) =>
@@ -15,7 +15,7 @@ export const textFieldSchema = (extra?: z.ZodRawShape) =>
       value: z.union([z.string(), z.number()]).optional(),
       ...extra,
     }),
-    { control: 'Single-Line Text' }
+    { control: 'Single-Line Text', fieldType: 'Text' }
   );
 
 /**
@@ -31,7 +31,7 @@ export const richTextFieldSchema = (extra?: z.ZodRawShape) =>
       value: z.string().optional(),
       ...extra,
     }),
-    { control: 'Rich Text' }
+    { control: 'Rich Text', fieldType: 'RichText' }
   );
 
 /**
@@ -47,7 +47,7 @@ export const dateFieldSchema = (extra?: z.ZodRawShape) =>
       value: z.string().optional(),
       ...extra,
     }),
-    { control: 'Date' }
+    { control: 'Date', fieldType: 'Date' }
   );
 
 /**
@@ -75,7 +75,7 @@ export const linkFieldSchema = (extra?: z.ZodRawShape) =>
       }),
       ...extra,
     }),
-    { control: 'Link' }
+    { control: 'Link', fieldType: 'Link' }
   );
 
 /**
@@ -101,7 +101,7 @@ export const imageFieldSchema = (extra?: z.ZodRawShape) =>
         .optional(),
       ...extra,
     }),
-    { control: 'Image' }
+    { control: 'Image', fieldType: 'Image' }
   );
 
 /**
@@ -123,7 +123,7 @@ export const fileFieldSchema = (extra?: z.ZodRawShape) =>
       }),
       ...extra,
     }),
-    { control: 'File' }
+    { control: 'File', fieldType: 'File' }
   );
 
 /**

--- a/packages/react/src/atoms/field-schemas.ts
+++ b/packages/react/src/atoms/field-schemas.ts
@@ -22,7 +22,7 @@ export const textFieldSchema = (extra?: z.ZodRawShape) =>
  * Zod schema for a Sitecore Rich Text field.
  * Mirrors the Sitecore Rich Text component (`RichText.tsx` in `@sitecore-content-sdk/react`).
  * @param {z.ZodRawShape} [extra] - Optional additional shape to merge into the schema.
- * @returns A ZodObject with `value?: string` and the DS control hint attached.
+ * @returns A ZodObject with `value?: string` and DS control/fieldType hints attached.
  * @public
  */
 export const richTextFieldSchema = (extra?: z.ZodRawShape) =>
@@ -38,7 +38,7 @@ export const richTextFieldSchema = (extra?: z.ZodRawShape) =>
  * Zod schema for a Sitecore Date field.
  * Mirrors the field shape used in the Date component (`Date.tsx` in `@sitecore-content-sdk/react`).
  * @param {z.ZodRawShape} [extra] - Optional additional shape to merge into the schema.
- * @returns A ZodObject with `value?: string` and the DS control hint attached.
+ * @returns A ZodObject with `value?: string` and DS control/fieldType hints attached.
  * @public
  */
 export const dateFieldSchema = (extra?: z.ZodRawShape) =>
@@ -56,7 +56,7 @@ export const dateFieldSchema = (extra?: z.ZodRawShape) =>
  * The inner value object uses `z.looseObject` to allow arbitrary Sitecore-added attributes,
  * matching the `[attributeName: string]: unknown` index signature on `LinkFieldValue`.
  * @param {z.ZodRawShape} [extra] - Optional additional shape to merge into the outer schema.
- * @returns A ZodObject with `value: LinkFieldValue` and the DS control hint attached.
+ * @returns A ZodObject with `value: LinkFieldValue` and DS control/fieldType hints attached.
  * @public
  */
 export const linkFieldSchema = (extra?: z.ZodRawShape) =>
@@ -84,7 +84,7 @@ export const linkFieldSchema = (extra?: z.ZodRawShape) =>
  * The inner value object uses `z.looseObject` to allow arbitrary HTML attributes,
  * matching the `[attributeName: string]: unknown` index signature on `ImageFieldValue`.
  * @param {z.ZodRawShape} [extra] - Optional additional shape to merge into the outer schema.
- * @returns A ZodObject with `value?: ImageFieldValue` and the DS control hint attached.
+ * @returns A ZodObject with `value?: ImageFieldValue` and DS control/fieldType hints attached.
  * @public
  */
 export const imageFieldSchema = (extra?: z.ZodRawShape) =>
@@ -110,7 +110,7 @@ export const imageFieldSchema = (extra?: z.ZodRawShape) =>
  * The inner value object uses `z.looseObject` to allow arbitrary extra properties,
  * matching the `[propName: string]: unknown` index signature on `FileFieldValue`.
  * @param {z.ZodRawShape} [extra] - Optional additional shape to merge into the outer schema.
- * @returns A ZodObject with `value: FileFieldValue` and the DS control hint attached.
+ * @returns A ZodObject with `value: FileFieldValue` and DS control/fieldType hints attached.
  * @public
  */
 export const fileFieldSchema = (extra?: z.ZodRawShape) =>

--- a/packages/react/src/atoms/schema-utils.ts
+++ b/packages/react/src/atoms/schema-utils.ts
@@ -2,18 +2,18 @@
 import { z } from 'zod';
 
 /**
- * Prop metadata (e.g. control hint for Design Studio).
+ * Prop metadata (e.g. control hint and field type for Design Studio).
  *  @public
  */
-export type PropMeta = { control?: string };
+export type PropMeta = { control?: string; fieldType?: string };
 
 const META_KEY = 'meta';
 
 /**
- * Attach editor hint (e.g. control type) to a prop schema. Metadata is stored under a key that
+ * Attach editor hint (e.g. control type, fieldType) to a prop schema. Metadata is stored under a key that
  * survives JSON Schema conversion for Design Studio.
  * @param {import('zod').ZodType} schema - Zod type for the prop
- * @param {PropMeta} meta - Editor metadata (e.g. control)
+ * @param {PropMeta} meta - Editor metadata (e.g. control, fieldType)
  * @returns The same Zod type with meta attached (or schema unchanged if .meta is not callable)
  * @public
  */


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Added `fieldType` to `PropMeta` and all field schema helpers so Design Studio can bind props to full field objects in state.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
