### PR TITLE
[Atoms] Add atoms agent skills to Next.js templates

### DIFF
--- a/.changeset/jss-9473-atoms-skills.md
+++ b/.changeset/jss-9473-atoms-skills.md
@@ -1,0 +1,5 @@
+---
+'create-content-sdk-app': patch
+---
+
+[create-content-sdk-app] Add agent skills for atoms setup, create, and maintain in Next.js starter templates

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/.agents/skills/content-sdk-atoms-create/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/.agents/skills/content-sdk-atoms-create/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: content-sdk-atoms-create
+description: Creates atoms via defineAtomsCatalog and defineAtomsRegistry — props, field schemas, slots, actions.
+---
+
+# Atoms create (App Router + Cache Components)
+
+**Read first:** `src/atoms/index.tsx`
+**Related:** `content-sdk-atoms-setup`, `content-sdk-atoms-maintain`
+
+## When
+
+- Adding or editing atom components / actions in the catalog and registry
+- Choosing Zod props or Sitecore field schemas for atom props
+
+## Rules
+
+- Define schema with `defineAtomsCatalog` and React implementations with `defineAtomsRegistry` (import from `@sitecore-content-sdk/nextjs/atoms`)
+- Catalog needs `components` and `actions` (use `actions: {}` when none); export the catalog as **`catalog`**
+- Per component: `props` (Zod), `description`, optional `slots`, `allowedChildren` / `allowedParents`, optional `version`
+- Registry component names must match catalog names; each renderer gets `{ props, children, emit, on, bindings }`
+- If catalog defines actions, map matching handlers under registry `actions`
+- Sitecore fields: prefer `textFieldSchema`, `richTextFieldSchema`, `linkFieldSchema`, `imageFieldSchema`, `dateFieldSchema`, `fileFieldSchema` — do not invent parallel field shapes
+- **Do not** put `className` in catalog props (type-enforced); wrapper styling uses rendering `params.styles` / `params.RenderingIdentifier`, not catalog schema
+- Keep registry as a Client Component surface (`'use client'` via `defineAtomsRegistry`)
+- Do **not** add atoms to `.sitecore/component-map*` — Provider `atomsConfig` is the registration path
+- After intentional schema changes, run `npm run sitecore-tools:atoms:update` (see maintain skill)
+
+## Stop
+
+- Stop if setup wiring is missing → `content-sdk-atoms-setup`
+- Stop if the change is only version/lock drift → `content-sdk-atoms-maintain`
+- Stop if the user wants a normal Sitecore rendering under `src/components/` → `content-sdk-component-scaffold`

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/.agents/skills/content-sdk-atoms-maintain/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/.agents/skills/content-sdk-atoms-maintain/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: content-sdk-atoms-maintain
+description: Maintains atom versions and atoms.lock.json — validate, update, breakOnError, schema drift.
+---
+
+# Atoms maintain (App Router + Cache Components)
+
+**Read first:** `.sitecore/atoms.lock.json`, `sitecore.cli.config.ts` (`atoms.validation`)
+**Related:** `content-sdk-atoms-setup`, `content-sdk-atoms-create`
+
+## When
+
+- Schema or version changes after atoms already exist
+- `atoms validate` fails on `dev` / `build`
+- Tuning `breakOnError` for CI vs local
+
+## Rules
+
+- Lock file: `.sitecore/atoms.lock.json` — per-atom schema hashes (+ optional versions); optional catalog-level `version`
+- `npm run sitecore-tools:atoms:validate` — compares current `src/atoms` definitions to the lock; runs on `dev`/`build`
+- `npm run sitecore-tools:atoms:update` — regenerate lock **after intentional** schema/version changes (this is how you accept a new hash)
+- Common issues: missing lock (`MV-012`); schema hash changed (`IV-010`); new atom not in lock (`MV-014`); lock atom missing from catalog (`MV-013`)
+- Versions are **optional**. If you set catalog or per-atom `version`, lock and source must match (`IV-008` / `IV-009`); bump the version string when you intend a versioned change, then run `atoms update`
+- `atoms.validation.breakOnError` in `sitecore.cli.config.ts`: `false` (starter default) logs issues without failing; `true` throws (`IE-009`) — use in CI when ready
+- Do not hand-edit lock hashes; always regenerate via `atoms update`
+- Removing an atom: delete from catalog/registry, then `atoms update` so the lock drops it
+
+## Stop
+
+- Stop if creating a new atom from scratch → `content-sdk-atoms-create`
+- Stop if Provider/CLI wiring is broken → `content-sdk-atoms-setup`

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/.agents/skills/content-sdk-atoms-setup/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/.agents/skills/content-sdk-atoms-setup/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: content-sdk-atoms-setup
+description: Explains starter atoms wiring — src/atoms, Providers atomsConfig, CLI validate/update, first lock file.
+---
+
+# Atoms setup (App Router + Cache Components)
+
+**Read first:** `src/atoms/index.tsx`, `src/Providers.tsx`, `sitecore.cli.config.ts`
+
+## When
+
+- First-time atoms onboarding in a scaffolded app
+- Confirming Provider/CLI wiring before creating atoms
+- Generating the initial `.sitecore/atoms.lock.json`
+
+## Rules
+
+- Starter already wires atoms: empty catalog/registry in `src/atoms/index.tsx`, `atomsConfig` on `SitecoreProvider` in `Providers.tsx`, `atoms.validation.breakOnError` in `sitecore.cli.config.ts`
+- `npm run sitecore-tools:atoms:validate` runs on `dev` and `build`; `npm run sitecore-tools:atoms:update` regenerates the lock file
+- CLI reads **`src/atoms/index.ts(x)` only** and requires a named **`catalog`** export (from `defineAtomsCatalog`)
+- Atoms are **not** registered in `.sitecore/component-map*` — they use `atomsConfig`, not the component map
+- After scaffold (or before first validate), run `npm run sitecore-tools:atoms:update` once so `.sitecore/atoms.lock.json` exists (`MV-012` if missing)
+- Commit the lock file (templates keep it via `!.sitecore/atoms.lock.json`); do not hand-edit hashes
+
+## Stop
+
+- Stop if the app lacks `src/atoms/` or `atomsConfig` — restore from the template before creating atoms
+- For defining components/actions → `content-sdk-atoms-create`
+- For versioning / lock drift → `content-sdk-atoms-maintain`

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/AGENTS.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/AGENTS.md
@@ -17,6 +17,8 @@ npm run type-check   # Run TypeScript compiler
 
 **Environment:** Copy `.env.example` to `.env.local` and set Sitecore API endpoint, key, default site, language, and `SITECORE_REVALIDATE_SECRET` (used by `POST /api/revalidate`). Never commit `.env` or `.env.local`.
 
+**Atoms:** Catalog/registry in `src/atoms/index.tsx`; wired via `atomsConfig` on `SitecoreProvider` (not the component map). Run `npm run sitecore-tools:atoms:update` after intentional schema changes; `atoms:validate` runs on `dev`/`build`. Skills: `content-sdk-atoms-setup`, `content-sdk-atoms-create`, `content-sdk-atoms-maintain`.
+
 ---
 
 ## Application Structure (App Router + Cache Components)
@@ -38,6 +40,7 @@ src/
       sitemap/route.ts, robots/route.ts
       editing/config/route.ts, editing/render/route.ts
       revalidate/route.ts         # POST /api/revalidate (OSR)
+  atoms/                         # Atoms catalog + registry (defineAtomsCatalog / defineAtomsRegistry)
   components/                    # React components (Sitecore + app-specific)
   lib/
     sitecore-client.ts            # Single SitecoreClient instance
@@ -50,7 +53,7 @@ src/
     request.ts                    # getRequestConfig, getSitecoreDictionary per site
   Layout.tsx, Providers.tsx, Bootstrap.tsx, Scripts.tsx
 proxy.ts                         # Edge middleware (preview, bot-tracking, locale, multisite, redirects, personalize)
-.sitecore/                       # component-map.ts, component-map.client.ts, import-map.*, sites.json, metadata.json
+.sitecore/                       # component-map.ts, component-map.client.ts, import-map.*, atoms.lock.json, sites.json, metadata.json
 sitecore.config.ts               # Sitecore config (api, defaultSite, defaultLanguage, dictionary cache off)
 next.config.ts                   # cacheComponents: true, next-intl plugin, rewrites, images
 ```
@@ -62,7 +65,7 @@ next.config.ts                   # cacheComponents: true, next-intl plugin, rewr
 - **Quick checks:** If locale or dictionary is wrong, ensure `setRequestLocale(\`${site}_${locale}\`)` is called at the top of the page and `src/i18n/request.ts` parses `requestLocale` and calls `getSitecoreDictionary`. If a content change does not appear, verify the webhook posted to `POST /api/revalidate` with the right secret and check the tag families (`sc:route`, `sc:item`, `sc:dict`) returned by the cache helpers.
 - **Security:** Use only environment variables in `sitecore.config.ts`; never hardcode API keys, editing secret, or `SITECORE_REVALIDATE_SECRET`. Do not expose secrets in client-side code or logs. Validate and sanitize user input at boundaries.
 - **Performance:** Keep middleware lightweight; use the proxy `matcher` so it does not run on `/api/*`, `_next`, sitemap, robots, or static assets. Use Server Components for data fetching and the cache helpers under `'use cache'` so cached payloads carry the right tags. Use `generateStaticParams` and caching as in the existing page.
-- **Sitecore patterns:** Use SDK field components (`<Text>`, `<RichText>`, `<Image>`) and validate field existence before render. Regenerate the component maps with `npm run sitecore-tools:generate-map` or `npm run sitecore-tools:generate-map:watch`; edit the maps manually only when the generator cannot handle the change. Use the cache helpers in `src/lib/cache/` for all non-preview Sitecore reads so tags stay consistent across the app.
+- **Sitecore patterns:** Use SDK field components (`<Text>`, `<RichText>`, `<Image>`) and validate field existence before render. Regenerate the component maps with `npm run sitecore-tools:generate-map` or `npm run sitecore-tools:generate-map:watch`; edit the maps manually only when the generator cannot handle the change. Use the cache helpers in `src/lib/cache/` for all non-preview Sitecore reads so tags stay consistent across the app. Define atoms in `src/atoms/` via `defineAtomsCatalog` / `defineAtomsRegistry` and `atomsConfig` — do not register atoms in the component map.
 - **Consistency:** Follow the existing patterns in `[site]/[locale]/[[...path]]/page.tsx`, `not-found.tsx`, `i18n/request.ts` (site_locale + `getSitecoreDictionary`), and API route handlers. When adding routes or rewrites, keep the middleware matcher and next-intl config in sync.
 
 ---
@@ -85,6 +88,7 @@ next.config.ts                   # cacheComponents: true, next-intl plugin, rewr
 | Use Sitecore field components and validate fields | Expose API keys or editing secret in client code |
 | Document required env vars in `.env.example` only | Commit `.env` or `.env.local` |
 | Run `npm run build` after changes to verify the app builds | Add npm dependencies without explicit user approval |
+| Define atoms in `src/atoms/` and pass via `atomsConfig`; run `atoms:update` after schema changes | Register atoms in the component map or hand-edit `atoms.lock.json` hashes |
 
 ---
 

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/Skills.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router-cache-components/Skills.md
@@ -19,6 +19,9 @@ App Router + Cache Components (`src/lib/cache/`, `POST /api/revalidate`). Load *
 | [content-sdk-upgrade-assistant](.agents/skills/content-sdk-upgrade-assistant/SKILL.md) | Upgrade @sitecore-content-sdk/*; follow CHANGELOG and migration guides |
 | [content-sdk-component-data-strategy](.agents/skills/content-sdk-component-data-strategy/SKILL.md) | Cached layout data via cache helpers; preview via client; site/locale from params |
 | [content-sdk-cache-components-and-osr](.agents/skills/content-sdk-cache-components-and-osr/SKILL.md) | Tag-based caching in src/lib/cache/ and POST /api/revalidate webhook for on-demand invalidation |
+| [content-sdk-atoms-setup](.agents/skills/content-sdk-atoms-setup/SKILL.md) | Starter atoms wiring: src/atoms, Providers atomsConfig, CLI validate/update, first lock file |
+| [content-sdk-atoms-create](.agents/skills/content-sdk-atoms-create/SKILL.md) | Define catalog + registry (props, field schemas, slots, actions); not component-map |
+| [content-sdk-atoms-maintain](.agents/skills/content-sdk-atoms-maintain/SKILL.md) | Atom versioning and atoms.lock.json: validate, update, breakOnError, schema drift |
 
 Do **not** load every skill at session start. Open [AGENTS.md](AGENTS.md) first; add one skill when the task matches a row above.
 

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/.agents/skills/content-sdk-atoms-create/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/.agents/skills/content-sdk-atoms-create/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: content-sdk-atoms-create
+description: Creates atoms via defineAtomsCatalog and defineAtomsRegistry — props, field schemas, slots, actions.
+---
+
+# Atoms create (App Router)
+
+**Read first:** `src/atoms/index.tsx`
+**Related:** `content-sdk-atoms-setup`, `content-sdk-atoms-maintain`
+
+## When
+
+- Adding or editing atom components / actions in the catalog and registry
+- Choosing Zod props or Sitecore field schemas for atom props
+
+## Rules
+
+- Define schema with `defineAtomsCatalog` and React implementations with `defineAtomsRegistry` (import from `@sitecore-content-sdk/nextjs/atoms`)
+- Catalog needs `components` and `actions` (use `actions: {}` when none); export the catalog as **`catalog`**
+- Per component: `props` (Zod), `description`, optional `slots`, `allowedChildren` / `allowedParents`, optional `version`
+- Registry component names must match catalog names; each renderer gets `{ props, children, emit, on, bindings }`
+- If catalog defines actions, map matching handlers under registry `actions`
+- Sitecore fields: prefer `textFieldSchema`, `richTextFieldSchema`, `linkFieldSchema`, `imageFieldSchema`, `dateFieldSchema`, `fileFieldSchema` — do not invent parallel field shapes
+- **Do not** put `className` in catalog props (type-enforced); wrapper styling uses rendering `params.styles` / `params.RenderingIdentifier`, not catalog schema
+- Keep registry as a Client Component surface (`'use client'` via `defineAtomsRegistry`)
+- Do **not** add atoms to `.sitecore/component-map*` — Provider `atomsConfig` is the registration path
+- After intentional schema changes, run `npm run sitecore-tools:atoms:update` (see maintain skill)
+
+## Stop
+
+- Stop if setup wiring is missing → `content-sdk-atoms-setup`
+- Stop if the change is only version/lock drift → `content-sdk-atoms-maintain`
+- Stop if the user wants a normal Sitecore rendering under `src/components/` → `content-sdk-component-scaffold`

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/.agents/skills/content-sdk-atoms-maintain/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/.agents/skills/content-sdk-atoms-maintain/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: content-sdk-atoms-maintain
+description: Maintains atom versions and atoms.lock.json — validate, update, breakOnError, schema drift.
+---
+
+# Atoms maintain (App Router)
+
+**Read first:** `.sitecore/atoms.lock.json`, `sitecore.cli.config.ts` (`atoms.validation`)
+**Related:** `content-sdk-atoms-setup`, `content-sdk-atoms-create`
+
+## When
+
+- Schema or version changes after atoms already exist
+- `atoms validate` fails on `dev` / `build`
+- Tuning `breakOnError` for CI vs local
+
+## Rules
+
+- Lock file: `.sitecore/atoms.lock.json` — per-atom schema hashes (+ optional versions); optional catalog-level `version`
+- `npm run sitecore-tools:atoms:validate` — compares current `src/atoms` definitions to the lock; runs on `dev`/`build`
+- `npm run sitecore-tools:atoms:update` — regenerate lock **after intentional** schema/version changes (this is how you accept a new hash)
+- Common issues: missing lock (`MV-012`); schema hash changed (`IV-010`); new atom not in lock (`MV-014`); lock atom missing from catalog (`MV-013`)
+- Versions are **optional**. If you set catalog or per-atom `version`, lock and source must match (`IV-008` / `IV-009`); bump the version string when you intend a versioned change, then run `atoms update`
+- `atoms.validation.breakOnError` in `sitecore.cli.config.ts`: `false` (starter default) logs issues without failing; `true` throws (`IE-009`) — use in CI when ready
+- Do not hand-edit lock hashes; always regenerate via `atoms update`
+- Removing an atom: delete from catalog/registry, then `atoms update` so the lock drops it
+
+## Stop
+
+- Stop if creating a new atom from scratch → `content-sdk-atoms-create`
+- Stop if Provider/CLI wiring is broken → `content-sdk-atoms-setup`

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/.agents/skills/content-sdk-atoms-setup/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/.agents/skills/content-sdk-atoms-setup/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: content-sdk-atoms-setup
+description: Explains starter atoms wiring — src/atoms, Providers atomsConfig, CLI validate/update, first lock file.
+---
+
+# Atoms setup (App Router)
+
+**Read first:** `src/atoms/index.tsx`, `src/Providers.tsx`, `sitecore.cli.config.ts`
+
+## When
+
+- First-time atoms onboarding in a scaffolded app
+- Confirming Provider/CLI wiring before creating atoms
+- Generating the initial `.sitecore/atoms.lock.json`
+
+## Rules
+
+- Starter already wires atoms: empty catalog/registry in `src/atoms/index.tsx`, `atomsConfig` on `SitecoreProvider` in `Providers.tsx`, `atoms.validation.breakOnError` in `sitecore.cli.config.ts`
+- `npm run sitecore-tools:atoms:validate` runs on `dev` and `build`; `npm run sitecore-tools:atoms:update` regenerates the lock file
+- CLI reads **`src/atoms/index.ts(x)` only** and requires a named **`catalog`** export (from `defineAtomsCatalog`)
+- Atoms are **not** registered in `.sitecore/component-map*` — they use `atomsConfig`, not the component map
+- After scaffold (or before first validate), run `npm run sitecore-tools:atoms:update` once so `.sitecore/atoms.lock.json` exists (`MV-012` if missing)
+- Commit the lock file (templates keep it via `!.sitecore/atoms.lock.json`); do not hand-edit hashes
+
+## Stop
+
+- Stop if the app lacks `src/atoms/` or `atomsConfig` — restore from the template before creating atoms
+- For defining components/actions → `content-sdk-atoms-create`
+- For versioning / lock drift → `content-sdk-atoms-maintain`

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/AGENTS.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/AGENTS.md
@@ -19,6 +19,8 @@ npm run type-check   # Run TypeScript compiler
 
 **Component maps:** `.sitecore/component-map.ts` (Server) and `.sitecore/component-map.client.ts` (Client) are auto-generated from `src/components/` during `npm run dev` (watch) and `npm run build`. The generator scans `src/components/` and creates entries in the appropriate map (Server vs Client based on `'use client'`).
 
+**Atoms:** Catalog/registry in `src/atoms/index.tsx`; wired via `atomsConfig` on `SitecoreProvider` (not the component map). Run `npm run sitecore-tools:atoms:update` after intentional schema changes; `atoms:validate` runs on `dev`/`build`. Skills: `content-sdk-atoms-setup`, `content-sdk-atoms-create`, `content-sdk-atoms-maintain`.
+
 ---
 
 ## Application Structure (App Router)
@@ -37,6 +39,7 @@ src/
     not-found.tsx                 # Root not-found
     api/                          # Route handlers
       sitemap/route.ts, robots/route.ts, editing/config/route.ts, editing/render/route.ts
+  atoms/                         # Atoms catalog + registry (defineAtomsCatalog / defineAtomsRegistry)
   components/                    # React components (Sitecore + app-specific)
   lib/                           # sitecore-client, component-props
   i18n/                          # next-intl
@@ -44,7 +47,7 @@ src/
     request.ts                    # getRequestConfig, getDictionary per site
   Layout.tsx, Providers.tsx, Bootstrap.tsx, Scripts.tsx
 proxy.ts                         # Edge middleware (preview, bot-tracking, locale, multisite, redirects, personalize)
-.sitecore/                       # component-map.ts, component-map.client.ts, import-map.*, sites.json, metadata.json
+.sitecore/                       # component-map.ts, component-map.client.ts, import-map.*, atoms.lock.json, sites.json, metadata.json
 sitecore.config.ts               # Sitecore config (api, defaultSite, defaultLanguage, multisite, etc.)
 next.config.ts                   # next-intl plugin, rewrites, images
 ```
@@ -56,7 +59,7 @@ next.config.ts                   # next-intl plugin, rewrites, images
 - **Quick checks:** If locale or dictionary is wrong, ensure `setRequestLocale(\`${site}_${locale}\`)` is called at the top of the page and `src/i18n/request.ts` parses `requestLocale` and calls `client.getDictionary`. If segment not-found lacks site/locale, ensure `setCachedPageParams` runs in `[[...path]]/layout.tsx` and read with `getCachedPageParams()` in `not-found.tsx` (do not use `headers()` — it opts out of SSG). Always `await params` (Next.js 15+).
 - **Security:** Use only environment variables in `sitecore.config.ts`; never hardcode API keys, editing secret, or host URLs. Do not expose secrets in client-side code or in logs. Validate and sanitize user input at boundaries.
 - **Performance:** Keep middleware lightweight; use the proxy `matcher` so it does not run on API routes, `_next`, sitemap, robots, or static assets. Use Server Components for data fetching; add `'use client'` only where interactivity is needed. Use `generateStaticParams` and caching as in the existing page.
-- **Sitecore patterns:** Use SDK field components (`<Text>`, `<RichText>`, `<Image>`) and validate field existence before render. Regenerate the component maps with `npm run sitecore-tools:generate-map` or `npm run sitecore-tools:generate-map:watch`; edit the maps manually only when the generator cannot handle the change. Use the single Sitecore client in `lib/sitecore-client.ts` for all data fetching.
+- **Sitecore patterns:** Use SDK field components (`<Text>`, `<RichText>`, `<Image>`) and validate field existence before render. Regenerate the component maps with `npm run sitecore-tools:generate-map` or `npm run sitecore-tools:generate-map:watch`; edit the maps manually only when the generator cannot handle the change. Use the single Sitecore client in `lib/sitecore-client.ts` for all data fetching. Define atoms in `src/atoms/` via `defineAtomsCatalog` / `defineAtomsRegistry` and `atomsConfig` — do not register atoms in the component map.
 - **Consistency:** Follow the existing patterns in `[site]/[locale]/[[...path]]/page.tsx`, layout hierarchy, `i18n/request.ts` (site_locale), and API route handlers. When adding routes or rewrites, keep the middleware matcher and next-intl config in sync.
 
 ---
@@ -75,6 +78,7 @@ next.config.ts                   # next-intl plugin, rewrites, images
 | Use Sitecore field components and validate fields | Expose API keys or editing secret in client code |
 | Document required env vars in `.env.example` only | Commit `.env` or `.env.local` |
 | Run `npm run build` after changes to verify the app builds | Add npm dependencies without explicit user approval |
+| Define atoms in `src/atoms/` and pass via `atomsConfig`; run `atoms:update` after schema changes | Register atoms in the component map or hand-edit `atoms.lock.json` hashes |
 
 ---
 

--- a/packages/create-content-sdk-app/src/templates/nextjs-app-router/Skills.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs-app-router/Skills.md
@@ -18,6 +18,9 @@ App Router with `[site]`/`[locale]`, next-intl, server/client component maps. Lo
 | [content-sdk-troubleshoot-editing](.agents/skills/content-sdk-troubleshoot-editing/SKILL.md) | Check draftMode, getPreviewData(headers), setRequestLocale, getCachedPageParams, maps |
 | [content-sdk-upgrade-assistant](.agents/skills/content-sdk-upgrade-assistant/SKILL.md) | Upgrade @sitecore-content-sdk/*; follow CHANGELOG and migration guides |
 | [content-sdk-component-data-strategy](.agents/skills/content-sdk-component-data-strategy/SKILL.md) | Layout from getPage; site/locale from route params; serializable client props |
+| [content-sdk-atoms-setup](.agents/skills/content-sdk-atoms-setup/SKILL.md) | Starter atoms wiring: src/atoms, Providers atomsConfig, CLI validate/update, first lock file |
+| [content-sdk-atoms-create](.agents/skills/content-sdk-atoms-create/SKILL.md) | Define catalog + registry (props, field schemas, slots, actions); not component-map |
+| [content-sdk-atoms-maintain](.agents/skills/content-sdk-atoms-maintain/SKILL.md) | Atom versioning and atoms.lock.json: validate, update, breakOnError, schema drift |
 
 Do **not** load every skill at session start. Open [AGENTS.md](AGENTS.md) first; add one skill when the task matches a row above.
 

--- a/packages/create-content-sdk-app/src/templates/nextjs/.agents/skills/content-sdk-atoms-create/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs/.agents/skills/content-sdk-atoms-create/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: content-sdk-atoms-create
+description: Creates atoms via defineAtomsCatalog and defineAtomsRegistry — props, field schemas, slots, actions.
+---
+
+# Atoms create (Pages Router)
+
+**Read first:** `src/atoms/index.tsx`
+**Related:** `content-sdk-atoms-setup`, `content-sdk-atoms-maintain`
+
+## When
+
+- Adding or editing atom components / actions in the catalog and registry
+- Choosing Zod props or Sitecore field schemas for atom props
+
+## Rules
+
+- Define schema with `defineAtomsCatalog` and React implementations with `defineAtomsRegistry` (import from `@sitecore-content-sdk/nextjs/atoms`)
+- Catalog needs `components` and `actions` (use `actions: {}` when none); export the catalog as **`catalog`**
+- Per component: `props` (Zod), `description`, optional `slots`, `allowedChildren` / `allowedParents`, optional `version`
+- Registry component names must match catalog names; each renderer gets `{ props, children, emit, on, bindings }`
+- If catalog defines actions, map matching handlers under registry `actions`
+- Sitecore fields: prefer `textFieldSchema`, `richTextFieldSchema`, `linkFieldSchema`, `imageFieldSchema`, `dateFieldSchema`, `fileFieldSchema` — do not invent parallel field shapes
+- **Do not** put `className` in catalog props (type-enforced); wrapper styling uses rendering `params.styles` / `params.RenderingIdentifier`, not catalog schema
+- Keep registry as a Client Component surface (`'use client'` via `defineAtomsRegistry`)
+- Do **not** add atoms to `.sitecore/component-map*` — Provider `atomsConfig` is the registration path
+- After intentional schema changes, run `npm run sitecore-tools:atoms:update` (see maintain skill)
+
+## Stop
+
+- Stop if setup wiring is missing → `content-sdk-atoms-setup`
+- Stop if the change is only version/lock drift → `content-sdk-atoms-maintain`
+- Stop if the user wants a normal Sitecore rendering under `src/components/` → `content-sdk-component-scaffold`

--- a/packages/create-content-sdk-app/src/templates/nextjs/.agents/skills/content-sdk-atoms-maintain/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs/.agents/skills/content-sdk-atoms-maintain/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: content-sdk-atoms-maintain
+description: Maintains atom versions and atoms.lock.json — validate, update, breakOnError, schema drift.
+---
+
+# Atoms maintain (Pages Router)
+
+**Read first:** `.sitecore/atoms.lock.json`, `sitecore.cli.config.ts` (`atoms.validation`)
+**Related:** `content-sdk-atoms-setup`, `content-sdk-atoms-create`
+
+## When
+
+- Schema or version changes after atoms already exist
+- `atoms validate` fails on `dev` / `build`
+- Tuning `breakOnError` for CI vs local
+
+## Rules
+
+- Lock file: `.sitecore/atoms.lock.json` — per-atom schema hashes (+ optional versions); optional catalog-level `version`
+- `npm run sitecore-tools:atoms:validate` — compares current `src/atoms` definitions to the lock; runs on `dev`/`build`
+- `npm run sitecore-tools:atoms:update` — regenerate lock **after intentional** schema/version changes (this is how you accept a new hash)
+- Common issues: missing lock (`MV-012`); schema hash changed (`IV-010`); new atom not in lock (`MV-014`); lock atom missing from catalog (`MV-013`)
+- Versions are **optional**. If you set catalog or per-atom `version`, lock and source must match (`IV-008` / `IV-009`); bump the version string when you intend a versioned change, then run `atoms update`
+- `atoms.validation.breakOnError` in `sitecore.cli.config.ts`: `false` (starter default) logs issues without failing; `true` throws (`IE-009`) — use in CI when ready
+- Do not hand-edit lock hashes; always regenerate via `atoms update`
+- Removing an atom: delete from catalog/registry, then `atoms update` so the lock drops it
+
+## Stop
+
+- Stop if creating a new atom from scratch → `content-sdk-atoms-create`
+- Stop if Provider/CLI wiring is broken → `content-sdk-atoms-setup`

--- a/packages/create-content-sdk-app/src/templates/nextjs/.agents/skills/content-sdk-atoms-setup/SKILL.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs/.agents/skills/content-sdk-atoms-setup/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: content-sdk-atoms-setup
+description: Explains starter atoms wiring — src/atoms, Providers atomsConfig, CLI validate/update, first lock file.
+---
+
+# Atoms setup (Pages Router)
+
+**Read first:** `src/atoms/index.tsx`, `src/Providers.tsx`, `sitecore.cli.config.ts`
+
+## When
+
+- First-time atoms onboarding in a scaffolded app
+- Confirming Provider/CLI wiring before creating atoms
+- Generating the initial `.sitecore/atoms.lock.json`
+
+## Rules
+
+- Starter already wires atoms: empty catalog/registry in `src/atoms/index.tsx`, `atomsConfig` on `SitecoreProvider` in `Providers.tsx`, `atoms.validation.breakOnError` in `sitecore.cli.config.ts`
+- `npm run sitecore-tools:atoms:validate` runs on `dev` and `build`; `npm run sitecore-tools:atoms:update` regenerates the lock file
+- CLI reads **`src/atoms/index.ts(x)` only** and requires a named **`catalog`** export (from `defineAtomsCatalog`)
+- Atoms are **not** registered in `.sitecore/component-map*` — they use `atomsConfig`, not the component map
+- After scaffold (or before first validate), run `npm run sitecore-tools:atoms:update` once so `.sitecore/atoms.lock.json` exists (`MV-012` if missing)
+- Commit the lock file (templates keep it via `!.sitecore/atoms.lock.json`); do not hand-edit hashes
+
+## Stop
+
+- Stop if the app lacks `src/atoms/` or `atomsConfig` — restore from the template before creating atoms
+- For defining components/actions → `content-sdk-atoms-create`
+- For versioning / lock drift → `content-sdk-atoms-maintain`

--- a/packages/create-content-sdk-app/src/templates/nextjs/AGENTS.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs/AGENTS.md
@@ -19,6 +19,8 @@ npm run type-check   # Run TypeScript compiler
 
 **Component map:** `.sitecore/component-map.ts` is auto-generated from `src/components/` during `npm run dev` (watch) and `npm run build`. No manual action needed unless the generator cannot handle a case.
 
+**Atoms:** Catalog/registry in `src/atoms/index.tsx`; wired via `atomsConfig` on `SitecoreProvider` (not the component map). Run `npm run sitecore-tools:atoms:update` after intentional schema changes; `atoms:validate` runs on `dev`/`build`. Skills: `content-sdk-atoms-setup`, `content-sdk-atoms-create`, `content-sdk-atoms-maintain`.
+
 ---
 
 ## Application Structure (Pages Router)
@@ -30,11 +32,12 @@ src/
     _app.tsx
     404.tsx, 500.tsx, _error.tsx
     api/             # API routes (sitemap, robots, editing, healthz)
+  atoms/             # Atoms catalog + registry (defineAtomsCatalog / defineAtomsRegistry)
   components/        # React components (Sitecore + app-specific)
   lib/               # sitecore-client, component-props
   Layout.tsx, Providers.tsx, Bootstrap.tsx, Scripts.tsx
 proxy.ts             # Edge middleware (preview, bot-tracking, multisite, redirects, personalize)
-.sitecore/           # component-map.ts, import-map.ts, sites.json, metadata.json
+.sitecore/           # component-map.ts, import-map.ts, atoms.lock.json, sites.json, metadata.json
 sitecore.config.ts   # Sitecore config (api, defaultSite, defaultLanguage, multisite, etc.)
 next.config.js       # i18n (locales, defaultLocale), rewrites, images
 ```
@@ -46,7 +49,7 @@ next.config.js       # i18n (locales, defaultLocale), rewrites, images
 - **Quick checks:** If path or locale is wrong, ensure you use `extractPath(context)` and `context.locale` (from getStaticProps/getServerSideProps); do not assume path or locale from elsewhere. Keep the proxy chain order (PreviewProxy → BotTrackingProxy → Multisite → Redirects → Personalize).
 - **Security:** Use only environment variables in `sitecore.config.ts`; never hardcode API keys, editing secret, or host URLs. Do not expose secrets in client-side code or in logs. Validate and sanitize user input at boundaries.
 - **Performance:** Keep middleware lightweight; use the proxy `skip` callback and `matcher` so middleware does not run on `/api`, `_next`, static files, or health checks. Use `revalidate` in getStaticProps for ISR where appropriate. Prefer server-side data fetching for Sitecore content.
-- **Sitecore patterns:** Use SDK field components (`<Text>`, `<RichText>`, `<Image>`) and validate field existence before render. Regenerate `.sitecore/component-map.ts` with `npm run sitecore-tools:generate-map` or `npm run sitecore-tools:generate-map:watch`; edit the map manually only when the generator cannot handle the change. Keep the single Sitecore client instance in `lib/sitecore-client.ts` and pass it (or use it) in API routes and getStaticProps/getServerSideProps.
+- **Sitecore patterns:** Use SDK field components (`<Text>`, `<RichText>`, `<Image>`) and validate field existence before render. Regenerate `.sitecore/component-map.ts` with `npm run sitecore-tools:generate-map` or `npm run sitecore-tools:generate-map:watch`; edit the map manually only when the generator cannot handle the change. Keep the single Sitecore client instance in `lib/sitecore-client.ts` and pass it (or use it) in API routes and getStaticProps/getServerSideProps. Define atoms in `src/atoms/` via `defineAtomsCatalog` / `defineAtomsRegistry` and `atomsConfig` — do not register atoms in the component map.
 - **Consistency:** Follow the existing patterns in `[[...path]].tsx`, `_app.tsx`, and API routes. When adding API routes, add the corresponding rewrite in `next.config.js` and keep the middleware matcher in sync.
 
 ---
@@ -63,6 +66,7 @@ next.config.js       # i18n (locales, defaultLocale), rewrites, images
 | Use Sitecore field components (`<Text>`, `<RichText>`, `<Image>`) and validate fields | Expose API keys or editing secret in client code |
 | Document required env vars in `.env.example` only | Commit `.env` or `.env.local` |
 | Run `npm run build` after changes to verify the app builds | Add npm dependencies without explicit user approval |
+| Define atoms in `src/atoms/` and pass via `atomsConfig`; run `atoms:update` after schema changes | Register atoms in the component map or hand-edit `atoms.lock.json` hashes |
 
 ---
 

--- a/packages/create-content-sdk-app/src/templates/nextjs/Skills.md
+++ b/packages/create-content-sdk-app/src/templates/nextjs/Skills.md
@@ -18,6 +18,9 @@ Pages Router app with `[[...path]].tsx`, Next.js i18n (`context.locale`), single
 | [content-sdk-troubleshoot-editing](.agents/skills/content-sdk-troubleshoot-editing/SKILL.md) | Debug Pages Router preview: context |
 | [content-sdk-upgrade-assistant](.agents/skills/content-sdk-upgrade-assistant/SKILL.md) | Upgrade @sitecore-content-sdk/* packages; check CHANGELOG and migration guides |
 | [content-sdk-component-data-strategy](.agents/skills/content-sdk-component-data-strategy/SKILL.md) | Layout data from getPage/getComponentData; path/locale from extractPath/context |
+| [content-sdk-atoms-setup](.agents/skills/content-sdk-atoms-setup/SKILL.md) | Starter atoms wiring: src/atoms, Providers atomsConfig, CLI validate/update, first lock file |
+| [content-sdk-atoms-create](.agents/skills/content-sdk-atoms-create/SKILL.md) | Define catalog + registry (props, field schemas, slots, actions); not component-map |
+| [content-sdk-atoms-maintain](.agents/skills/content-sdk-atoms-maintain/SKILL.md) | Atom versioning and atoms.lock.json: validate, update, breakOnError, schema drift |
 
 Do **not** load every skill at session start. Open [AGENTS.md](AGENTS.md) first; add one skill when the task matches a row above.
 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR includes the following Agentic related updates for Atoms:

It adds three atoms agent skills to all Next.js starter templates (`nextjs`, `nextjs-app-router`, `nextjs-app-router-cache-components`):
  - `content-sdk-atoms-setup` — starter wiring, Provider `atomsConfig`, CLI validate/update, first lock file
  - `content-sdk-atoms-create` — catalog/registry, field schemas, composition/actions, no-`className` rule
  - `content-sdk-atoms-maintain` — versioning, `atoms.lock.json`, validate/update, `breakOnError`
 
 Additionally, it also includes: 
- Index of the skills in each template `Skills.md` and add a short atoms section to `AGENTS.md`

## Testing Details
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
