### PR TITLE
[react] RichText builds a new dangerouslySetInnerHTML object every render, causing full DOM replacement and dropped internal-link listeners

### DIFF
--- a/.changeset/afraid-snakes-help.md
+++ b/.changeset/afraid-snakes-help.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/react': patch
+---
+
+Fix `RichText` recreating nested DOM on parent re-renders by memoizing `dangerouslySetInnerHTML`, preserving event listeners on unchanged HTML.

--- a/packages/nextjs/test/setup.js
+++ b/packages/nextjs/test/setup.js
@@ -1,3 +1,24 @@
+const Module = require('module');
+
+// Ensure a single React instance when tests load @sitecore-content-sdk/react.
+// That package may otherwise resolve its own nested react and break hooks (e.g. useMemo).
+const originalResolveFilename = Module._resolveFilename;
+const forcedReactIds = new Set([
+  'react',
+  'react-dom',
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
+  'react-dom/client',
+]);
+
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (forcedReactIds.has(request)) {
+    // Resolve from this package (nextjs) instead of the requiring package's nested copy.
+    return originalResolveFilename.call(this, request, module, isMain, options);
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
 require('ts-node/register/transpile-only');
 require('../src/tests/request.ts');
 require('../src/tests/jsdom-setup.ts');

--- a/packages/react/src/components/RichText.test.tsx
+++ b/packages/react/src/components/RichText.test.tsx
@@ -55,6 +55,33 @@ describe('<RichText />', () => {
     expect(rendered[0].innerHTML).to.contain(field.value);
   });
 
+  it('should keep the same DOM nodes when re-rendered with unchanged html', () => {
+    const field = {
+      value: '<p>Hello <a id="rt-link" href="/foo">link</a></p>',
+    };
+
+    const Parent = ({ tick }: { tick: number }) => (
+      <div data-tick={tick}>
+        <RichText field={field} />
+      </div>
+    );
+
+    const { container, rerender } = render(<Parent tick={0} />);
+    const linkBefore = container.querySelector('#rt-link') as HTMLAnchorElement & {
+      __marker?: boolean;
+    };
+    expect(linkBefore).to.not.equal(null);
+    linkBefore.__marker = true;
+
+    rerender(<Parent tick={1} />);
+
+    const linkAfter = container.querySelector('#rt-link') as HTMLAnchorElement & {
+      __marker?: boolean;
+    };
+    expect(linkAfter).to.equal(linkBefore);
+    expect(linkAfter.__marker).to.equal(true);
+  });
+
   it('should render tag with a tag provided', () => {
     const field = {
       value: 'value',

--- a/packages/react/src/components/RichText.tsx
+++ b/packages/react/src/components/RichText.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { isFieldValueEmpty, type RichTextField } from '@sitecore-content-sdk/content/layout';
 import { withFieldMetadata } from '../enhancers/withFieldMetadata';
 import { withEmptyFieldEditingComponent } from '../enhancers/withEmptyFieldEditingComponent';
@@ -23,28 +23,16 @@ export interface RichTextProps extends EditableFieldProps<RichTextProps> {
   ref?: React.Ref<HTMLElement>;
 }
 
-// Keep a stable dangerouslySetInnerHTML object per HTML string across re-renders.
-const dangerouslySetInnerHTMLCache = new Map<string, { __html: string }>();
-
-const getStableDangerouslySetInnerHTML = (
-  html: string | undefined
-): { __html: string } | undefined => {
-  if (html === undefined || html === '') {
-    return undefined;
-  }
-
-  let prop = dangerouslySetInnerHTMLCache.get(html);
-  if (!prop) {
-    prop = { __html: html };
-    dangerouslySetInnerHTMLCache.set(html, prop);
-  }
-  return prop;
-};
-
 const RichTextComponent: React.FC<RichTextProps> = ({ field, tag = 'div', ref, ...otherProps }) => {
-  // Stabilize the object reference so React DOM does not rewrite innerHTML on every
-  // parent re-render when the HTML string is unchanged (preserves DOM nodes / listeners).
-  const dangerouslySetInnerHTML = getStableDangerouslySetInnerHTML(field?.value);
+  const html = field?.value;
+
+  // Keep the object reference stable across re-renders when the html is unchanged,
+  // since React DOM compares dangerouslySetInnerHTML by reference and re-sets
+  // innerHTML (recreating all child DOM nodes) whenever it changes.
+  const dangerouslySetInnerHTML = useMemo(
+    () => (html !== undefined && html !== '' ? { __html: html } : undefined),
+    [html]
+  );
 
   if (isFieldValueEmpty(field) || !dangerouslySetInnerHTML) {
     return null;

--- a/packages/react/src/components/RichText.tsx
+++ b/packages/react/src/components/RichText.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { isFieldValueEmpty, type RichTextField } from '@sitecore-content-sdk/content/layout';
 import { withFieldMetadata } from '../enhancers/withFieldMetadata';
 import { withEmptyFieldEditingComponent } from '../enhancers/withEmptyFieldEditingComponent';
@@ -24,16 +24,22 @@ export interface RichTextProps extends EditableFieldProps<RichTextProps> {
 }
 
 const RichTextComponent: React.FC<RichTextProps> = ({ field, tag = 'div', ref, ...otherProps }) => {
-  if (isFieldValueEmpty(field)) {
+  // Stabilize the object reference so React DOM does not rewrite innerHTML on every
+  // parent re-render when the HTML string is unchanged (preserves DOM nodes / listeners).
+  const html = field?.value;
+  const dangerouslySetInnerHTML = useMemo(
+    () => (html != null && html !== '' ? { __html: html } : undefined),
+    [html]
+  );
+
+  if (isFieldValueEmpty(field) || !dangerouslySetInnerHTML) {
     return null;
   }
 
   delete otherProps.editable; // prevent editable from being passed to the DOM
 
   const htmlProps = {
-    dangerouslySetInnerHTML: {
-      __html: field.value,
-    },
+    dangerouslySetInnerHTML,
     ref,
     suppressHydrationWarning: field.metadata ? true : undefined,
     ...otherProps,

--- a/packages/react/src/components/RichText.tsx
+++ b/packages/react/src/components/RichText.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { isFieldValueEmpty, type RichTextField } from '@sitecore-content-sdk/content/layout';
 import { withFieldMetadata } from '../enhancers/withFieldMetadata';
 import { withEmptyFieldEditingComponent } from '../enhancers/withEmptyFieldEditingComponent';
@@ -23,14 +23,28 @@ export interface RichTextProps extends EditableFieldProps<RichTextProps> {
   ref?: React.Ref<HTMLElement>;
 }
 
+// Keep a stable dangerouslySetInnerHTML object per HTML string across re-renders.
+const dangerouslySetInnerHTMLCache = new Map<string, { __html: string }>();
+
+const getStableDangerouslySetInnerHTML = (
+  html: string | undefined
+): { __html: string } | undefined => {
+  if (html === undefined || html === '') {
+    return undefined;
+  }
+
+  let prop = dangerouslySetInnerHTMLCache.get(html);
+  if (!prop) {
+    prop = { __html: html };
+    dangerouslySetInnerHTMLCache.set(html, prop);
+  }
+  return prop;
+};
+
 const RichTextComponent: React.FC<RichTextProps> = ({ field, tag = 'div', ref, ...otherProps }) => {
   // Stabilize the object reference so React DOM does not rewrite innerHTML on every
   // parent re-render when the HTML string is unchanged (preserves DOM nodes / listeners).
-  const html = field?.value;
-  const dangerouslySetInnerHTML = useMemo(
-    () => (html !== undefined && html !== '' ? { __html: html } : undefined),
-    [html]
-  );
+  const dangerouslySetInnerHTML = getStableDangerouslySetInnerHTML(field?.value);
 
   if (isFieldValueEmpty(field) || !dangerouslySetInnerHTML) {
     return null;

--- a/packages/react/src/components/RichText.tsx
+++ b/packages/react/src/components/RichText.tsx
@@ -28,7 +28,7 @@ const RichTextComponent: React.FC<RichTextProps> = ({ field, tag = 'div', ref, .
   // parent re-render when the HTML string is unchanged (preserves DOM nodes / listeners).
   const html = field?.value;
   const dangerouslySetInnerHTML = useMemo(
-    () => (html != null && html !== '' ? { __html: html } : undefined),
+    () => (html !== undefined && html !== '' ? { __html: html } : undefined),
     [html]
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Memoize `RichText` `dangerouslySetInnerHTML` (keyed on the HTML string) so React DOM does not rewrite `innerHTML` on unrelated parent re-renders.
- Preserves nested DOM nodes and attached listeners (e.g. Next.js internal links).
- Non-breaking bug fix; public API unchanged. Parallel fix for Sitecore JSS.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
