### PR TITLE
[react] Pages Editor hydration warning on sc-jss-empty-placeholder for empty placeholders

### DIFF
--- a/.changeset/stale-plums-relax.md
+++ b/.changeset/stale-plums-relax.md
@@ -3,3 +3,5 @@
 ---
 
 Fix hydration mismatch warnings in Pages Editor for empty placeholders and placeholder/rendering chrome markers, most visibly with `AppPlaceholder` in Next.js App Router. Sitecore Pages attaches chrome attributes (e.g. `cursor: pointer` styling) to these SDK-owned elements directly in the DOM, which can happen before React hydration completes and previously surfaced as a "server rendered HTML didn't match the client" warning. `suppressHydrationWarning` is now set on these editing-only elements, since their DOM is expected to be mutated externally.
+
+Also fixes a separate "Each child in a list should have a unique key prop" warning from the same code path: `AppPlaceholder`'s outer `PlaceholderMetadata` key now falls back to a placeholder-name-based key (`placeholder-metadata-${name}`) when the route rendering has no `uid`.

--- a/.changeset/stale-plums-relax.md
+++ b/.changeset/stale-plums-relax.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/react': patch
+---
+
+Fix hydration mismatch warnings in Pages Editor for empty placeholders and placeholder/rendering chrome markers, most visibly with `AppPlaceholder` in Next.js App Router. Sitecore Pages attaches chrome attributes (e.g. `cursor: pointer` styling) to these SDK-owned elements directly in the DOM, which can happen before React hydration completes and previously surfaced as a "server rendered HTML didn't match the client" warning. `suppressHydrationWarning` is now set on these editing-only elements, since their DOM is expected to be mutated externally.

--- a/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.test.tsx
@@ -1188,6 +1188,31 @@ describe('App Placeholder logic', () => {
       expect(wrapper?.container.querySelectorAll('.scpm').length).to.equal(8);
     });
 
+    it('should fall back to a placeholder-name-based key for the outer <PlaceholderMetadata> when the route rendering has no uid', () => {
+      // layoutData.sitecore.route has no `uid` (route data isn't a ComponentRendering). React
+      // never exposes a `key` value through rendered output (it's stripped before touching the
+      // DOM), so the only observable symptom of a missing/undefined key is the
+      // "unique key" console warning - assert that doesn't fire.
+      expect((layoutData.sitecore.route as unknown as ComponentRendering).uid).to.be.undefined;
+
+      const errorSpy = sandbox.stub(console, 'error');
+
+      render(
+        <AppPlaceholder
+          name="main"
+          rendering={layoutData.sitecore.route}
+          componentMap={componentMap}
+          page={page}
+        />,
+        { container: document.body }
+      );
+
+      const keyWarning = errorSpy
+        .getCalls()
+        .find((call) => String(call.args[0]).includes('unique "key" prop'));
+      expect(keyWarning, 'expected no React "unique key" warning').to.be.undefined;
+    });
+
     it('should add data-csdk-component-runtime="server" when rsc is true', () => {
       // rsc is already set to true in beforeEach, so we just verify
       const wrapper = render(

--- a/packages/react/src/components/Placeholder/AppPlaceholder.tsx
+++ b/packages/react/src/components/Placeholder/AppPlaceholder.tsx
@@ -136,7 +136,7 @@ const getPlaceholderComponents = (
 
   return [
     <PlaceholderMetadata
-      key={(rendering as ComponentRendering).uid}
+      key={(rendering as ComponentRendering).uid || `placeholder-metadata-${name}`}
       placeholderName={name}
       rendering={rendering as ComponentRendering}
     >

--- a/packages/react/src/components/Placeholder/PlaceholderMetadata.tsx
+++ b/packages/react/src/components/Placeholder/PlaceholderMetadata.tsx
@@ -102,13 +102,21 @@ export const PlaceholderMetadata = ({
     return attributes;
   };
 
+  // suppressHydrationWarning: Pages Editor attaches attributes to these chrome markers
+  // directly in the DOM (outside of React), which can happen before hydration completes.
+  // That mutation is expected in edit mode and isn't something app code can control, so it
+  // shouldn't surface as a hydration mismatch.
   return (
     <>
       <code
+        suppressHydrationWarning
         {...getCodeBlockAttributes({ kind: MetadataKind.Open, id: rendering.uid, placeholderName })}
       />
       {children}
-      <code {...getCodeBlockAttributes({ kind: MetadataKind.Close, placeholderName })} />
+      <code
+        suppressHydrationWarning
+        {...getCodeBlockAttributes({ kind: MetadataKind.Close, placeholderName })}
+      />
     </>
   );
 };

--- a/packages/react/src/components/Placeholder/placeholder-utils.tsx
+++ b/packages/react/src/components/Placeholder/placeholder-utils.tsx
@@ -98,12 +98,21 @@ export const getSXAParams = (rendering: ComponentRendering): { styles: string } 
 
 /**
  * Renders the placeholder when it is empty. The required CSS styles are applied to the placeholder in edit mode.
+ *
+ * `suppressHydrationWarning` is set because Pages Editor attaches chrome (e.g. `cursor: pointer`
+ * styling, click handlers) directly to this element outside of React, which can happen before
+ * client-side hydration completes. That DOM mutation is expected in edit mode and isn't something
+ * app code can control, so it shouldn't surface as a hydration mismatch.
  * @param {React.ReactNode | React.ReactElement[]} node react node
  * @returns react node
  * @public
  */
 export const renderEmptyPlaceholder = (node: React.ReactNode | React.ReactElement[]) => {
-  return <div className="sc-jss-empty-placeholder">{node}</div>;
+  return (
+    <div className="sc-jss-empty-placeholder" suppressHydrationWarning>
+      {node}
+    </div>
+  );
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fixes #441.

Rendering an empty placeholder in **Next.js App Router**  via Sitecore Pages' `/api/editing/render` produced a React hydration mismatch warning; the same scenario in Pages Router did not reproduce it.

Root cause: Sitecore Pages attaches chrome to SDK-owned editing markup directly in the DOM (e.g. `cursor: pointer` on the `sc-jss-empty-placeholder` wrapper), which can happen before React finishes hydrating. This is expected/external DOM mutation, not something app code controls. App Router is more exposed to the race because RSC streaming hydrates the tree progressively per Suspense boundary, unlike Pages Router's single synchronous hydration pass, giving Pages' independently-loaded chrome script more of a window to touch the DOM before React reconciles it.

Changes:
- `renderEmptyPlaceholder` and `PlaceholderMetadata`'s open/close `<code>` chrome markers now set `suppressHydrationWarning`, since Pages is expected to mutate these SDK-owned, editing-only elements externally.
- `AppPlaceholder`'s outer `PlaceholderMetadata` key now falls back to a placeholder-name-based key (`placeholder-metadata-${name}`) when the route rendering has no `uid`, fixing a separate "Each child in a list should have a unique key prop" warning that the same code path was triggering.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other - Verified in Sitecore Pages editor

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
