### PR TITLE
[next][angular] Work around fetch causing sitecore-tools:build to fail

### DIFF
--- a/.changeset/public-games-talk.md
+++ b/.changeset/public-games-talk.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/content': patch
+---
+
+sitecore-tools:build sites generation fails with an exception when the last command utilizes fetch (Windows only). This happens because there are some hanging connections in keep-alive pool that undici leaves, that don't close before sitecore-tools:build calls process.exit()

--- a/packages/content/api/content-sdk-content.api.md
+++ b/packages/content/api/content-sdk-content.api.md
@@ -190,6 +190,9 @@ export interface ComponentUpdateEventArgs {
 // @public
 export function containsDefaultEdgeHost(str: string): boolean;
 
+// @public (undocumented)
+export const createCliGraphQLClientFactory: (options: GraphQLClientOptions) => GraphQLRequestClientFactory;
+
 // @internal
 export const createComponentInstance: (importMap: ImportEntry[], generatedComponentData: GeneratedComponentData) => unknown;
 

--- a/packages/content/api/content-sdk-content.api.md
+++ b/packages/content/api/content-sdk-content.api.md
@@ -190,7 +190,7 @@ export interface ComponentUpdateEventArgs {
 // @public
 export function containsDefaultEdgeHost(str: string): boolean;
 
-// @public (undocumented)
+// @public
 export const createCliGraphQLClientFactory: (options: GraphQLClientOptions) => GraphQLRequestClientFactory;
 
 // @internal

--- a/packages/content/src/client/index.ts
+++ b/packages/content/src/client/index.ts
@@ -7,7 +7,7 @@ export {
   GraphQLRequestClientFactoryConfig,
   DefaultRetryStrategy,
   RetryStrategy,
-  FetchOptions
+  FetchOptions,
 } from '@sitecore-content-sdk/core';
 export { PageInfo } from '../models';
 export { getEdgeProxyContentUrl, getEdgeProxyFormsUrl } from './edge-proxy';
@@ -20,4 +20,8 @@ export {
   ErrorPage,
 } from './sitecore-client';
 export { SitecoreClientInit } from './models';
-export { createGraphQLClientFactory, GraphQLClientOptions } from './utils';
+export {
+  createGraphQLClientFactory,
+  createCliGraphQLClientFactory,
+  GraphQLClientOptions,
+} from './utils';

--- a/packages/content/src/client/utils.test.ts
+++ b/packages/content/src/client/utils.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-unused-expressions, @typescript-eslint/no-unused-expressions */
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { Agent } from 'undici';
 import { GraphQLRequestClient } from '@sitecore-content-sdk/core';
-import { createGraphQLClientFactory } from './utils';
+import { createGraphQLClientFactory, createCliGraphQLClientFactory } from './utils';
 
 describe('createGraphQLClientFactory', () => {
   const originalWindow = global.window;
@@ -187,6 +188,185 @@ describe('createGraphQLClientFactory', () => {
       endpoint: 'https://test.edge.url/v1/content/api/graphql/v1',
       contextId: 'test-context-id',
       fetch: customFetch,
+    });
+  });
+});
+
+describe('createCliGraphQLClientFactory', () => {
+  const originalWindow = global.window;
+  const edgeApi = { edge: { contextId: 'test-context-id', edgeUrl: 'https://test.edge.url' } };
+
+  // Track and neutralize Agent#destroy so tests never tear down real sockets,
+  // while still asserting the CLI factory cleans up its dispatcher.
+  let destroyCalls: number;
+  let originalDestroy: typeof Agent.prototype.destroy;
+
+  beforeEach(() => {
+    delete (global as any).window;
+    destroyCalls = 0;
+    originalDestroy = Agent.prototype.destroy;
+    // Own-property assignment shadows the inherited Dispatcher#destroy regardless
+    // of where it lives on the prototype chain.
+    (Agent.prototype as any).destroy = function () {
+      destroyCalls++;
+      return Promise.resolve();
+    };
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    (Agent.prototype as any).destroy = originalDestroy;
+    sinon.restore();
+  });
+
+  // Pulls the wrapped `nonHangingFetch` back out of the client factory config so we
+  // can exercise it directly without a real GraphQL request.
+  const getWrappedFetch = (options: Parameters<typeof createCliGraphQLClientFactory>[0]) => {
+    const spy = sinon.spy(GraphQLRequestClient, 'createClientFactory');
+    createCliGraphQLClientFactory(options);
+    expect(spy.calledOnce).to.be.true;
+    return spy.firstCall.args[0].fetch as (input: any, init?: any) => Promise<any>;
+  };
+
+  it('returns a client factory (delegates to createGraphQLClientFactory)', () => {
+    const spy = sinon.spy(GraphQLRequestClient, 'createClientFactory');
+
+    const factory = createCliGraphQLClientFactory({ api: edgeApi });
+
+    expect(factory).to.not.be.undefined;
+    expect(spy.calledOnce).to.be.true;
+    expect(spy.firstCall.args[0]).to.deep.include({
+      endpoint: 'https://test.edge.url/v1/content/api/graphql/v1',
+      contextId: 'test-context-id',
+    });
+  });
+
+  it('wraps fetch: the fetch handed to the factory is not the raw fetch', () => {
+    const spy = sinon.spy(GraphQLRequestClient, 'createClientFactory');
+    const customFetch = sinon.stub();
+
+    createCliGraphQLClientFactory({ api: edgeApi, fetch: customFetch as unknown as typeof fetch });
+
+    const passedFetch = spy.firstCall.args[0].fetch;
+    expect(passedFetch).to.be.a('function');
+    expect(passedFetch).to.not.equal(customFetch);
+  });
+
+  it('propagates the misconfiguration error from the underlying factory', () => {
+    // Server (no window) + empty api → createGraphQLClientFactory throws.
+    expect(() => createCliGraphQLClientFactory({ api: {} })).to.throw(
+      'GraphQL client misconfigured.'
+    );
+  });
+
+  describe('wrapped fetch (nonHangingFetch)', () => {
+    it('calls the provided fetch with a fresh undici Agent merged into init', async () => {
+      const response = { ok: true };
+      const customFetch = sinon.stub().resolves(response);
+      const wrapped = getWrappedFetch({
+        api: edgeApi,
+        fetch: customFetch as unknown as typeof fetch,
+      });
+
+      const result = await wrapped('https://example.test/graphql', { method: 'POST' });
+
+      expect(customFetch.calledOnce).to.be.true;
+      const [calledInput, calledInit] = customFetch.firstCall.args;
+      expect(calledInput).to.equal('https://example.test/graphql');
+      // original init is preserved
+      expect(calledInit.method).to.equal('POST');
+      // dispatcher is injected as an undici Agent
+      expect(calledInit.dispatcher).to.be.instanceOf(Agent);
+      expect(result).to.equal(response);
+    });
+
+    it('destroys the dispatcher after the fetch resolves', async () => {
+      const customFetch = sinon.stub().resolves({});
+      const wrapped = getWrappedFetch({
+        api: edgeApi,
+        fetch: customFetch as unknown as typeof fetch,
+      });
+
+      await wrapped('https://example.test/graphql');
+
+      expect(customFetch.calledOnce).to.be.true;
+      expect(destroyCalls).to.equal(1);
+    });
+
+    it('falls back to globalThis.fetch when no fetch option is provided', async () => {
+      const globalFetchStub = sinon.stub(globalThis, 'fetch').resolves({} as Response);
+      const wrapped = getWrappedFetch({ api: edgeApi });
+
+      await wrapped('https://example.test/graphql');
+
+      expect(globalFetchStub.calledOnce).to.be.true;
+      expect(globalFetchStub.firstCall.args[1]?.dispatcher).to.be.instanceOf(Agent);
+      expect(destroyCalls).to.equal(1);
+    });
+
+    it('uses a fresh dispatcher and cleans it up on every call', async () => {
+      const customFetch = sinon.stub().resolves({});
+      const wrapped = getWrappedFetch({
+        api: edgeApi,
+        fetch: customFetch as unknown as typeof fetch,
+      });
+
+      await wrapped('https://example.test/a');
+      await wrapped('https://example.test/b');
+
+      const firstDispatcher = customFetch.firstCall.args[1].dispatcher;
+      const secondDispatcher = customFetch.secondCall.args[1].dispatcher;
+      expect(firstDispatcher).to.be.instanceOf(Agent);
+      expect(secondDispatcher).to.be.instanceOf(Agent);
+      expect(firstDispatcher).to.not.equal(secondDispatcher);
+      expect(destroyCalls).to.equal(2);
+    });
+
+    it('does not overwrite a caller-supplied dispatcher key silently (CLI dispatcher wins)', async () => {
+      const customFetch = sinon.stub().resolves({});
+      const wrapped = getWrappedFetch({
+        api: edgeApi,
+        fetch: customFetch as unknown as typeof fetch,
+      });
+
+      const callerDispatcher = { marker: 'caller' };
+      await wrapped('https://example.test/graphql', { dispatcher: callerDispatcher });
+
+      // The CLI wrapper appends its own dispatcher last, so it replaces the caller's.
+      expect(customFetch.firstCall.args[1].dispatcher).to.be.instanceOf(Agent);
+      expect(customFetch.firstCall.args[1].dispatcher).to.not.equal(callerDispatcher);
+    });
+
+    it('propagates errors from the underlying fetch', async () => {
+      const failure = new Error('network boom');
+      const customFetch = sinon.stub().rejects(failure);
+      const wrapped = getWrappedFetch({
+        api: edgeApi,
+        fetch: customFetch as unknown as typeof fetch,
+      });
+
+      let caught: unknown;
+      try {
+        await wrapped('https://example.test/graphql');
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).to.equal(failure);
+    });
+
+    it('destroys the dispatcher even when the underlying fetch rejects', async () => {
+      const customFetch = sinon.stub().rejects(new Error('network boom'));
+      const wrapped = getWrappedFetch({
+        api: edgeApi,
+        fetch: customFetch as unknown as typeof fetch,
+      });
+
+      // The rejection must not skip the finally-block cleanup.
+      await wrapped('https://example.test/graphql').catch(() => undefined);
+
+      expect(customFetch.calledOnce).to.be.true;
+      expect(destroyCalls).to.equal(1);
     });
   });
 });

--- a/packages/content/src/client/utils.ts
+++ b/packages/content/src/client/utils.ts
@@ -1,3 +1,4 @@
+import { Agent } from 'undici';
 import {
   FetchOptions,
   GraphQLRequestClient,
@@ -11,6 +12,31 @@ import { getEdgeProxyContentUrl } from './edge-proxy';
  * @public
  */
 export type GraphQLClientOptions = Pick<SitecoreConfigInput, 'api'> & FetchOptions;
+
+export const createCliGraphQLClientFactory = (options: GraphQLClientOptions) => {
+  const nonHangingFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    // Removes the chance of lingering connections after fetch has completed
+    // This prevents CLI logic from crashing when process.exit is called explicitly after a fetch call
+    const nonHangingAgent = new Agent({
+      keepAliveTimeout: 1,
+      keepAliveMaxTimeout: 1,
+      connections: 1,
+      pipelining: 0,
+    });
+    let res: Response;
+    try {
+      const customInit = { ...init, dispatcher: nonHangingAgent };
+      const fetchFunction =
+        options.fetch ??
+        ((input: RequestInfo | URL, init?: RequestInit) => globalThis.fetch(input, init));
+      res = await fetchFunction(input, customInit);
+    } finally {
+      await nonHangingAgent.destroy();
+    }
+    return res;
+  };
+  return createGraphQLClientFactory({ ...options, fetch: nonHangingFetch });
+};
 
 /**
  * Creates a new GraphQLRequestClientFactory instance

--- a/packages/content/src/client/utils.ts
+++ b/packages/content/src/client/utils.ts
@@ -13,6 +13,12 @@ import { getEdgeProxyContentUrl } from './edge-proxy';
  */
 export type GraphQLClientOptions = Pick<SitecoreConfigInput, 'api'> & FetchOptions;
 
+/**
+ * Creates a new GraphQLRequestClientFactory instance to be used in CLI commands
+ * @param {GraphQLClientOptions} options content sdk config
+ * @returns GraphQLRequestClientFactory instance
+ * @public
+ */
 export const createCliGraphQLClientFactory = (options: GraphQLClientOptions) => {
   const nonHangingFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     // Removes the chance of lingering connections after fetch has completed

--- a/packages/content/src/tools/generateSites.ts
+++ b/packages/content/src/tools/generateSites.ts
@@ -5,7 +5,7 @@ import { ensurePathExists } from '@sitecore-content-sdk/core/node-tools';
 import { constants } from '@sitecore-content-sdk/core';
 import { SiteInfo, SiteInfoService } from '../site';
 import { SitecoreConfig } from '../config';
-import { createGraphQLClientFactory } from '../client';
+import { createCliGraphQLClientFactory } from '../client';
 import debug from '../debug';
 
 const { ERROR_MESSAGES } = constants;
@@ -49,7 +49,7 @@ export const generateSites = ({ destinationPath }: GenerateSitesConfig = {}): ((
     if (scConfig.multisite.enabled) {
       try {
         const siteInfoService = new SiteInfoService({
-          clientFactory: createGraphQLClientFactory({
+          clientFactory: createCliGraphQLClientFactory({
             api: scConfig.api,
             retries: scConfig.retries.count,
             retryStrategy: scConfig.retries.retryStrategy,


### PR DESCRIPTION
## Description / Motivation
sitecore-tools:build will fail with an exception when the last command utilizes `fetch` (Windows only).  This happens because there are some hanging connections in keep-alive pool that undici leaves, that don't close before sitecore-tools:build calls process.exit().
More info here: https://github.com/nodejs/undici/issues/5680

This PR works around/fixes it for CSDK by introducing a client factory for CLI logic specifically.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
