### PR TITLE
[core] sitecore-tools project build fails when using pnpm because harded "npm query" in metadata.ts

### DIFF
--- a/.changeset/modern-readers-bathe.md
+++ b/.changeset/modern-readers-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/core': patch
+---
+
+Fix metadata package discovery for pnpm projects. When invoked by pnpm, read Sitecore package versions from `node_modules` instead of using `npm query`, which fails with `EBADDEVENGINES` when `devEngines.packageManager` is set to pnpm.

--- a/packages/core/src/tools/metadata/generateMetadata.test.ts
+++ b/packages/core/src/tools/metadata/generateMetadata.test.ts
@@ -10,14 +10,30 @@ import npmQueryResultNext from './test-data/npm-query-nextjs.json';
 describe('generateMetadata', () => {
   let execSyncStub: sinon.SinonStub;
   let writeFileSyncStub: sinon.SinonStub;
+  const originalExecPath = process.env.npm_execpath;
+  const originalUserAgent = process.env.npm_config_user_agent;
 
   beforeEach(() => {
+    delete process.env.npm_execpath;
+    process.env.npm_config_user_agent = 'npm/10.0.0 node/v22.0.0';
     execSyncStub = sinon.stub(childProcess, 'execSync').returns(JSON.stringify(npmQueryResultNext));
     writeFileSyncStub = sinon.stub(fs, 'writeFileSync');
   });
 
   afterEach(() => {
     sinon.restore();
+
+    if (originalExecPath === undefined) {
+      delete process.env.npm_execpath;
+    } else {
+      process.env.npm_execpath = originalExecPath;
+    }
+
+    if (originalUserAgent === undefined) {
+      delete process.env.npm_config_user_agent;
+    } else {
+      process.env.npm_config_user_agent = originalUserAgent;
+    }
   });
 
   it('should generate metadata and write to default path if no config is provided', async () => {

--- a/packages/core/src/tools/metadata/metadata.test.ts
+++ b/packages/core/src/tools/metadata/metadata.test.ts
@@ -4,6 +4,9 @@ import { expect } from 'chai';
 import { getMetadata } from './metadata';
 import sinon, { SinonStub } from 'sinon';
 import childProcess from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import metadataNextjs from './test-data/metadata-nextjs.json';
 import npmQueryResultNext from './test-data/npm-query-nextjs.json';
 import npmQueryResultNoSc from './test-data/npm-query-no-sc.json';
@@ -16,13 +19,29 @@ describe('metadata', () => {
   describe('getMetadata', () => {
     let execSyncStub: SinonStub;
     let logStub: SinonStub;
+    const originalExecPath = process.env.npm_execpath;
+    const originalUserAgent = process.env.npm_config_user_agent;
 
     afterEach(() => {
       execSyncStub?.restore();
       logStub?.restore();
+
+      if (originalExecPath === undefined) {
+        delete process.env.npm_execpath;
+      } else {
+        process.env.npm_execpath = originalExecPath;
+      }
+
+      if (originalUserAgent === undefined) {
+        delete process.env.npm_config_user_agent;
+      } else {
+        process.env.npm_config_user_agent = originalUserAgent;
+      }
     });
 
     it('should return tracked packages with exact versions from result of npm query (nextjs app)', () => {
+      delete process.env.npm_execpath;
+      process.env.npm_config_user_agent = 'npm/10.0.0 node/v22.0.0';
       execSyncStub = sinon.stub(childProcess, 'execSync');
       execSyncStub
         .withArgs('npm query [name*=@sitecore] --workspaces false')
@@ -32,6 +51,8 @@ describe('metadata', () => {
     });
 
     it('should return metadata with empty package object and log error in the console if result of npm query is not valid', () => {
+      delete process.env.npm_execpath;
+      process.env.npm_config_user_agent = 'npm/10.0.0 node/v22.0.0';
       execSyncStub = sinon.stub(childProcess, 'execSync');
       execSyncStub.withArgs('npm query [name*=@sitecore] --workspaces false').returns('[{"name":}');
       logStub = sinon.stub(console, 'error');
@@ -43,6 +64,8 @@ describe('metadata', () => {
     });
 
     it('should return metadata with empty package object and log error in the console if npm query command fails', () => {
+      delete process.env.npm_execpath;
+      process.env.npm_config_user_agent = 'npm/10.0.0 node/v22.0.0';
       execSyncStub = sinon.stub(childProcess, 'execSync');
       execSyncStub.withArgs('npm query [name*=@sitecore] --workspaces false').throws();
       logStub = sinon.stub(console, 'error');
@@ -54,6 +77,8 @@ describe('metadata', () => {
     });
 
     it('should not return packages for result of npm query not containng tracked packages', () => {
+      delete process.env.npm_execpath;
+      process.env.npm_config_user_agent = 'npm/10.0.0 node/v22.0.0';
       execSyncStub = sinon.stub(childProcess, 'execSync');
       execSyncStub
         .withArgs('npm query [name*=@sitecore] --workspaces false')
@@ -61,5 +86,71 @@ describe('metadata', () => {
       const metadata = getMetadata();
       expect(metadata).to.deep.equal({ packages: {} });
     });
+
+    it('should read sitecore packages from node_modules instead of npm when invoked by pnpm', () => {
+      process.env.npm_execpath = path.join('home', 'user', 'pnpm', 'pnpm.cjs');
+      process.env.npm_config_user_agent = 'pnpm/10.33.0 npm/? node/v22.0.0';
+      execSyncStub = sinon.stub(childProcess, 'execSync');
+
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'metadata-pnpm-'));
+      writeInstalledPackage(tmp, '@sitecore-content-sdk/nextjs', '1.2.3');
+      writeInstalledPackage(tmp, '@sitecore/components', '2.0.0');
+      fs.writeFileSync(path.join(tmp, 'pnpm-lock.yaml'), '');
+
+      try {
+        const metadata = withCwd(tmp, () => getMetadata());
+
+        expect(execSyncStub.notCalled).to.be.true;
+        expect(metadata.packages).to.deep.equal({
+          '@sitecore-content-sdk/nextjs': '1.2.3',
+          '@sitecore/components': '2.0.0',
+        });
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('should include sitecore packages hoisted to the monorepo root when invoked by pnpm', () => {
+      process.env.npm_execpath = path.join('home', 'user', 'pnpm', 'pnpm.cjs');
+      process.env.npm_config_user_agent = 'pnpm/10.33.0 npm/? node/v22.0.0';
+      execSyncStub = sinon.stub(childProcess, 'execSync');
+
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'metadata-pnpm-mono-'));
+      const appDir = path.join(tmp, 'apps', 'web');
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.writeFileSync(path.join(tmp, 'pnpm-lock.yaml'), '');
+      fs.writeFileSync(
+        path.join(appDir, 'package.json'),
+        JSON.stringify({ name: 'web', private: true })
+      );
+      writeInstalledPackage(tmp, '@sitecore-content-sdk/core', '9.9.9');
+
+      try {
+        const metadata = withCwd(appDir, () => getMetadata());
+
+        expect(execSyncStub.notCalled).to.be.true;
+        expect(metadata.packages).to.deep.equal({
+          '@sitecore-content-sdk/core': '9.9.9',
+        });
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
   });
 });
+
+function writeInstalledPackage(root: string, name: string, version: string): void {
+  const dir = path.join(root, 'node_modules', ...name.split('/'));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version }));
+}
+
+function withCwd<T>(dir: string, fn: () => T): T {
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    return fn();
+  } finally {
+    process.chdir(cwd);
+  }
+}

--- a/packages/core/src/tools/metadata/metadata.ts
+++ b/packages/core/src/tools/metadata/metadata.ts
@@ -1,4 +1,6 @@
 ﻿import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 
 type Package = {
   name: string;
@@ -25,9 +27,7 @@ export function getMetadata(allowWorkspaces: boolean = false): Metadata {
 
   let queryResult: Package[] = [];
   try {
-    queryResult = JSON.parse(
-      execSync(`npm query [name*=@sitecore] --workspaces ${allowWorkspaces}`).toString()
-    );
+    queryResult = queryInstalledPackages(allowWorkspaces);
   } catch (error) {
     console.error('Failed to retrieve sitecore packages using npm query', error);
     return metadata;
@@ -36,6 +36,174 @@ export function getMetadata(allowWorkspaces: boolean = false): Metadata {
   metadata.packages = getPackagesFromQueryResult(queryResult);
 
   return metadata;
+}
+
+/**
+ * Query installed packages using the package manager that invoked this process.
+ * `npm query` is npm-specific and fails with EBADDEVENGINES when a project
+ * declares `devEngines.packageManager` for pnpm.
+ * @param {boolean} allowWorkspaces - Whether to include workspace packages.
+ * @returns {Package[]} Installed packages reported by the current package manager.
+ */
+function queryInstalledPackages(allowWorkspaces: boolean): Package[] {
+  if (isPnpmContext()) {
+    return collectPackagesFromNodeModules(process.cwd());
+  }
+
+  return JSON.parse(
+    execSync(`npm query [name*=@sitecore] --workspaces ${allowWorkspaces}`).toString()
+  );
+}
+
+/**
+ * Detect pnpm from the environment set by package-manager shims/scripts.
+ * `npm_execpath` points at the CLI entry file (e.g. pnpm.cjs); `npm_config_user_agent` is `pnpm/<version> ...`.
+ */
+function isPnpmContext(): boolean {
+  const execPath = process.env.npm_execpath || '';
+  const userAgent = process.env.npm_config_user_agent || '';
+  return /pnpm/i.test(execPath) || userAgent.toLowerCase().startsWith('pnpm/');
+}
+
+/**
+ * Collect tracked Sitecore packages from installed node_modules, walking up to the
+ * install root so monorepo apps still see packages hoisted to the workspace root.
+ * @param {string} startDir - Directory to start scanning from (typically `process.cwd()`).
+ * @returns {Package[]} Installed tracked packages.
+ */
+function collectPackagesFromNodeModules(startDir: string): Package[] {
+  const packages: Record<string, string> = {};
+  let dir = path.resolve(startDir);
+
+  while (true) {
+    collectFromNodeModulesDir(path.join(dir, 'node_modules'), packages);
+
+    if (isInstallRoot(dir)) {
+      break;
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+
+    dir = parent;
+  }
+
+  return Object.entries(packages).map(([name, version]) => ({ name, version }));
+}
+
+/**
+ * True when this directory is the package-manager install root (has a lockfile).
+ * @param {string} dir - Directory to inspect.
+ * @returns {boolean} Whether scanning should stop after this directory.
+ */
+function isInstallRoot(dir: string): boolean {
+  return (
+    fs.existsSync(path.join(dir, 'pnpm-lock.yaml')) ||
+    fs.existsSync(path.join(dir, 'yarn.lock')) ||
+    fs.existsSync(path.join(dir, 'package-lock.json')) ||
+    fs.existsSync(path.join(dir, 'npm-shrinkwrap.json')) ||
+    fs.existsSync(path.join(dir, 'bun.lock')) ||
+    fs.existsSync(path.join(dir, 'bun.lockb'))
+  );
+}
+
+/**
+ * Scan a node_modules directory for tracked Sitecore scopes, including pnpm's virtual store.
+ * @param {string} nodeModulesDir - Path to a node_modules directory.
+ * @param {Record<string, string>} packages - Accumulator of package name to version.
+ */
+function collectFromNodeModulesDir(
+  nodeModulesDir: string,
+  packages: Record<string, string>
+): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(nodeModulesDir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry === '.pnpm') {
+      collectFromPnpmStore(path.join(nodeModulesDir, entry), packages);
+      continue;
+    }
+
+    if (!trackedScopes.some((scope) => entry.startsWith(scope))) {
+      continue;
+    }
+
+    collectFromScopeDir(path.join(nodeModulesDir, entry), packages);
+  }
+}
+
+/**
+ * Scan pnpm's virtual store, limited to folders that can contain tracked Sitecore packages.
+ * @param {string} pnpmDir - Path to node_modules/.pnpm.
+ * @param {Record<string, string>} packages - Accumulator of package name to version.
+ */
+function collectFromPnpmStore(pnpmDir: string, packages: Record<string, string>): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(pnpmDir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!trackedScopes.some((scope) => entry.startsWith(scope))) {
+      continue;
+    }
+
+    collectFromNodeModulesDir(path.join(pnpmDir, entry, 'node_modules'), packages);
+  }
+}
+
+/**
+ * Read each package in a scoped node_modules folder (e.g. node_modules/@sitecore-content-sdk).
+ * @param {string} scopeDir - Path to a scoped package directory.
+ * @param {Record<string, string>} packages - Accumulator of package name to version.
+ */
+function collectFromScopeDir(scopeDir: string, packages: Record<string, string>): void {
+  let names: string[];
+  try {
+    names = fs.readdirSync(scopeDir);
+  } catch {
+    return;
+  }
+
+  for (const name of names) {
+    readTrackedPackage(path.join(scopeDir, name), packages);
+  }
+}
+
+/**
+ * Read a package.json and record it when it belongs to a tracked Sitecore scope.
+ * Closer installs win: existing entries are not overwritten.
+ * @param {string} pkgDir - Directory that may contain a package.json.
+ * @param {Record<string, string>} packages - Accumulator of package name to version.
+ */
+function readTrackedPackage(pkgDir: string, packages: Record<string, string>): void {
+  try {
+    const pkgJson = JSON.parse(
+      fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8')
+    ) as Package;
+
+    if (
+      !pkgJson.name ||
+      !pkgJson.version ||
+      packages[pkgJson.name] ||
+      !trackedScopes.some((scope) => pkgJson.name.startsWith(scope))
+    ) {
+      return;
+    }
+
+    packages[pkgJson.name] = pkgJson.version;
+  } catch {
+    // not a package directory
+  }
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fix `getMetadata` so pnpm projects can resolve Sitecore package versions without calling `npm query`, which fails with `EBADDEVENGINES` when `devEngines.packageManager` is set to pnpm.
- Detect pnpm via `npm_execpath` / `npm_config_user_agent`, then collect tracked `@sitecore*` packages from `node_modules` (including `.pnpm` and packages hoisted to the monorepo install root).
- Keep the existing `npm query` path for npm; update unit tests for both npm and pnpm contexts.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
