### PR TITLE
[bug][Angular] Fix unicode path routing producing 404

### DIFF
--- a/.changeset/sharp-suns-doubt.md
+++ b/.changeset/sharp-suns-doubt.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/angular': patch
+---
+
+[bug] Fix unicode path routing producing 404

--- a/packages/angular/src/loaders/loader-resolver.spec.ts
+++ b/packages/angular/src/loaders/loader-resolver.spec.ts
@@ -106,6 +106,43 @@ describe('loaderResolver', () => {
       expect(result).toEqual({ title: 'Home' });
     });
 
+    it('should decode the encoded state.url before passing it to ClientLoaderDataService.getData', async () => {
+      mockLoaderData.getData.mockResolvedValue({ kind: 'data', data: { title: 'Über uns' } });
+
+      const resolver = loaderResolver('page');
+      const route = makeRouteSnapshot({ pathFromRoot: [{ params: {} }] });
+      const state = makeRouterStateSnapshot('/de/%C3%BCber%20uns');
+
+      await TestBed.runInInjectionContext(async () => {
+        return (
+          resolver as (r: ActivatedRouteSnapshot, s: RouterStateSnapshot) => Promise<unknown>
+        )(route, state);
+      });
+
+      expect(mockLoaderData.getData).toHaveBeenCalledTimes(1);
+      expect(mockLoaderData.getData).toHaveBeenCalledWith(
+        expect.objectContaining({ url: '/de/über uns' })
+      );
+    });
+
+    it('should key transfer state by the decoded url', async () => {
+      const resolver = loaderResolver('page');
+      const key = makeStateKey<unknown>('loader:page:/de/über uns');
+      transferState.set(key, { fromTransfer: true });
+
+      const route = makeRouteSnapshot();
+      const state = makeRouterStateSnapshot('/de/%C3%BCber%20uns');
+      const result = await TestBed.runInInjectionContext(async () => {
+        return (
+          resolver as (_r: ActivatedRouteSnapshot, _s: RouterStateSnapshot) => Promise<unknown>
+        )(route, state);
+      });
+
+      expect(result).toEqual({ fromTransfer: true });
+      expect(transferState.hasKey(key)).toBe(false);
+      expect(mockLoaderData.getData).not.toHaveBeenCalled();
+    });
+
     it('should return RedirectCommand when getData returns redirect', async () => {
       mockLoaderData.getData.mockResolvedValue({
         kind: 'redirect',
@@ -317,6 +354,39 @@ describe('loaderResolver', () => {
         csdkRequestData: {},
       });
       expect(result).toEqual({ server: true, title: 'SSR' });
+    });
+
+    it('should decode the encoded state.url before passing it to the loader', async () => {
+      const resolver = loaderResolver('page');
+      const route = makeRouteSnapshot({ pathFromRoot: [{ params: {} }] });
+      const state = makeRouterStateSnapshot('/de/%C3%BCber%20uns');
+
+      await TestBed.runInInjectionContext(async () => {
+        return (
+          resolver as (r: ActivatedRouteSnapshot, s: RouterStateSnapshot) => Promise<unknown>
+        )(route, state);
+      });
+
+      expect(mockLoader).toHaveBeenCalledTimes(1);
+      expect(mockLoader).toHaveBeenCalledWith(
+        expect.objectContaining({ url: '/de/über uns' })
+      );
+    });
+
+    it('should key transfer state by the decoded url on the server', async () => {
+      const resolver = loaderResolver('page');
+      const route = makeRouteSnapshot({ pathFromRoot: [{ params: {} }] });
+      const state = makeRouterStateSnapshot('/de/%C3%BCber%20uns');
+
+      await TestBed.runInInjectionContext(async () => {
+        return (
+          resolver as (r: ActivatedRouteSnapshot, s: RouterStateSnapshot) => Promise<unknown>
+        )(route, state);
+      });
+
+      const key = makeStateKey<unknown>('loader:page:/de/über uns');
+      expect(transferState.hasKey(key)).toBe(true);
+      expect(transferState.get(key, null)).toEqual({ server: true, title: 'SSR' });
     });
 
     it('should set transfer state with loader result and return data', async () => {

--- a/packages/angular/src/loaders/loader-resolver.ts
+++ b/packages/angular/src/loaders/loader-resolver.ts
@@ -72,7 +72,7 @@ function buildLoaderParams(route: ActivatedRouteSnapshot, defaultLanguage: strin
  * Injects TransferState, ClientLoaderDataService. Called by the resolver when isPlatformBrowser.
  * @param {object} options - The options for the resolveOnBrowser function
  * @param {ActivatedRouteSnapshot} options.route - The current route snapshot
- * @param {RouterStateSnapshot} options.state - The router state snapshot
+ * @param {stateUrl} options.stateUrl - URL for current route from RouteState
  * @param {string} options.loaderId - loader ID to resolve, used for transfer state key and ClientLoaderDataService call
  * @param {Router} options.router - The Angular router instance
  * @param {string} [options.defaultLanguage] - Default language for locale fallback in params
@@ -81,14 +81,14 @@ function buildLoaderParams(route: ActivatedRouteSnapshot, defaultLanguage: strin
  */
 async function resolveOnBrowser({
   route,
-  state,
+  stateUrl,
   loaderId,
   router,
   defaultLanguage,
   cacheOptions,
 }: {
   route: ActivatedRouteSnapshot;
-  state: RouterStateSnapshot;
+  stateUrl: string;
   loaderId: string;
   router: Router;
   defaultLanguage: string;
@@ -97,8 +97,7 @@ async function resolveOnBrowser({
   const transferState = inject(TransferState);
   const browserLoaderData = inject(ClientLoaderDataService);
 
-  const url = state.url;
-  const key = stateKey(loaderId, url);
+  const key = stateKey(loaderId, stateUrl);
 
   if (transferState.hasKey(key)) {
     const data = transferState.get(key, null);
@@ -109,7 +108,7 @@ async function resolveOnBrowser({
   const allParams = buildLoaderParams(route, defaultLanguage);
 
   const resp = await browserLoaderData.getData({
-    url,
+    url: stateUrl,
     loaderId,
     routeParams: allParams,
     query: route.queryParams as Record<string, string | string[]>,
@@ -149,14 +148,15 @@ export const loaderResolver = (
     const config = inject(SITECORE_CONFIG_TOKEN);
     const defaultLanguage = config.defaultLanguage;
 
-    const url = state.url;
+    // Angular state will have an encoded path. CSDK logic needs a decoded one
+    const url = decodeURIComponent(state.url);
     const key = stateKey(loaderId, url);
 
     if (isPlatformBrowser(platformId)) {
       try {
         return await resolveOnBrowser({
           route,
-          state,
+          stateUrl: url,
           loaderId,
           router,
           defaultLanguage,


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Angular RouterState URL has an encoded path. CSDK layout service does not like that. We ensure a decoded path is passed down into logic at framework boundary, similar to how next logic does it.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
