### PR TITLE
[Chore][Angular] Adjust Vercel, Netlify instructions

### DIFF
--- a/packages/create-content-sdk-app/src/templates/angular/README.md
+++ b/packages/create-content-sdk-app/src/templates/angular/README.md
@@ -68,7 +68,7 @@ After that, configure redirect rules for Vercel request to reach your app code, 
 }
 ```
 
-3. In Vercel portal, set the required Content SDK environment variables. Additionally, set `NG_ALLOWED_HOSTS` and `NG_TRUST_PROXY_HEADERS` environment variabled to allow Vercel URLs and prevent Vercel rendering from falling back to CSR:
+3. In Vercel portal, set the required Content SDK environment variables. Additionally, set `NG_ALLOWED_HOSTS` and `NG_TRUST_PROXY_HEADERS` environment variables to allow Vercel URLs and prevent Vercel rendering from falling back to CSR:
 ```
   NG_ALLOWED_HOSTS=*.vercel.app
   NG_TRUST_PROXY_HEADERS=X-FORWARDED-PORT,X-FORWARDED-PATH,X-FORWARDED-FOR,X-FORWARDED-HOST,X-FORWARDED-PROTO

--- a/packages/create-content-sdk-app/src/templates/angular/README.md
+++ b/packages/create-content-sdk-app/src/templates/angular/README.md
@@ -153,6 +153,6 @@ where `<your_app_name>` is the name of application set in `package.json`.
 
 4. In Netlify portal, set the required Content SDK environment variables. Additionally, set `NG_ALLOWED_HOSTS` and `NG_TRUST_PROXY_HEADERS` environment variables to allow netlify URLs and ensure Angular SSR works correctly from behind the Netlify proxy:
 ```
-  NG_ALLOWED_HOSTS=*.vercel.app
+  NG_ALLOWED_HOSTS=*.netlify.app
   NG_TRUST_PROXY_HEADERS=X-FORWARDED-PORT,X-FORWARDED-PATH,X-FORWARDED-FOR,X-FORWARDED-HOST,X-FORWARDED-PROTO
 ```

--- a/packages/create-content-sdk-app/src/templates/angular/README.md
+++ b/packages/create-content-sdk-app/src/templates/angular/README.md
@@ -53,7 +53,7 @@ After that, configure redirect rules for Vercel request to reach your app code, 
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build",
-  "outputDirectory": "dist/<your_app_name>/browser",
+  "outputDirectory": "dist/<your_app_name>",
   "rewrites": [
     {
       "source": "/(.*)",
@@ -68,9 +68,10 @@ After that, configure redirect rules for Vercel request to reach your app code, 
 }
 ```
 
-3. In Vercel portal, set the required Content SDK environment variables. Additionally, set `NG_ALLOWED_HOSTS` environment variable to allow Vercel URLs:
+3. In Vercel portal, set the required Content SDK environment variables. Additionally, set `NG_ALLOWED_HOSTS` and `NG_TRUST_PROXY_HEADERS` environment variabled to allow Vercel URLs and prevent Vercel rendering from falling back to CSR:
 ```
-  NG_ALLOWED_HOSTS=*.vercel.app`
+  NG_ALLOWED_HOSTS=*.vercel.app
+  NG_TRUST_PROXY_HEADERS=X-FORWARDED-PORT,X-FORWARDED-PATH,X-FORWARDED-FOR,X-FORWARDED-HOST,X-FORWARDED-PROTO
 ```
 
 Deploying your app to Vercel should now result in the site being correctly served.
@@ -150,7 +151,8 @@ where `<your_app_name>` is the name of application set in `package.json`.
 
 ```
 
-4. In Netlify portal, set the required Content SDK environment variables. Additionally, set `NG_ALLOWED_HOSTS` environment variable to allow netlify URLs:
+4. In Netlify portal, set the required Content SDK environment variables. Additionally, set `NG_ALLOWED_HOSTS` and `NG_TRUST_PROXY_HEADERS` environment variables to allow netlify URLs and ensure Angular SSR works correctly from behind the Netlify proxy:
 ```
-  NG_ALLOWED_HOSTS=*.netlify.app`
+  NG_ALLOWED_HOSTS=*.vercel.app
+  NG_TRUST_PROXY_HEADERS=X-FORWARDED-PORT,X-FORWARDED-PATH,X-FORWARDED-FOR,X-FORWARDED-HOST,X-FORWARDED-PROTO
 ```

--- a/packages/create-content-sdk-app/src/templates/angular/README.md
+++ b/packages/create-content-sdk-app/src/templates/angular/README.md
@@ -53,7 +53,7 @@ After that, configure redirect rules for Vercel request to reach your app code, 
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build",
-  "outputDirectory": "dist/<your_app_name>",
+  "outputDirectory": "dist/<your_app_name>/browser",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Adds one extra step for Netlify, Vercel deployment instructions in Angular sample readme file: providing `NG_TRUST_PROXY_HEADERS`.

Since headless functions in both providers serve as basically a proxy, Netlify and Vercel make use of `X-Forwarded..` headers to have the app, the function and the browser communicate. However, when Angular app receives a header it wasn't made to like, it starts serving CSR app and CSR markup instead of doing SSR. This leads to some side effects, like having client navigation active always, and 404, 500 pages not reporting correct HTTP codes.
