### PR TITLE
[bug][content] Revert to using raw component name in getComponentList

### DIFF
--- a/.changeset/odd-baths-create.md
+++ b/.changeset/odd-baths-create.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/angular': patch
+---
+
+Apply pascalCase transformation for component map entries at framework level

--- a/.changeset/witty-papers-argue.md
+++ b/.changeset/witty-papers-argue.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/content': patch
+---
+
+Revert to using the unmodified file name as componentName in getComponentList

--- a/packages/angular/src/server/tools/generate-map.spec.ts
+++ b/packages/angular/src/server/tools/generate-map.spec.ts
@@ -25,6 +25,17 @@ const fsMock = vi.hoisted(() => ({
   writeFileSync: vi.fn(),
 }));
 
+// Spy backed by the real PascalCase implementation so we can both keep the
+// generated output faithful and assert that generateMap applies it.
+const toPascalCaseMock = vi.hoisted(() =>
+  vi.fn((name: string) =>
+    name
+      .split(/[-_]/)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join('')
+  )
+);
+
 vi.mock('node:fs', () => fsMock);
 
 vi.mock('@sitecore-content-sdk/content/node-tools', () => ({
@@ -34,6 +45,7 @@ vi.mock('@sitecore-content-sdk/content/node-tools', () => ({
 vi.mock('@sitecore-content-sdk/content/tools', () => ({
   prepareComponentsForMap: vi.fn(),
   buildComponentMapContent: vi.fn(() => '// generated map'),
+  toPascalCase: toPascalCaseMock,
 }));
 
 import { generateMap } from '../tools/generate-map';
@@ -74,6 +86,7 @@ describe('generateMap', () => {
     mockBuildComponentMapContent.mockReturnValue('// map file body');
     mockGetComponentList.mockReset();
     mockGetComponentList.mockReturnValue([]);
+    toPascalCaseMock.mockClear();
   });
 
   afterEach(() => {
@@ -125,6 +138,29 @@ describe('generateMap', () => {
     const [passedComponents] = mockPrepareComponentsForMap.mock.calls[0];
     expect(passedComponents).toHaveLength(1);
     expect(passedComponents[0].filePath).toContain('with.component');
+  });
+
+  it('should apply toPascalCase to componentName and moduleName', () => {
+    const comp = makeComponent({
+      filePath: '/project/root/src/my-hero.component.ts',
+      componentName: 'my-hero',
+      moduleName: 'my_hero',
+      importPath: 'src/my-hero.component',
+    });
+    mockGetComponentList.mockReturnValue([comp]);
+
+    generateMap({ paths: ['src'] });
+
+    // Raw names from getComponentList are normalized through toPascalCase.
+    expect(toPascalCaseMock).toHaveBeenCalledWith('my-hero');
+    expect(toPascalCaseMock).toHaveBeenCalledWith('my_hero');
+
+    // The components forwarded to the map builder carry the PascalCased names.
+    expect(mockPrepareComponentsForMap).toHaveBeenCalledTimes(1);
+    const [passedComponents] = mockPrepareComponentsForMap.mock.calls[0];
+    expect(passedComponents).toHaveLength(1);
+    expect(passedComponents[0].componentName).toBe('MyHero');
+    expect(passedComponents[0].moduleName).toBe('MyHero');
   });
 
   it('should use default buildAngularComponentMap function when no mapTemplate is provided', () => {

--- a/packages/angular/src/server/tools/generate-map.ts
+++ b/packages/angular/src/server/tools/generate-map.ts
@@ -8,6 +8,7 @@ import {
   type GenerateMapFunction,
 } from '@sitecore-content-sdk/content/tools';
 import { getComponentList } from '@sitecore-content-sdk/content/node-tools';
+import { toPascalCase } from '@sitecore-content-sdk/content/tools';
 
 export type AngularGenerateMapArgs = Omit<
   GenerateMapArgs,
@@ -58,7 +59,11 @@ export const generateMap: GenerateMapFunction = (params: GenerateMapArgs) => {
     mapTemplate,
   } = params;
 
-  const comps = getComponentList(paths, exclude, includeVariants);
+  const comps = getComponentList(paths, exclude, includeVariants).map((component) => ({
+    ...component,
+    componentName: toPascalCase(component.componentName),
+    moduleName: toPascalCase(component.moduleName),
+  }));
 
   const withComponentDecorator = comps.filter((c) => fileHasAngularComponentDecorator(c.filePath));
 

--- a/packages/content/api/content-sdk-content.api.md
+++ b/packages/content/api/content-sdk-content.api.md
@@ -1664,6 +1664,9 @@ export interface TextField extends FieldMetadata {
 }
 
 // @internal
+export const toPascalCase: (name: string) => string;
+
+// @internal
 export const updateComponent: (component: ComponentRendering<ComponentFields>, fields: ComponentFields | undefined, params: ComponentParams | undefined) => void;
 
 // @public

--- a/packages/content/src/tools/index.ts
+++ b/packages/content/src/tools/index.ts
@@ -12,5 +12,6 @@ export {
   EnhancedComponentMapTemplate,
   prepareComponentsForMap,
   buildComponentMapContent,
+  toPascalCase,
 } from './templating';
 export { combineImportEntries } from './codegen/import-map-utils';

--- a/packages/content/src/tools/templating/components.test.ts
+++ b/packages/content/src/tools/templating/components.test.ts
@@ -234,13 +234,13 @@ describe('components', () => {
           importPath: 'src/test-data/component-variants/qux.component',
           filePath: path.normalize('src/test-data/component-variants/qux.component.ts'),
           componentName: 'qux.component',
-          moduleName: 'quxcomponent',
+          moduleName: 'Quxcomponent',
         },
         {
           importPath: 'src/test-data/component-variants/foo.component',
           filePath: path.normalize('src/test-data/component-variants/foo.component.ts'),
           componentName: 'foo.component',
-          moduleName: 'foocomponent',
+          moduleName: 'Foocomponent',
         },
         {
           componentName: 'Baz',

--- a/packages/content/src/tools/templating/components.test.ts
+++ b/packages/content/src/tools/templating/components.test.ts
@@ -233,14 +233,14 @@ describe('components', () => {
         {
           importPath: 'src/test-data/component-variants/qux.component',
           filePath: path.normalize('src/test-data/component-variants/qux.component.ts'),
-          componentName: 'Qux.component',
-          moduleName: 'Quxcomponent',
+          componentName: 'qux.component',
+          moduleName: 'quxcomponent',
         },
         {
           importPath: 'src/test-data/component-variants/foo.component',
           filePath: path.normalize('src/test-data/component-variants/foo.component.ts'),
-          componentName: 'Foo.component',
-          moduleName: 'Foocomponent',
+          componentName: 'foo.component',
+          moduleName: 'foocomponent',
         },
         {
           componentName: 'Baz',
@@ -392,11 +392,6 @@ describe('components', () => {
     it('should convert kebab-case to PascalCase', () => {
       expect(toPascalCase('my-component')).to.equal('MyComponent');
       expect(toPascalCase('my-long-component-name')).to.equal('MyLongComponentName');
-    });
-
-    it('should convert snake_case to PascalCase', () => {
-      expect(toPascalCase('my_component')).to.equal('MyComponent');
-      expect(toPascalCase('my_long_component_name')).to.equal('MyLongComponentName');
     });
 
     it('should capitalize the first letter of a camelCase string', () => {

--- a/packages/content/src/tools/templating/components.ts
+++ b/packages/content/src/tools/templating/components.ts
@@ -191,7 +191,7 @@ function _getComponentList(
             importPath: filePath.match(componentPathPattern)![1].replace(/\\/g, '/'), // use forward slashes for consistency
             // TODO: enabled using `toPascalCase()` for the two lines below with NextJS CSDK major release
             componentName: name,
-            moduleName: name.replace(/[^\w]+/g, ''),
+            moduleName: toPascalCase(name).replace(/[^\w]+/g, ''),
           };
         })
     );

--- a/packages/content/src/tools/templating/components.ts
+++ b/packages/content/src/tools/templating/components.ts
@@ -109,8 +109,9 @@ export interface ComponentImport {
 
 /**
  * Converts string to PascalCase.
- * @param {string} name - kebab-case, snake_case, dot.notation, camelCase, or PascalCase string (e.g. `my-component`, `my_component`, `my.component`, `myComponent`)
+ * @param {string} name - kebab-case, dot.notation, camelCase, or PascalCase string (e.g. `my-component`, `my_component`, `my.component`, `myComponent`)
  * @returns {string} PascalCase string (e.g. `MyComponent`)
+ * @internal
  */
 export const toPascalCase = (name: string): string =>
   name
@@ -188,8 +189,9 @@ function _getComponentList(
           return {
             filePath,
             importPath: filePath.match(componentPathPattern)![1].replace(/\\/g, '/'), // use forward slashes for consistency
-            componentName: toPascalCase(name),
-            moduleName: toPascalCase(name).replace(/[^\w]+/g, ''),
+            // TODO: enabled using `toPascalCase()` for the two lines below with NextJS CSDK major release
+            componentName: name,
+            moduleName: name.replace(/[^\w]+/g, ''),
           };
         })
     );

--- a/packages/content/src/tools/templating/index.ts
+++ b/packages/content/src/tools/templating/index.ts
@@ -9,5 +9,6 @@ export {
   ComponentMapEntry,
   ComponentMapTemplate,
   EnhancedComponentMapTemplate,
+  toPascalCase,
 } from './components';
 export { prepareComponentsForMap, buildComponentMapContent } from './utils';


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- Fixes a regression in component/import map generations where components with underscore in names were not properly processed
- toPascalCase util no longer converts `snake_case`

Note: eventually we should enforce a convention for component names in Content SDK, which may be a breaking change.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
