### PR TITLE
[Angular] Preview protection and protected navigation

### DIFF
--- a/.changeset/angular-preview-protection.md
+++ b/.changeset/angular-preview-protection.md
@@ -1,0 +1,10 @@
+---
+'@sitecore-content-sdk/angular': minor
+'@sitecore-content-sdk/content': patch
+---
+
+Add preview protection for Angular editing.
+ - Enables preview navigation in Sitecore AI Pages editor
+ - The editing render middleware issues the `sc_preview_token` cookie from the editor bearer
+ - The new `resolvePreviewPage` util forwards that token as the `Authorization` header when fetching preview / Design Library layout in page loader
+ - Promotes the shared `PREVIEW_TOKEN` cookie name into `@sitecore-content-sdk/content/editing`.

--- a/packages/angular/src/editing/constants.ts
+++ b/packages/angular/src/editing/constants.ts
@@ -1,6 +1,5 @@
 /**
- * Header used to propagate editing preview parameters from the editing render
- * middleware to the page loader via the rewritten Angular SSR request.
+ * Header propagating editing preview parameters to the page loader.
  * @public
  */
 export const EDITING_PARAMS_HEADER = 'x-sitecore-editing-params';

--- a/packages/angular/src/loaders/utils.spec.ts
+++ b/packages/angular/src/loaders/utils.spec.ts
@@ -113,6 +113,13 @@ describe('extractRequestData', () => {
     expect(ctx.query).toEqual({});
   });
 
+  it('parses cookies from the Cookie header when req.cookies is absent (no cookie-parser)', () => {
+    const ctx = extractRequestData({
+      headers: { cookie: 'sc_preview_token=Bearer%20abc; sc_site=website' },
+    });
+    expect(ctx.cookies).toEqual({ sc_preview_token: 'Bearer%20abc', sc_site: 'website' });
+  });
+
   it('reads scParams from SC_PARAMS_HEADER on Fetch Request', () => {
     const req = new Request('https://example.com/about', {
       headers: {

--- a/packages/angular/src/loaders/utils.ts
+++ b/packages/angular/src/loaders/utils.ts
@@ -137,8 +137,17 @@ export function extractRequestData(req: FetchLikeRequest | ExpressLikeRequest): 
     }
   } else {
     headers = req.headers ?? {};
-    cookies = req.cookies ?? {};
     query = req.query ?? {};
+    // Prefer parsed cookies (cookie-parser); otherwise parse the raw Cookie header
+    // so cookies are available on the Express `/_data` leg without cookie-parser.
+    if (req.cookies && Object.keys(req.cookies).length > 0) {
+      cookies = req.cookies;
+    } else {
+      const rawCookie = headers.cookie;
+      cookies = parseCookieHeader(
+        (Array.isArray(rawCookie) ? rawCookie.join(';') : rawCookie) ?? null
+      );
+    }
   }
   hostname =
     hostname ??

--- a/packages/angular/src/server/editing/resolve-preview.spec.ts
+++ b/packages/angular/src/server/editing/resolve-preview.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getPreviewAuthToken,
+  resolvePreviewPage,
+  resolvePreviewNavigation,
+} from './resolve-preview';
+import type { CsdkRequestData } from '../../loaders/models';
+
+const editPreviewData = {
+  mode: 'edit',
+  site: 'my-site',
+  itemId: 'item-1',
+  language: 'en',
+  variantId: 'default',
+} as never;
+
+const designLibraryPreviewData = {
+  mode: 'library',
+  site: 'my-site',
+  itemId: 'item-1',
+  componentUid: 'uid-1',
+  language: 'en',
+} as never;
+
+const makeClient = (overrides: Record<string, unknown> = {}) =>
+  ({
+    getPreview: vi.fn().mockResolvedValue({ id: 'preview-page' }),
+    getDesignLibraryData: vi.fn().mockResolvedValue({ id: 'design-library-page' }),
+    getPage: vi.fn().mockResolvedValue({ id: 'nav-page' }),
+    ...overrides,
+  } as never);
+
+describe('getPreviewAuthToken', () => {
+  it('returns the Authorization header when present', () => {
+    const data: CsdkRequestData = { headers: { authorization: 'Bearer abc' } };
+    expect(getPreviewAuthToken(data)).toBe('Bearer abc');
+  });
+
+  it('falls back to the sc_preview_token cookie', () => {
+    const data: CsdkRequestData = { cookies: { sc_preview_token: 'Bearer cookie' } };
+    expect(getPreviewAuthToken(data)).toBe('Bearer cookie');
+  });
+
+  it('prefers the header over the cookie', () => {
+    const data: CsdkRequestData = {
+      headers: { authorization: 'Bearer header' },
+      cookies: { sc_preview_token: 'Bearer cookie' },
+    };
+    expect(getPreviewAuthToken(data)).toBe('Bearer header');
+  });
+
+  it('url-decodes the cookie value', () => {
+    const data: CsdkRequestData = { cookies: { sc_preview_token: 'Bearer%20abc.def' } };
+    expect(getPreviewAuthToken(data)).toBe('Bearer abc.def');
+  });
+
+  it('returns undefined when neither is present', () => {
+    expect(getPreviewAuthToken(undefined)).toBeUndefined();
+    expect(getPreviewAuthToken({})).toBeUndefined();
+  });
+});
+
+describe('resolvePreviewPage', () => {
+  it('fetches preview layout with the token forwarded as Authorization', async () => {
+    const client = makeClient();
+    const data: CsdkRequestData = { headers: { authorization: 'Bearer abc' } };
+
+    const page = await resolvePreviewPage(client, editPreviewData, data);
+
+    expect(page).toEqual({ id: 'preview-page' });
+    expect((client as never as { getPreview: ReturnType<typeof vi.fn> }).getPreview).toHaveBeenCalledWith(
+      editPreviewData,
+      { headers: { Authorization: 'Bearer abc' } }
+    );
+  });
+
+  it('uses getDesignLibraryData for Design Library modes', async () => {
+    const client = makeClient();
+    const data: CsdkRequestData = { cookies: { sc_preview_token: 'Bearer cookie' } };
+
+    const page = await resolvePreviewPage(client, designLibraryPreviewData, data);
+
+    expect(page).toEqual({ id: 'design-library-page' });
+    expect(
+      (client as never as { getDesignLibraryData: ReturnType<typeof vi.fn> }).getDesignLibraryData
+    ).toHaveBeenCalledWith(designLibraryPreviewData, { headers: { Authorization: 'Bearer cookie' } });
+  });
+
+  it('forwards an empty Authorization when no token is present', async () => {
+    const client = makeClient();
+
+    await resolvePreviewPage(client, editPreviewData, {});
+
+    expect((client as never as { getPreview: ReturnType<typeof vi.fn> }).getPreview).toHaveBeenCalledWith(
+      editPreviewData,
+      { headers: { Authorization: '' } }
+    );
+  });
+
+  it('throws when preview content is not found or access is denied', async () => {
+    const client = makeClient({ getPreview: vi.fn().mockResolvedValue(null) });
+
+    await expect(resolvePreviewPage(client, editPreviewData, {})).rejects.toThrow(
+      'Preview content is not found or access is denied'
+    );
+  });
+});
+
+describe('resolvePreviewNavigation', () => {
+  it('fetches via getPage with preview headers and the token from the cookie', async () => {
+    const client = makeClient();
+    const data: CsdkRequestData = { cookies: { sc_preview_token: 'Bearer%20abc' } };
+
+    const page = await resolvePreviewNavigation(
+      client,
+      '/about',
+      { site: 'my-site', locale: 'en' },
+      data
+    );
+
+    expect(page).toEqual({ id: 'nav-page' });
+    expect((client as never as { getPage: ReturnType<typeof vi.fn> }).getPage).toHaveBeenCalledWith(
+      '/about',
+      { site: 'my-site', locale: 'en' },
+      { headers: { Authorization: 'Bearer abc', sc_previewMode: 'true', sc_site: 'my-site' } }
+    );
+  });
+
+  it('throws when preview content is not found or access is denied', async () => {
+    const client = makeClient({ getPage: vi.fn().mockResolvedValue(null) });
+
+    await expect(
+      resolvePreviewNavigation(client, '/about', { site: 'my-site', locale: 'en' }, {})
+    ).rejects.toThrow('Preview content is not found or access is denied');
+  });
+});

--- a/packages/angular/src/server/editing/resolve-preview.ts
+++ b/packages/angular/src/server/editing/resolve-preview.ts
@@ -1,0 +1,89 @@
+import { PREVIEW_TOKEN } from '@sitecore-content-sdk/content/editing';
+import type { Page, SitecoreClient } from '@sitecore-content-sdk/content/client';
+import type { CsdkRequestData } from '../../loaders/models';
+import { isDesignLibraryPreviewData, type EditingRenderPreviewData } from './get-editing-preview-data';
+
+/**
+ * Reads the bearer token authorizing preview / edit layout: the `Authorization`
+ * header (initial editing render) or the {@link PREVIEW_TOKEN} cookie (later navigation).
+ * @param {CsdkRequestData | undefined} csdkRequestData - Request data from the incoming request.
+ * @returns {string | undefined} Token, or `undefined` when none is present.
+ * @public
+ */
+export function getPreviewAuthToken(
+  csdkRequestData: CsdkRequestData | undefined
+): string | undefined {
+  const header = csdkRequestData?.headers?.authorization;
+  const headerValue = Array.isArray(header) ? header[0] : header;
+  if (headerValue) return headerValue;
+  const cookie = csdkRequestData?.cookies?.[PREVIEW_TOKEN];
+  return cookie ? decodeURIComponent(cookie) : undefined;
+}
+
+/**
+ * Fetches protected preview / edit layout, forwarding the preview token as the
+ * `Authorization` header. Uses `getDesignLibraryData` for Design Library modes,
+ * otherwise `getPreview`. Throws when access is denied or the page is not found.
+ * @param {SitecoreClient} client - Content SDK client.
+ * @param {EditingRenderPreviewData} previewData - Preview data from the editing request.
+ * @param {CsdkRequestData} [csdkRequestData] - Request data used to read the preview token.
+ * @returns {Promise<Page>} Preview page.
+ * @throws {Error} When preview content is not found or access is denied.
+ * @public
+ */
+export async function resolvePreviewPage(
+  client: SitecoreClient,
+  previewData: EditingRenderPreviewData,
+  csdkRequestData?: CsdkRequestData
+): Promise<Page> {
+  const token = getPreviewAuthToken(csdkRequestData);
+  const fetchOptions = { headers: { Authorization: token ?? '' } };
+
+  const page = isDesignLibraryPreviewData(previewData)
+    ? await client.getDesignLibraryData(previewData, fetchOptions)
+    : await client.getPreview(previewData, fetchOptions);
+
+  if (!page) {
+    throw new Error('Preview content is not found or access is denied');
+  }
+  return page;
+}
+
+/**
+ * Fetches preview layout for a follow-up navigation via `getPage`, forwarding the
+ * preview token plus `sc_previewMode` / `sc_site` headers. Throws when access is
+ * denied or the page is not found.
+ * @param {SitecoreClient} client - Content SDK client.
+ * @param {string} path - Route path to fetch.
+ * @param {{ site: string; locale: string }} options - Resolved site and locale.
+ * @param {string} options.site - Resolved site name.
+ * @param {string} options.locale - Resolved locale.
+ * @param {CsdkRequestData} [csdkRequestData] - Request data used to read the preview token.
+ * @returns {Promise<Page>} Preview page.
+ * @throws {Error} When preview content is not found or access is denied.
+ * @public
+ */
+export async function resolvePreviewNavigation(
+  client: SitecoreClient,
+  path: string,
+  options: { site: string; locale: string },
+  csdkRequestData?: CsdkRequestData
+): Promise<Page> {
+  const token = getPreviewAuthToken(csdkRequestData);
+  const page = await client.getPage(
+    path,
+    { site: options.site, locale: options.locale },
+    {
+      headers: {
+        Authorization: token ?? '',
+        sc_previewMode: 'true',
+        sc_site: options.site,
+      },
+    }
+  );
+
+  if (!page) {
+    throw new Error('Preview content is not found or access is denied');
+  }
+  return page;
+}

--- a/packages/angular/src/server/index.ts
+++ b/packages/angular/src/server/index.ts
@@ -10,6 +10,11 @@ export {
   isDesignLibraryPreviewData,
   type EditingRenderPreviewData,
 } from './editing/get-editing-preview-data';
+export {
+  getPreviewAuthToken,
+  resolvePreviewPage,
+  resolvePreviewNavigation,
+} from './editing/resolve-preview';
 
 // Loader cache (server-only). Browser code must not reach createLoaderCache —
 // see plan §1 (Browser safety). The exports here are types + server factories;

--- a/packages/angular/src/server/middleware/editing-render-middleware.ts
+++ b/packages/angular/src/server/middleware/editing-render-middleware.ts
@@ -6,6 +6,7 @@ import {
   DesignLibraryMode,
   DesignLibraryVariantGeneration,
   DesignLibraryRenderPreviewData,
+  PREVIEW_TOKEN,
 } from '@sitecore-content-sdk/content/editing';
 import { DEFAULT_VARIANT } from '@sitecore-content-sdk/content/personalize';
 import { getAllowedOriginsFromEnv, getEnforcedCorsHeaders } from '@sitecore-content-sdk/core/tools';
@@ -312,6 +313,18 @@ export function createEditingRenderMiddleware(
 
       if (typeof res.setHeader === 'function') {
         res.setHeader('Content-Security-Policy', buildCSPHeader());
+      }
+
+      // On the internal editing host, persist the editor-issued bearer as the
+      // preview token cookie so later navigation stays authorized; re-set on every
+      // render to refresh it.
+      const authHeader = req.headers?.authorization;
+      const token = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+      if (token && readProcessEnv('SITECORE') && typeof res.setHeader === 'function') {
+        res.setHeader(
+          'Set-Cookie',
+          `${PREVIEW_TOKEN}=${encodeURIComponent(token)}; Path=/; HttpOnly; Secure; SameSite=None`
+        );
       }
 
       const decodedRoute = flatQuery.route ?? '';

--- a/packages/content/src/editing/index.ts
+++ b/packages/content/src/editing/index.ts
@@ -11,6 +11,7 @@ export {
   PAGES_EDITING_MARKER,
   ComponentUpdateEventArgs,
   PREVIEW_KEY,
+  PREVIEW_TOKEN,
 } from './utils';
 export {
   ComponentLayoutService,

--- a/packages/content/src/editing/utils.ts
+++ b/packages/content/src/editing/utils.ts
@@ -26,6 +26,12 @@ export const INVALID_SECRET_HTML_MESSAGE = '<html><body>Missing or invalid secre
 export const PREVIEW_KEY = 'sc_preview';
 
 /**
+ * Cookie holding the bearer token that authorizes preview / edit layout.
+ * @public
+ */
+export const PREVIEW_TOKEN = 'sc_preview_token';
+
+/**
  * ID to be used as a marker for a script rendered in XMC Pages
  * Should identify app is in XM Cloud Pages editing mode
  * @internal

--- a/packages/create-content-sdk-app/src/templates/angular/src/content-sdk/loaders/page.loader.ts
+++ b/packages/create-content-sdk-app/src/templates/angular/src/content-sdk/loaders/page.loader.ts
@@ -2,7 +2,9 @@ import type { LoaderFn, Page } from '@sitecore-content-sdk/angular';
 import {
   NotFoundNavigationError,
   getEditingPreviewData,
-  isDesignLibraryPreviewData,
+  getPreviewAuthToken,
+  resolvePreviewPage,
+  resolvePreviewNavigation,
   getSiteName,
   getVariantId,
   getComponentVariantIds,
@@ -21,21 +23,30 @@ export const pageLoader: LoaderFn<Page> = async (context) => {
   const locale = getLanguage(context) || scConfig.defaultLanguage;
   const { nonLocalePath } = splitLocaleFromPath(context.url, scConfig.angular.locales);
 
-  let page: Page | null;
-  if (isDesignLibraryPreviewData(previewData)) {
-    page = await getClient().getDesignLibraryData(previewData);
-  } else if (previewData) {
-    page = await getClient().getPreview(previewData);
-  } else {
-    page = await getClient().getPage(nonLocalePath, {
-      locale,
-      site: getSiteName(context),
-      personalize: {
-        variantId: getVariantId(context),
-        componentVariantIds: getComponentVariantIds(context),
-      },
-    });
+  // Editing render: fetch preview / Design Library layout with the forwarded token.
+  if (previewData) {
+    return resolvePreviewPage(getClient(), previewData, context.csdkRequestData);
   }
+
+  // Follow-up preview navigation: the preview token cookie is present but there is
+  // no editing header, so fetch via getPage with the preview headers.
+  if (getPreviewAuthToken(context.csdkRequestData)) {
+    return resolvePreviewNavigation(
+      getClient(),
+      nonLocalePath,
+      { site: getSiteName(context), locale },
+      context.csdkRequestData
+    );
+  }
+
+  const page = await getClient().getPage(nonLocalePath, {
+    locale,
+    site: getSiteName(context),
+    personalize: {
+      variantId: getVariantId(context),
+      componentVariantIds: getComponentVariantIds(context),
+    },
+  });
 
   if (!page) {
     throw new NotFoundNavigationError();

--- a/packages/nextjs/src/editing/utils.ts
+++ b/packages/nextjs/src/editing/utils.ts
@@ -4,6 +4,7 @@ import {
   EditingRenderQueryParams,
   isDesignLibraryMode,
   PREVIEW_KEY,
+  PREVIEW_TOKEN,
   QUERY_PARAM_EDITING_SECRET,
 } from '@sitecore-content-sdk/content/editing';
 import { DEFAULT_VARIANT } from '@sitecore-content-sdk/content/personalize';
@@ -124,7 +125,7 @@ export const getAllowedQueryParams = (
 export const PREVIEW_COOKIES = {
   PREVIEW_DATA: '__next_preview_data',
   PRERENDER_BYPASS: '__prerender_bypass',
-  PREVIEW_TOKEN: 'sc_preview_token',
+  PREVIEW_TOKEN,
 };
 
 /**


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Implements preview protection for Angular CSDK. Unlike next.js implementation done via PreviewProxy, this one is wired to the pageLoader that conditionally launches `getPreview`, `getPage` or `getPage` with extra headers depending on scenario (editing, preview navigation, normal mode/normal mode editing).
Header setting duty (done by PreviewProxy in next) goes to editing-render-middleware.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
