### PR TITLE
[react] Highlight area between Atoms elements when an Atom is being dragged over the canvas

### DIFF
--- a/.changeset/eager-tables-repeat.md
+++ b/.changeset/eager-tables-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/react': minor
+---
+
+Highlight area between Atoms elements when an Atom is being dragged over the canvas

--- a/packages/nextjs/api/content-sdk-nextjs.api.md
+++ b/packages/nextjs/api/content-sdk-nextjs.api.md
@@ -11,6 +11,7 @@ import { AtomActionDefinition } from '@sitecore-content-sdk/react';
 import { AtomActionHandler } from '@sitecore-content-sdk/react';
 import { AtomComponentDefinition } from '@sitecore-content-sdk/react';
 import { AtomsActionsMap } from '@sitecore-content-sdk/react';
+import { AtomsCatalog } from '@sitecore-content-sdk/react';
 import { AtomsCatalogInput } from '@sitecore-content-sdk/react';
 import { AtomsComponentsMap } from '@sitecore-content-sdk/react';
 import { AtomsConfig } from '@sitecore-content-sdk/react';
@@ -251,6 +252,8 @@ export { AtomActionHandler }
 export { AtomComponentDefinition }
 
 export { AtomsActionsMap }
+
+export { AtomsCatalog }
 
 export { AtomsCatalogInput }
 

--- a/packages/nextjs/src/atoms/index.ts
+++ b/packages/nextjs/src/atoms/index.ts
@@ -4,6 +4,7 @@ export {
   extractDocumentClasses,
   type AtomComponentDefinition,
   type AtomActionDefinition,
+  type AtomsCatalog,
   type AtomsCatalogInput,
   type AtomsComponentsMap,
   type AtomActionHandler,

--- a/packages/react/api/content-sdk-react.api.md
+++ b/packages/react/api/content-sdk-react.api.md
@@ -92,6 +92,9 @@ export type AtomComponentDefinition = BaseComponent & SitecoreComponentMeta;
 // @public
 export type AtomsActionsMap = Record<string, AtomActionHandler>;
 
+// @public
+export type AtomsCatalog = Catalog<any, AtomsCatalogInput>;
+
 // Warning: (ae-forgotten-export) The symbol "BaseCatalog" needs to be exported by the entry point api-surface.d.ts
 //
 // @public
@@ -108,7 +111,7 @@ export type AtomsComponentsMap = Record<string, AtomsComponentRenderer>;
 
 // @public
 export interface AtomsConfig {
-    catalog: Catalog<any, AtomsCatalogInput>;
+    catalog: AtomsCatalog;
     compileCssAction?: (classes: string[]) => Promise<string>;
     navigate?: (path: string) => void;
     registry: DefineRegistryResult;

--- a/packages/react/src/atoms/catalog-serializer.ts
+++ b/packages/react/src/atoms/catalog-serializer.ts
@@ -1,5 +1,4 @@
-import type { Catalog } from '@json-render/core';
-import { AtomsCatalogInput } from './types';
+import type { AtomsCatalog } from './types';
 import {
   AtomCatalogActionEntry,
   AtomCatalogComponentEntry,
@@ -8,11 +7,11 @@ import {
 
 /**
  * Serialize a json-render Catalog into the payload shape expected by Design Studio.
- * @param { Catalog<any, AtomsCatalogInput> } catalog - The json-render Catalog to serialize
+ * @param {AtomsCatalog} catalog - The Atoms catalog to serialize
  * @returns Serialized catalog for the Design Library event
  * @internal
  */
-export function serializeCatalog(catalog: Catalog<any, AtomsCatalogInput>): SerializedCatalog {
+export function serializeCatalog(catalog: AtomsCatalog): SerializedCatalog {
   const { version, components, actions } = catalog.data;
 
   const serializedComponents: AtomCatalogComponentEntry[] = Object.entries(components).map(

--- a/packages/react/src/atoms/constants.ts
+++ b/packages/react/src/atoms/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * The type identifier for an atom component in the Design Library.
+ */
+export const ATOM_TYPE = 'atom';

--- a/packages/react/src/atoms/constants.ts
+++ b/packages/react/src/atoms/constants.ts
@@ -1,4 +1,5 @@
 /**
  * The type identifier for an atom component in the Design Library.
+ * @internal
  */
 export const ATOM_TYPE = 'atom';

--- a/packages/react/src/atoms/create-ncc.test.tsx
+++ b/packages/react/src/atoms/create-ncc.test.tsx
@@ -149,8 +149,8 @@ describe('create-ncc', () => {
       const View = createNCC(doc, registry, catalog);
       const { container } = renderInProvider(<View />);
 
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="list-el"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="card-el"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="list-el"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el"]`)).to.not.be.null;
     });
 
     it('suffixes repeated atoms with the repeat index and keeps the repeat owner unsuffixed', () => {
@@ -171,9 +171,9 @@ describe('create-ncc', () => {
       const View = createNCC(doc, registry, catalog);
       const { container } = renderInProvider(<View />);
 
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="list-el"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="card-el_0"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="card-el_1"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="list-el"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el_0"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el_1"]`)).to.not.be.null;
     });
   });
 });

--- a/packages/react/src/atoms/create-ncc.test.tsx
+++ b/packages/react/src/atoms/create-ncc.test.tsx
@@ -33,13 +33,20 @@ describe('create-ncc', () => {
     executeAction: async () => {},
   };
 
+  const mockCatalog = defineAtomsCatalog({
+    components: {
+      Card: { props: z.object({ title: z.string().optional() }), description: 'Card' },
+    },
+    actions: {},
+  });
+
   it('returns an FC with the document name as displayName', () => {
-    const View = createNCC(mockDoc, mockRegistry);
+    const View = createNCC(mockDoc, mockRegistry, mockCatalog);
     expect(View.displayName).to.equal('TestComponent');
   });
 
   it('returns a functional component', () => {
-    const View = createNCC(mockDoc, mockRegistry);
+    const View = createNCC(mockDoc, mockRegistry, mockCatalog);
     expect(typeof View).to.equal('function');
   });
 
@@ -139,7 +146,7 @@ describe('create-ncc', () => {
           'card-el': { type: 'Card', props: { title: 'Hello' } },
         },
       };
-      const View = createNCC(doc, registry);
+      const View = createNCC(doc, registry, catalog);
       const { container } = renderInProvider(<View />);
 
       expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="list-el"]`)).to.not.be.null;
@@ -161,7 +168,7 @@ describe('create-ncc', () => {
         },
         state: { cards: [{ title: 'One' }, { title: 'Two' }] },
       };
-      const View = createNCC(doc, registry);
+      const View = createNCC(doc, registry, catalog);
       const { container } = renderInProvider(<View />);
 
       expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="list-el"]`)).to.not.be.null;

--- a/packages/react/src/atoms/create-ncc.test.tsx
+++ b/packages/react/src/atoms/create-ncc.test.tsx
@@ -82,7 +82,7 @@ describe('create-ncc', () => {
       const View = createNCCWithMocks(mockDoc, mockRegistry);
       const { container } = render(<View />);
       const div = container.firstChild as HTMLElement;
-      expect(div.className).to.equal('component ');
+      expect(div.className).to.equal('component');
     });
 
     it('applies params.RenderingIdentifier to the wrapper div id', () => {

--- a/packages/react/src/atoms/create-ncc.test.tsx
+++ b/packages/react/src/atoms/create-ncc.test.tsx
@@ -1,11 +1,17 @@
 /* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import proxyquire from 'proxyquire';
+import { z } from 'zod';
 import type { Document } from '@sitecore-content-sdk/content/atoms';
 import type { DefineRegistryResult } from '@json-render/react';
 import { createNCC } from '.';
+import { defineAtomsCatalog } from './define-atoms-catalog';
+import { defineAtomsRegistry } from './define-atoms-registry';
+import { ATOM_TYPE } from './constants';
+import { SitecoreProvider } from '../components/SitecoreProvider';
 
 describe('create-ncc', () => {
   const mockDoc: Document = {
@@ -91,6 +97,76 @@ describe('create-ncc', () => {
       const { container } = render(<View />);
       const div = container.firstChild as HTMLElement;
       expect(div.id).to.equal('');
+    });
+  });
+
+  describe('editing chrome', () => {
+    const catalog = defineAtomsCatalog({
+      components: {
+        Card: { props: z.object({ title: z.string().optional() }), description: 'Card' },
+        List: { props: z.object({}), description: 'List' },
+      },
+      actions: {},
+    });
+
+    const registry = defineAtomsRegistry(catalog, {
+      components: {
+        Card: ({ props }) => <span data-testid="card">{props?.title}</span>,
+        List: ({ children }) => <div data-testid="list">{children}</div>,
+      },
+      actions: {},
+    });
+
+    const renderInProvider = (ui: React.ReactNode) =>
+      render(
+        <SitecoreProvider
+          api={{} as any}
+          componentMap={new Map()}
+          page={{ locale: 'en', layout: { sitecore: { context: {}, route: null } } } as any}
+          loadImportMap={async () => ({} as any)}
+          atomsConfig={{ catalog, registry }}
+        >
+          {ui}
+        </SitecoreProvider>
+      );
+
+    it('wraps every rendered atom with chrometype="atom" chrome using the element key', () => {
+      const doc: Document = {
+        name: 'chrome-doc',
+        root: 'list-el',
+        elements: {
+          'list-el': { type: 'List', props: {}, children: ['card-el'] },
+          'card-el': { type: 'Card', props: { title: 'Hello' } },
+        },
+      };
+      const View = createNCC(doc, registry);
+      const { container } = renderInProvider(<View />);
+
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="list-el"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="card-el"]`)).to.not.be.null;
+    });
+
+    it('suffixes repeated atoms with the repeat index and keeps the repeat owner unsuffixed', () => {
+      const doc: Document = {
+        name: 'repeat-doc',
+        root: 'list-el',
+        elements: {
+          'list-el': {
+            type: 'List',
+            props: {},
+            children: ['card-el'],
+            repeat: { statePath: '/cards' },
+          },
+          'card-el': { type: 'Card', props: { title: { $item: 'title' } } },
+        },
+        state: { cards: [{ title: 'One' }, { title: 'Two' }] },
+      };
+      const View = createNCC(doc, registry);
+      const { container } = renderInProvider(<View />);
+
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="list-el"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="card-el_0"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="card-el_1"]`)).to.not.be.null;
     });
   });
 });

--- a/packages/react/src/atoms/create-ncc.test.tsx
+++ b/packages/react/src/atoms/create-ncc.test.tsx
@@ -142,8 +142,8 @@ describe('create-ncc', () => {
       const View = createNCC(doc, registry);
       const { container } = renderInProvider(<View />);
 
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="list-el"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="card-el"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="list-el"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="card-el"]`)).to.not.be.null;
     });
 
     it('suffixes repeated atoms with the repeat index and keeps the repeat owner unsuffixed', () => {
@@ -164,9 +164,9 @@ describe('create-ncc', () => {
       const View = createNCC(doc, registry);
       const { container } = renderInProvider(<View />);
 
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="list-el"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="card-el_0"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="card-el_1"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="list-el"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="card-el_0"]`)).to.not.be.null;
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="card-el_1"]`)).to.not.be.null;
     });
   });
 });

--- a/packages/react/src/atoms/create-ncc.tsx
+++ b/packages/react/src/atoms/create-ncc.tsx
@@ -13,6 +13,7 @@ import type { StateModel } from '@json-render/core';
 import { Document } from '@sitecore-content-sdk/content/atoms';
 import { useSitecore } from '../components/SitecoreProvider';
 import type { ChildComponentProps } from '../components/Placeholder/models';
+import { withElementChromeKeys, withEditingChromeRegistry } from './with-editing-chrome';
 
 /**
  * Props accepted by the NCC component created by `createNCC`.
@@ -34,6 +35,8 @@ type NCCProps = {
  */
 export function createNCC(doc: Document, registryResult: DefineRegistryResult): FC<NCCProps> {
   const { registry, handlers } = registryResult;
+  const chromeDoc = withElementChromeKeys(doc);
+  const chromeRegistry = withEditingChromeRegistry(registry);
 
   const initialState: StateModel = {
     ...(doc.state ?? {}),
@@ -66,12 +69,12 @@ export function createNCC(doc: Document, registryResult: DefineRegistryResult): 
     );
 
     return (
-      <div className={`component ${params?.styles || ''}`} id={params?.RenderingIdentifier || ''}>
+      <div className={`component${params?.styles ? ` ${params.styles}` : ''}`} id={params?.RenderingIdentifier || ''}>
         <StateProvider store={store}>
           <VisibilityProvider>
             <ActionProvider handlers={resolvedHandlers} navigate={atomsConfig?.navigate}>
               <ValidationProvider>
-                <Renderer spec={doc} registry={registry} />
+                <Renderer spec={chromeDoc} registry={chromeRegistry} />
               </ValidationProvider>
             </ActionProvider>
           </VisibilityProvider>

--- a/packages/react/src/atoms/create-ncc.tsx
+++ b/packages/react/src/atoms/create-ncc.tsx
@@ -9,8 +9,10 @@ import {
 } from '@json-render/react';
 import type { DefineRegistryResult } from '@json-render/react';
 import { createStateStore } from '@json-render/react';
+import type { Catalog } from '@json-render/core';
 import type { StateModel } from '@json-render/core';
 import { Document } from '@sitecore-content-sdk/content/atoms';
+import type { AtomsCatalogInput } from './types';
 import { useSitecore } from '../components/SitecoreProvider';
 import type { ChildComponentProps } from '../components/Placeholder/models';
 import { withElementChromeKeys, withEditingChromeRegistry } from './with-editing-chrome';
@@ -30,13 +32,18 @@ type NCCProps = {
  * using json-render's Renderer. The document's flat element map is passed as a spec.
  * @param {Document} doc - Component Layout document (flat spec format)
  * @param {DefineRegistryResult} registryResult - The registry from defineAtomsRegistry
+ * @param {Catalog<any, AtomsCatalogInput>} catalog - The catalog containing component definitions
  * @returns {FC<NCCProps>} FC that accepts runtime props merged into spec state
  * @internal
  */
-export function createNCC(doc: Document, registryResult: DefineRegistryResult): FC<NCCProps> {
+export function createNCC(
+  doc: Document,
+  registryResult: DefineRegistryResult,
+  catalog: Catalog<any, AtomsCatalogInput>
+): FC<NCCProps> {
   const { registry, handlers } = registryResult;
   const chromeDoc = withElementChromeKeys(doc);
-  const chromeRegistry = withEditingChromeRegistry(registry);
+  const chromeRegistry = withEditingChromeRegistry(registry, catalog);
 
   const initialState: StateModel = {
     ...(doc.state ?? {}),

--- a/packages/react/src/atoms/create-ncc.tsx
+++ b/packages/react/src/atoms/create-ncc.tsx
@@ -9,10 +9,9 @@ import {
 } from '@json-render/react';
 import type { DefineRegistryResult } from '@json-render/react';
 import { createStateStore } from '@json-render/react';
-import type { Catalog } from '@json-render/core';
 import type { StateModel } from '@json-render/core';
 import { Document } from '@sitecore-content-sdk/content/atoms';
-import type { AtomsCatalogInput } from './types';
+import type { AtomsCatalog } from './types';
 import { useSitecore } from '../components/SitecoreProvider';
 import type { ChildComponentProps } from '../components/Placeholder/models';
 import { withElementChromeKeys, withEditingChromeRegistry } from './with-editing-chrome';
@@ -32,14 +31,14 @@ type NCCProps = {
  * using json-render's Renderer. The document's flat element map is passed as a spec.
  * @param {Document} doc - Component Layout document (flat spec format)
  * @param {DefineRegistryResult} registryResult - The registry from defineAtomsRegistry
- * @param {Catalog<any, AtomsCatalogInput>} catalog - The catalog containing component definitions
+ * @param {AtomsCatalog} catalog - The catalog containing component definitions
  * @returns {FC<NCCProps>} FC that accepts runtime props merged into spec state
  * @internal
  */
 export function createNCC(
   doc: Document,
   registryResult: DefineRegistryResult,
-  catalog: Catalog<any, AtomsCatalogInput>
+  catalog: AtomsCatalog
 ): FC<NCCProps> {
   const { registry, handlers } = registryResult;
   const chromeDoc = withElementChromeKeys(doc);

--- a/packages/react/src/atoms/index.ts
+++ b/packages/react/src/atoms/index.ts
@@ -1,6 +1,7 @@
 export type {
   AtomComponentDefinition,
   AtomActionDefinition,
+  AtomsCatalog,
   AtomsCatalogInput,
   AtomsComponentsMap,
   AtomActionHandler,

--- a/packages/react/src/atoms/types.ts
+++ b/packages/react/src/atoms/types.ts
@@ -38,6 +38,12 @@ export type AtomsCatalogInput = BaseCatalog & {
 };
 
 /**
+ * Catalog used by the Atoms APIs.
+ * @public
+ */
+export type AtomsCatalog = Catalog<any, AtomsCatalogInput>;
+
+/**
  * Type alias for the component renderer.
  * @public
  */
@@ -67,7 +73,7 @@ export type AtomsActionsMap = Record<string, AtomActionHandler>;
  */
 export interface AtomsConfig {
   /** The json-render catalog (schema + component/action definitions). */
-  catalog: Catalog<any, AtomsCatalogInput>;
+  catalog: AtomsCatalog;
   /** The registry result returned by defineAtomsRegistry. */
   registry: DefineRegistryResult;
   /** Optional navigate function to be passed to action handlers for navigation purposes. */

--- a/packages/react/src/atoms/with-editing-chrome.test.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.test.tsx
@@ -2,10 +2,12 @@
 /* eslint-disable no-unused-expressions */
 import React from 'react';
 import { expect } from 'chai';
+import { z } from 'zod';
 import { render } from '@testing-library/react';
 import { RepeatScopeProvider } from '@json-render/react';
 import type { ComponentRenderProps } from '@json-render/react';
 import type { Document } from '@sitecore-content-sdk/content/atoms';
+import { defineAtomsCatalog } from './define-atoms-catalog';
 import { ATOM_TYPE } from './constants';
 import {
   CHROME_ELEMENT_KEY_PROP,
@@ -82,6 +84,29 @@ describe('withEditingChrome', () => {
     expect(open?.getAttribute('atom-type')).to.equal('Stub');
     expect(open?.className).to.equal('scpm');
     expect(close).to.not.be.null;
+  });
+
+  it('includes the atom slot mapping in the opening chrome block', () => {
+    const catalog = defineAtomsCatalog({
+      components: {
+        Stub: { props: z.object({}), description: 'Stub', slots: ['header', 'body'] },
+      },
+      actions: {},
+    });
+    const Wrapped = withEditingChrome(Stub, catalog.data.components.Stub);
+    const { container } = render(
+      <Wrapped
+        {...baseRenderProps({
+          element: {
+            type: 'Stub',
+            props: { [CHROME_ELEMENT_KEY_PROP]: 'card-1' },
+          },
+        })}
+      />
+    );
+
+    const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
+    expect(open?.getAttribute('atom-slots')).to.equal(JSON.stringify(['header', 'body']));
   });
 
   it('strips the internal chrome-key prop before it reaches the wrapped component', () => {

--- a/packages/react/src/atoms/with-editing-chrome.test.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.test.tsx
@@ -79,9 +79,9 @@ describe('withEditingChrome', () => {
     const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
     const close = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="close"]`);
 
-    expect(open?.getAttribute('element-name')).to.equal('card-1');
+    expect(open?.getAttribute('data-element-name')).to.equal('card-1');
     expect(open?.getAttribute('type')).to.equal('text/sitecore');
-    expect(open?.getAttribute('atom-type')).to.equal('Stub');
+    expect(open?.getAttribute('data-atom-type')).to.equal('Stub');
     expect(open?.className).to.equal('scpm');
     expect(close).to.not.be.null;
   });
@@ -106,7 +106,7 @@ describe('withEditingChrome', () => {
     );
 
     const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
-    expect(open?.getAttribute('atom-slots')).to.equal(JSON.stringify(['header', 'body']));
+    expect(open?.getAttribute('data-atom-slots')).to.equal(JSON.stringify(['header', 'body']));
   });
 
   it('strips the internal chrome-key prop before it reaches the wrapped component', () => {
@@ -145,7 +145,7 @@ describe('withEditingChrome', () => {
     );
 
     const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
-    expect(open?.getAttribute('element-name')).to.equal('item_2');
+    expect(open?.getAttribute('data-element-name')).to.equal('item_2');
   });
 
   it('keeps the plain unsuffixed id for the container owning the repeat itself', () => {
@@ -159,7 +159,7 @@ describe('withEditingChrome', () => {
     );
 
     const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
-    expect(open?.getAttribute('element-name')).to.equal('list');
+    expect(open?.getAttribute('data-element-name')).to.equal('list');
   });
 });
 
@@ -194,7 +194,7 @@ describe('withEditingChromeRegistry', () => {
       </>
     );
 
-    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="text-1"]`)).to.not.be.null;
-    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="box-1"]`)).to.not.be.null;
+    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="text-1"]`)).to.not.be.null;
+    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="box-1"]`)).to.not.be.null;
   });
 });

--- a/packages/react/src/atoms/with-editing-chrome.test.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.test.tsx
@@ -1,0 +1,167 @@
+/* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable no-unused-expressions */
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { RepeatScopeProvider } from '@json-render/react';
+import type { ComponentRenderProps } from '@json-render/react';
+import type { Document } from '@sitecore-content-sdk/content/atoms';
+import { ATOM_TYPE } from './constants';
+import {
+  CHROME_ELEMENT_KEY_PROP,
+  withElementChromeKeys,
+  withEditingChrome,
+  withEditingChromeRegistry,
+} from './with-editing-chrome';
+
+const noop = () => undefined;
+const baseRenderProps = (
+  overrides: Partial<ComponentRenderProps> = {}
+): ComponentRenderProps => ({
+  element: { type: 'Stub', props: {} },
+  emit: noop,
+  on: () => ({ emit: noop, shouldPreventDefault: false, bound: false }),
+  ...overrides,
+});
+
+describe('withElementChromeKeys', () => {
+  it('injects each element key into its own props', () => {
+    const doc: Document = {
+      name: 'doc',
+      root: 'root-el',
+      elements: {
+        'root-el': { type: 'Box', props: { title: 'Hi' }, children: ['child-el'] },
+        'child-el': { type: 'Text', props: {} },
+      },
+    };
+
+    const result = withElementChromeKeys(doc);
+
+    expect(result.elements['root-el'].props).to.deep.equal({
+      title: 'Hi',
+      [CHROME_ELEMENT_KEY_PROP]: 'root-el',
+    });
+    expect(result.elements['child-el'].props).to.deep.equal({
+      [CHROME_ELEMENT_KEY_PROP]: 'child-el',
+    });
+  });
+
+  it('does not mutate the original document', () => {
+    const doc: Document = {
+      name: 'doc',
+      root: 'root-el',
+      elements: { 'root-el': { type: 'Box', props: {} } },
+    };
+
+    withElementChromeKeys(doc);
+
+    expect(doc.elements['root-el'].props).to.deep.equal({});
+  });
+});
+
+describe('withEditingChrome', () => {
+  const Stub = ({ element }: ComponentRenderProps) => (
+    <span data-testid="stub">{JSON.stringify(element.props)}</span>
+  );
+
+  it('renders open/close atom chrome around the wrapped component using the injected element key', () => {
+    const Wrapped = withEditingChrome(Stub);
+    const { container } = render(
+      <Wrapped
+        {...baseRenderProps({
+          element: { type: 'Stub', props: { [CHROME_ELEMENT_KEY_PROP]: 'card-1' } },
+        })}
+      />
+    );
+
+    const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
+    const close = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="close"]`);
+
+    expect(open?.getAttribute('id')).to.equal('card-1');
+    expect(open?.getAttribute('type')).to.equal('text/sitecore');
+    expect(open?.className).to.equal('scpm');
+    expect(close).to.not.be.null;
+  });
+
+  it('strips the internal chrome-key prop before it reaches the wrapped component', () => {
+    const Wrapped = withEditingChrome(Stub);
+    const { getByTestId } = render(
+      <Wrapped
+        {...baseRenderProps({
+          element: {
+            type: 'Stub',
+            props: { title: 'Hi', [CHROME_ELEMENT_KEY_PROP]: 'card-1' },
+          },
+        })}
+      />
+    );
+
+    expect(getByTestId('stub').textContent).to.equal(JSON.stringify({ title: 'Hi' }));
+  });
+
+  it('renders the wrapped component with no chrome when the element key is missing', () => {
+    const Wrapped = withEditingChrome(Stub);
+    const { container } = render(<Wrapped {...baseRenderProps({ element: { type: 'Stub', props: {} } })} />);
+
+    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"]`)).to.be.null;
+  });
+
+  it('suffixes the chrome id with the repeat index inside a repeat scope', () => {
+    const Wrapped = withEditingChrome(Stub);
+    const { container } = render(
+      <RepeatScopeProvider item={{}} index={2} basePath="/items/2">
+        <Wrapped
+          {...baseRenderProps({
+            element: { type: 'Stub', props: { [CHROME_ELEMENT_KEY_PROP]: 'item' } },
+          })}
+        />
+      </RepeatScopeProvider>
+    );
+
+    const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
+    expect(open?.getAttribute('id')).to.equal('item_2');
+  });
+
+  it('keeps the plain unsuffixed id for the container owning the repeat itself', () => {
+    const Wrapped = withEditingChrome(Stub);
+    const { container } = render(
+      <Wrapped
+        {...baseRenderProps({
+          element: { type: 'Stub', props: { [CHROME_ELEMENT_KEY_PROP]: 'list' } },
+        })}
+      />
+    );
+
+    const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
+    expect(open?.getAttribute('id')).to.equal('list');
+  });
+});
+
+describe('withEditingChromeRegistry', () => {
+  it('wraps every component in the registry', () => {
+    const Text = ({ element }: ComponentRenderProps) => <span>{JSON.stringify(element.props)}</span>;
+    const Box = ({ children }: ComponentRenderProps) => <div>{children}</div>;
+
+    const registry = withEditingChromeRegistry({ Text, Box });
+
+    const { container } = render(
+      <>
+        {React.createElement(
+          registry.Text,
+          baseRenderProps({
+            element: { type: 'Text', props: { [CHROME_ELEMENT_KEY_PROP]: 'text-1' } },
+          })
+        )}
+        {React.createElement(
+          registry.Box,
+          baseRenderProps({
+            element: { type: 'Box', props: { [CHROME_ELEMENT_KEY_PROP]: 'box-1' } },
+          })
+        )}
+      </>
+    );
+
+    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="text-1"]`)).to.not.be.null;
+    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="box-1"]`)).to.not.be.null;
+  });
+});

--- a/packages/react/src/atoms/with-editing-chrome.test.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.test.tsx
@@ -167,8 +167,15 @@ describe('withEditingChromeRegistry', () => {
   it('wraps every component in the registry', () => {
     const Text = ({ element }: ComponentRenderProps) => <span>{JSON.stringify(element.props)}</span>;
     const Box = ({ children }: ComponentRenderProps) => <div>{children}</div>;
+    const catalog = defineAtomsCatalog({
+      components: {
+        Text: { props: z.object({}), description: 'Text' },
+        Box: { props: z.object({}), description: 'Box' },
+      },
+      actions: {},
+    });
 
-    const registry = withEditingChromeRegistry({ Text, Box });
+    const registry = withEditingChromeRegistry({ Text, Box }, catalog);
 
     const { container } = render(
       <>

--- a/packages/react/src/atoms/with-editing-chrome.test.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.test.tsx
@@ -77,8 +77,9 @@ describe('withEditingChrome', () => {
     const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
     const close = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="close"]`);
 
-    expect(open?.getAttribute('id')).to.equal('card-1');
+    expect(open?.getAttribute('element-name')).to.equal('card-1');
     expect(open?.getAttribute('type')).to.equal('text/sitecore');
+    expect(open?.getAttribute('atom-type')).to.equal('Stub');
     expect(open?.className).to.equal('scpm');
     expect(close).to.not.be.null;
   });
@@ -119,7 +120,7 @@ describe('withEditingChrome', () => {
     );
 
     const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
-    expect(open?.getAttribute('id')).to.equal('item_2');
+    expect(open?.getAttribute('element-name')).to.equal('item_2');
   });
 
   it('keeps the plain unsuffixed id for the container owning the repeat itself', () => {
@@ -133,7 +134,7 @@ describe('withEditingChrome', () => {
     );
 
     const open = container.querySelector(`code[chrometype="${ATOM_TYPE}"][kind="open"]`);
-    expect(open?.getAttribute('id')).to.equal('list');
+    expect(open?.getAttribute('element-name')).to.equal('list');
   });
 });
 
@@ -161,7 +162,7 @@ describe('withEditingChromeRegistry', () => {
       </>
     );
 
-    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="text-1"]`)).to.not.be.null;
-    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][id="box-1"]`)).to.not.be.null;
+    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="text-1"]`)).to.not.be.null;
+    expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][element-name="box-1"]`)).to.not.be.null;
   });
 });

--- a/packages/react/src/atoms/with-editing-chrome.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.tsx
@@ -68,9 +68,9 @@ export function withEditingChrome(
     const openAttributes = {
       ...baseAttributes,
       kind: MetadataKind.Open,
-      'element-name': indexedElementKey,
-      'atom-type': element.type,
-      ...(componentDefinition?.slots ? { 'atom-slots': JSON.stringify(componentDefinition.slots) } : {}),
+      'data-element-name': indexedElementKey,
+      'data-atom-type': element.type,
+      ...(componentDefinition?.slots ? { 'data-atom-slots': JSON.stringify(componentDefinition.slots) } : {}),
     };
     const closeAttributes = { ...baseAttributes, kind: MetadataKind.Close };
 

--- a/packages/react/src/atoms/with-editing-chrome.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import type { ComponentRegistry, ComponentRenderer, ComponentRenderProps } from '@json-render/react';
 import { useRepeatScope } from '@json-render/react';
+import type { Catalog } from '@json-render/core';
 import type { Document } from '@sitecore-content-sdk/content/atoms';
 import { MetadataKind } from '@sitecore-content-sdk/content/editing';
+import type { AtomsCatalogInput } from './types';
 import { ATOM_TYPE } from './constants';
 
 /**
@@ -45,10 +47,14 @@ export function withElementChromeKeys(doc: Document): Document {
  * Reads the element's flat-spec key (injected by `withElementChromeKeys`) for the chrome id,
  * appending the current repeat index via `useRepeatScope()` when rendered inside a repeat scope.
  * @param {ComponentRenderer} Component - The registry component renderer to wrap
+ * @param {AtomsCatalogInput['components'][string]} [componentDefinition] - The catalog definition for the component
  * @returns {ComponentRenderer} A component renderer that renders the same output surrounded by atom chrome
  * @internal
  */
-export function withEditingChrome(Component: ComponentRenderer): ComponentRenderer {
+export function withEditingChrome(
+  Component: ComponentRenderer,
+  componentDefinition?: AtomsCatalogInput['components'][string]
+): ComponentRenderer {
   const WithEditingChrome = ({ element, ...rest }: ComponentRenderProps) => {
     const repeatScope = useRepeatScope();
     const elementProps = (element.props ?? {}) as Record<string, unknown>;
@@ -65,6 +71,7 @@ export function withEditingChrome(Component: ComponentRenderer): ComponentRender
       kind: MetadataKind.Open,
       'element-name': indexedElementKey,
       'atom-type': element.type,
+      ...(componentDefinition?.slots ? { 'atom-slots': JSON.stringify(componentDefinition.slots) } : {}),
     };
     const closeAttributes = { ...baseAttributes, kind: MetadataKind.Close };
 
@@ -85,14 +92,18 @@ export function withEditingChrome(Component: ComponentRenderer): ComponentRender
 /**
  * Wraps every component in a registry with {@link withEditingChrome}.
  * @param {ComponentRegistry} registry - The registry produced by `defineAtomsRegistry`
+ * @param {Catalog<any, AtomsCatalogInput>} [catalog] - The catalog containing component slot definitions
  * @returns {ComponentRegistry} A new registry with every component wrapped in atom editing chrome
  * @internal
  */
-export function withEditingChromeRegistry(registry: ComponentRegistry): ComponentRegistry {
+export function withEditingChromeRegistry(
+  registry: ComponentRegistry,
+  catalog?: Catalog<any, AtomsCatalogInput>
+): ComponentRegistry {
   const wrapped: ComponentRegistry = {};
 
   for (const [type, Component] of Object.entries(registry)) {
-    wrapped[type] = withEditingChrome(Component);
+    wrapped[type] = withEditingChrome(Component, catalog?.data.components[type]);
   }
 
   return wrapped;

--- a/packages/react/src/atoms/with-editing-chrome.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import type { ComponentRegistry, ComponentRenderer, ComponentRenderProps } from '@json-render/react';
+import { useRepeatScope } from '@json-render/react';
+import type { Document } from '@sitecore-content-sdk/content/atoms';
+import { MetadataKind } from '@sitecore-content-sdk/content/editing';
+import { ATOM_TYPE } from './constants';
+
+/**
+ * Internal prop name used to carry an element's flat-spec key through json-render's renderer,
+ * since `ComponentRenderProps` does not otherwise expose it. Injected by `withElementChromeKeys`
+ * and stripped by `withEditingChrome` before the real atom implementation ever sees it.
+ * @internal
+ */
+export const CHROME_ELEMENT_KEY_PROP = '__csdkChromeElementKey';
+
+/**
+ * Returns a copy of the document where every element's props carry their own flat-spec key
+ * under {@link CHROME_ELEMENT_KEY_PROP}, so `withEditingChrome` can read it at render time.
+ * @param {Document} doc - Component Layout document (flat spec format)
+ * @returns {Document} A shallow copy of `doc` with keys injected into each element's props
+ * @internal
+ */
+export function withElementChromeKeys(doc: Document): Document {
+  if (!doc.elements) {
+    return doc;
+  }
+
+  const elements: Document['elements'] = {};
+
+  for (const [key, element] of Object.entries(doc.elements)) {
+    elements[key] = {
+      ...element,
+      props: { ...(element.props as Record<string, unknown> | undefined), [CHROME_ELEMENT_KEY_PROP]: key },
+    };
+  }
+
+  return { ...doc, elements };
+}
+
+/**
+ * Wraps a registry component renderer with Sitecore editing chrome
+ * (`<code type="text/sitecore" chrometype="atom">`), so every atom is automatically
+ * selectable/editable/draggable in Pages and Design Studio with no developer effort.
+ *
+ * Reads the element's flat-spec key (injected by `withElementChromeKeys`) for the chrome id,
+ * appending the current repeat index via `useRepeatScope()` when rendered inside a repeat scope.
+ * @param {ComponentRenderer} Component - The registry component renderer to wrap
+ * @returns {ComponentRenderer} A component renderer that renders the same output surrounded by atom chrome
+ * @internal
+ */
+export function withEditingChrome(Component: ComponentRenderer): ComponentRenderer {
+  const WithEditingChrome = ({ element, ...rest }: ComponentRenderProps) => {
+    const repeatScope = useRepeatScope();
+    const elementProps = (element.props ?? {}) as Record<string, unknown>;
+    const { [CHROME_ELEMENT_KEY_PROP]: elementKey, ...cleanProps } = elementProps;
+
+    if (typeof elementKey !== 'string') {
+      return <Component element={element} {...rest} />;
+    }
+
+    const chromeId = repeatScope ? `${elementKey}_${repeatScope.index}` : elementKey;
+    const baseAttributes = { type: 'text/sitecore', chrometype: ATOM_TYPE, className: 'scpm' };
+    const openAttributes = { ...baseAttributes, kind: MetadataKind.Open, id: chromeId };
+    const closeAttributes = { ...baseAttributes, kind: MetadataKind.Close };
+
+    return (
+      <>
+        <code {...openAttributes} />
+        <Component element={{ ...element, props: cleanProps }} {...rest} />
+        <code {...closeAttributes} />
+      </>
+    );
+  };
+
+  WithEditingChrome.displayName = `withEditingChrome(${Component.displayName || Component.name || 'Component'})`;
+
+  return WithEditingChrome;
+}
+
+/**
+ * Wraps every component in a registry with {@link withEditingChrome}.
+ * @param {ComponentRegistry} registry - The registry produced by `defineAtomsRegistry`
+ * @returns {ComponentRegistry} A new registry with every component wrapped in atom editing chrome
+ * @internal
+ */
+export function withEditingChromeRegistry(registry: ComponentRegistry): ComponentRegistry {
+  const wrapped: ComponentRegistry = {};
+
+  for (const [type, Component] of Object.entries(registry)) {
+    wrapped[type] = withEditingChrome(Component);
+  }
+
+  return wrapped;
+}

--- a/packages/react/src/atoms/with-editing-chrome.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.tsx
@@ -58,9 +58,14 @@ export function withEditingChrome(Component: ComponentRenderer): ComponentRender
       return <Component element={element} {...rest} />;
     }
 
-    const chromeId = repeatScope ? `${elementKey}_${repeatScope.index}` : elementKey;
+    const indexedElementKey = repeatScope ? `${elementKey}_${repeatScope.index}` : elementKey;
     const baseAttributes = { type: 'text/sitecore', chrometype: ATOM_TYPE, className: 'scpm' };
-    const openAttributes = { ...baseAttributes, kind: MetadataKind.Open, id: chromeId };
+    const openAttributes = {
+      ...baseAttributes,
+      kind: MetadataKind.Open,
+      'element-name': indexedElementKey,
+      'atom-type': element.type,
+    };
     const closeAttributes = { ...baseAttributes, kind: MetadataKind.Close };
 
     return (

--- a/packages/react/src/atoms/with-editing-chrome.tsx
+++ b/packages/react/src/atoms/with-editing-chrome.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import type { ComponentRegistry, ComponentRenderer, ComponentRenderProps } from '@json-render/react';
 import { useRepeatScope } from '@json-render/react';
-import type { Catalog } from '@json-render/core';
 import type { Document } from '@sitecore-content-sdk/content/atoms';
 import { MetadataKind } from '@sitecore-content-sdk/content/editing';
-import type { AtomsCatalogInput } from './types';
+import type { AtomsCatalog, AtomsCatalogInput } from './types';
 import { ATOM_TYPE } from './constants';
 
 /**
@@ -92,18 +91,18 @@ export function withEditingChrome(
 /**
  * Wraps every component in a registry with {@link withEditingChrome}.
  * @param {ComponentRegistry} registry - The registry produced by `defineAtomsRegistry`
- * @param {Catalog<any, AtomsCatalogInput>} [catalog] - The catalog containing component slot definitions
+ * @param {AtomsCatalog} catalog - The catalog containing component slot definitions
  * @returns {ComponentRegistry} A new registry with every component wrapped in atom editing chrome
  * @internal
  */
 export function withEditingChromeRegistry(
   registry: ComponentRegistry,
-  catalog?: Catalog<any, AtomsCatalogInput>
+  catalog: AtomsCatalog
 ): ComponentRegistry {
   const wrapped: ComponentRegistry = {};
 
   for (const [type, Component] of Object.entries(registry)) {
-    wrapped[type] = withEditingChrome(Component, catalog?.data.components[type]);
+    wrapped[type] = withEditingChrome(Component, catalog.data.components[type]);
   }
 
   return wrapped;

--- a/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.test.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.test.tsx
@@ -184,7 +184,7 @@ describe('<DesignLibraryLowCodeComponent />', () => {
     expect(openChrome).to.not.be.null;
     expect(closeChrome).to.not.be.null;
     expect(openChrome?.getAttribute('data-csdk-component-runtime')).to.equal('client');
-    expect(openChrome?.getAttribute('component-type')).to.equal(ATOM_TYPE);
+    expect(openChrome?.getAttribute('data-component-type')).to.equal(ATOM_TYPE);
   });
 
   it('subscribes to component props update handler', async () => {
@@ -221,7 +221,7 @@ describe('<DesignLibraryLowCodeComponent />', () => {
       expect(codeBlocks[0].getAttribute('chrometype')).to.equal('rendering');
       expect(codeBlocks[0].getAttribute('id')).to.equal('design-library-low-code-component');
       expect(codeBlocks[0].getAttribute('data-csdk-component-runtime')).to.equal('client');
-      expect(codeBlocks[0].getAttribute('component-type')).to.equal(ATOM_TYPE);
+      expect(codeBlocks[0].getAttribute('data-component-type')).to.equal(ATOM_TYPE);
     });
   });
 

--- a/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.test.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.test.tsx
@@ -14,6 +14,7 @@ import {
   getDesignLibraryStatusEvent,
 } from '@sitecore-content-sdk/content/editing';
 import type { AtomsConfig } from '../../atoms/types';
+import { ATOM_TYPE } from '../../atoms/constants';
 import type { ImportMapImport } from './models';
 import type { DefineRegistryResult } from '@json-render/react';
 
@@ -183,6 +184,7 @@ describe('<DesignLibraryLowCodeComponent />', () => {
     expect(openChrome).to.not.be.null;
     expect(closeChrome).to.not.be.null;
     expect(openChrome?.getAttribute('data-csdk-component-runtime')).to.equal('client');
+    expect(openChrome?.getAttribute('component-type')).to.equal(ATOM_TYPE);
   });
 
   it('subscribes to component props update handler', async () => {
@@ -219,6 +221,7 @@ describe('<DesignLibraryLowCodeComponent />', () => {
       expect(codeBlocks[0].getAttribute('chrometype')).to.equal('rendering');
       expect(codeBlocks[0].getAttribute('id')).to.equal('design-library-low-code-component');
       expect(codeBlocks[0].getAttribute('data-csdk-component-runtime')).to.equal('client');
+      expect(codeBlocks[0].getAttribute('component-type')).to.equal(ATOM_TYPE);
     });
   });
 

--- a/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.tsx
@@ -45,7 +45,7 @@ export const __mockDependencies = (mocks: any) => {
  * - When `atomsConfig.compileCssAction` is provided, compiles Document class names and injects CSS so
  * utilities that exist only in MMS Document JSON are styled during editing.
  * - Wraps preview output with `PlaceholderMetadata` using the layout rendering UID so Design Studio
- * receives the same chrome handshake as normal Design Library components. Adds `component-type="atom"`
+ * receives the same chrome handshake as normal Design Library components. Adds `data-component-type="atom"`
  * to that wrap so Sitecore Pages can skip the whole Atoms subtree by ancestor when querying chrome.
  * @returns {JSX.Element} The low-code preview surface.
  * @internal

--- a/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.tsx
+++ b/packages/react/src/components/DesignLibrary/DesignLibraryLowCodeComponent.tsx
@@ -10,6 +10,7 @@ import * as atoms from '@sitecore-content-sdk/content/atoms';
 import { debug } from '@sitecore-content-sdk/content';
 import { DesignLibraryErrorBoundary, PlaceholderMetadata } from '../..';
 import type { ChildComponentProps } from '../Placeholder/models';
+import { ATOM_TYPE } from '../../atoms/constants';
 
 let { postToDesignLibrary, getDesignLibraryStatusEvent, DesignLibraryStatus } = editing;
 let {
@@ -44,7 +45,8 @@ export const __mockDependencies = (mocks: any) => {
  * - When `atomsConfig.compileCssAction` is provided, compiles Document class names and injects CSS so
  * utilities that exist only in MMS Document JSON are styled during editing.
  * - Wraps preview output with `PlaceholderMetadata` using the layout rendering UID so Design Studio
- * receives the same chrome handshake as normal Design Library components.
+ * receives the same chrome handshake as normal Design Library components. Adds `component-type="atom"`
+ * to that wrap so Sitecore Pages can skip the whole Atoms subtree by ancestor when querying chrome.
  * @returns {JSX.Element} The low-code preview surface.
  * @internal
  */
@@ -125,7 +127,11 @@ export const DesignLibraryLowCodeComponent = () => {
   return (
     <DesignLibraryErrorBoundary uid={uid} renderKey={renderKey}>
       {documentCss ? <style dangerouslySetInnerHTML={{ __html: documentCss }} /> : null}
-      <PlaceholderMetadata rendering={{ uid: uid, componentName: uid }} componentRuntime="client">
+      <PlaceholderMetadata
+        rendering={{ uid: uid, componentName: uid }}
+        componentRuntime="client"
+        componentType={ATOM_TYPE}
+      >
         <StudioComponentWrapper document={currentDocument} fields={fields} params={params} />
       </PlaceholderMetadata>
     </DesignLibraryErrorBoundary>

--- a/packages/react/src/components/DesignLibrary/StudioComponentWrapper.tsx
+++ b/packages/react/src/components/DesignLibrary/StudioComponentWrapper.tsx
@@ -35,7 +35,7 @@ export const StudioComponentWrapper = ({
   const NCComponent = useMemo(() => {
     if (!document || !atomsConfig) return null;
 
-    return createNCC(document, atomsConfig.registry);
+    return createNCC(document, atomsConfig.registry, atomsConfig.catalog);
   }, [document, atomsConfig]);
 
   if (!NCComponent) return null;

--- a/packages/react/src/components/Placeholder/PlaceholderMetadata.tsx
+++ b/packages/react/src/components/Placeholder/PlaceholderMetadata.tsx
@@ -17,6 +17,12 @@ export interface PlaceholderMetadataProps {
    * Component runtime type. Used to add data-csdk-component-runtime attribute to rendering chromes
    */
   componentRuntime?: 'server' | 'client';
+  /**
+   * Adds a `component-type` attribute to the outer rendering chrome, so Sitecore Pages can
+   * identify (and skip nested chrome queries within) a whole subtree by ancestor, e.g. `"atom"`
+   * for the Atoms low-code wrapper.
+   */
+  componentType?: string;
 }
 
 export type CodeBlockAttributes = {
@@ -26,6 +32,7 @@ export type CodeBlockAttributes = {
   kind: string;
   id?: string;
   'data-csdk-component-runtime'?: 'server' | 'client';
+  'component-type'?: string;
 };
 
 /**
@@ -36,6 +43,7 @@ export type CodeBlockAttributes = {
  * @param {ComponentRendering} props.rendering The rendering data.
  * @param {string} [props.placeholderName] The name of the placeholder.
  * @param {'server' | 'client'} [props.componentRuntime] Component runtime type. Used to add data-csdk-component-runtime attribute to rendering chromes.
+ * @param {string} [props.componentType] Adds a component-type attribute to the outer rendering chrome (e.g. "atom").
  * @param {JSX.Element} props.children The child components or elements to be wrapped by the metadata code blocks.
  * @returns {JSX.Element} A React fragment containing open and close code blocks surrounding the children elements.
  * @internal
@@ -45,6 +53,7 @@ export const PlaceholderMetadata = ({
   placeholderName,
   children,
   componentRuntime,
+  componentType,
 }: PlaceholderMetadataProps): JSX.Element => {
   const getCodeBlockAttributes = ({
     kind,
@@ -96,6 +105,10 @@ export const PlaceholderMetadata = ({
       // Add component runtime attribute for rendering chromes
       if (chrometype === 'rendering' && componentRuntime) {
         attributes['data-csdk-component-runtime'] = componentRuntime;
+      }
+
+      if (componentType) {
+        attributes['component-type'] = componentType;
       }
     }
 

--- a/packages/react/src/components/Placeholder/PlaceholderMetadata.tsx
+++ b/packages/react/src/components/Placeholder/PlaceholderMetadata.tsx
@@ -18,7 +18,7 @@ export interface PlaceholderMetadataProps {
    */
   componentRuntime?: 'server' | 'client';
   /**
-   * Adds a `component-type` attribute to the outer rendering chrome, so Sitecore Pages can
+   * Adds a `data-component-type` attribute to the outer rendering chrome, so Sitecore Pages can
    * identify (and skip nested chrome queries within) a whole subtree by ancestor, e.g. `"atom"`
    * for the Atoms low-code wrapper.
    */
@@ -32,7 +32,7 @@ export type CodeBlockAttributes = {
   kind: string;
   id?: string;
   'data-csdk-component-runtime'?: 'server' | 'client';
-  'component-type'?: string;
+  'data-component-type'?: string;
 };
 
 /**
@@ -43,7 +43,7 @@ export type CodeBlockAttributes = {
  * @param {ComponentRendering} props.rendering The rendering data.
  * @param {string} [props.placeholderName] The name of the placeholder.
  * @param {'server' | 'client'} [props.componentRuntime] Component runtime type. Used to add data-csdk-component-runtime attribute to rendering chromes.
- * @param {string} [props.componentType] Adds a component-type attribute to the outer rendering chrome (e.g. "atom").
+ * @param {string} [props.componentType] Adds a data-component-type attribute to the outer rendering chrome (e.g. "atom").
  * @param {JSX.Element} props.children The child components or elements to be wrapped by the metadata code blocks.
  * @returns {JSX.Element} A React fragment containing open and close code blocks surrounding the children elements.
  * @internal
@@ -108,7 +108,7 @@ export const PlaceholderMetadata = ({
       }
 
       if (componentType) {
-        attributes['component-type'] = componentType;
+        attributes['data-component-type'] = componentType;
       }
     }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -120,6 +120,7 @@ export {
   type PropMeta,
   type AtomComponentDefinition,
   type AtomActionDefinition,
+  type AtomsCatalog,
   type AtomsCatalogInput,
   type AtomsComponentsMap,
   type AtomActionHandler,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
**Atoms Editing Chrome — Phase 1 (`chrometype="atom"`)**

- Every rendered Atom now automatically gets wrapped in `<code type="text/sitecore"
  chrometype="atom">` chrome (via a new internal `withEditingChrome`/`withElementChromeKeys` pair
  wired into `createNCC`), so Atoms become selectable/editable/draggable in Design Studio
  with zero developer effort.
- Repeated atoms (rendered via `repeat`) get a distinct chrome id per row by suffixing the
  element's flat-spec key with the current repeat index from `useRepeatScope()`; the opening
  chrome block exposes this value as `data-element-name`, while the repeat's owning container keeps
  its plain, unsuffixed name.
- The opening atom chrome block exposes the registry element type as `data-atom-type`, allowing Design Studio to identify the atom implementation directly.
- Catalog-defined slot names are serialized as JSON in the opening block's `data-atom-slots` attribute,
  preserving the named slots declared by each atom definition for the editing experience.
- The existing top-level `PlaceholderMetadata` wrap in `DesignLibraryLowCodeComponent` now carries
  `data-component-type="atom"`, so Sitecore Pages' chrome selector can skip the whole Atoms subtree by
  ancestor instead of needing a per-kind naming convention.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
