### PR TITLE
[react] Enable atom chromes only in edit mode

### DIFF
--- a/.changeset/bumpy-lights-notice.md
+++ b/.changeset/bumpy-lights-notice.md
@@ -1,0 +1,5 @@
+---
+'@sitecore-content-sdk/react': patch
+---
+
+Enable chromes only in editing mode

--- a/packages/react/src/atoms/create-ncc.test.tsx
+++ b/packages/react/src/atoms/create-ncc.test.tsx
@@ -129,13 +129,49 @@ describe('create-ncc', () => {
         <SitecoreProvider
           api={{} as any}
           componentMap={new Map()}
-          page={{ locale: 'en', layout: { sitecore: { context: {}, route: null } } } as any}
+          page={
+            {
+              locale: 'en',
+              mode: { isEditing: true },
+              layout: { sitecore: { context: {}, route: null } },
+            } as any
+          }
           loadImportMap={async () => ({} as any)}
           atomsConfig={{ catalog, registry }}
         >
           {ui}
         </SitecoreProvider>
       );
+
+    it('does not render chrome when the page is not in editing mode', () => {
+      const doc: Document = {
+        name: 'chrome-doc',
+        root: 'card-el',
+        elements: {
+          'card-el': { type: 'Card', props: { title: 'Hello' } },
+        },
+      };
+      const View = createNCC(doc, registry, catalog);
+      const { container } = render(
+        <SitecoreProvider
+          api={{} as any}
+          componentMap={new Map()}
+          page={
+            {
+              locale: 'en',
+              mode: { isEditing: false },
+              layout: { sitecore: { context: {}, route: null } },
+            } as any
+          }
+          loadImportMap={async () => ({} as any)}
+          atomsConfig={{ catalog, registry }}
+        >
+          <View />
+        </SitecoreProvider>
+      );
+
+      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"]`)).to.be.null;
+    });
 
     it('wraps every rendered atom with chrometype="atom" chrome using the element key', () => {
       const doc: Document = {
@@ -149,8 +185,12 @@ describe('create-ncc', () => {
       const View = createNCC(doc, registry, catalog);
       const { container } = renderInProvider(<View />);
 
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="list-el"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el"]`)).to.not.be.null;
+      expect(
+        container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="list-el"]`)
+      ).to.not.be.null;
+      expect(
+        container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el"]`)
+      ).to.not.be.null;
     });
 
     it('suffixes repeated atoms with the repeat index and keeps the repeat owner unsuffixed', () => {
@@ -171,9 +211,15 @@ describe('create-ncc', () => {
       const View = createNCC(doc, registry, catalog);
       const { container } = renderInProvider(<View />);
 
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="list-el"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el_0"]`)).to.not.be.null;
-      expect(container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el_1"]`)).to.not.be.null;
+      expect(
+        container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="list-el"]`)
+      ).to.not.be.null;
+      expect(
+        container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el_0"]`)
+      ).to.not.be.null;
+      expect(
+        container.querySelector(`code[chrometype="${ATOM_TYPE}"][data-element-name="card-el_1"]`)
+      ).to.not.be.null;
     });
   });
 });

--- a/packages/react/src/atoms/create-ncc.tsx
+++ b/packages/react/src/atoms/create-ncc.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { type FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useMemo, useState } from 'react';
 import {
   Renderer,
   StateProvider,
@@ -41,15 +41,21 @@ export function createNCC(
   catalog: AtomsCatalog
 ): FC<NCCProps> {
   const { registry, handlers } = registryResult;
-  const chromeDoc = withElementChromeKeys(doc);
-  const chromeRegistry = withEditingChromeRegistry(registry, catalog);
 
   const initialState: StateModel = {
     ...(doc.state ?? {}),
   };
 
   const Generated: FC<NCCProps> = ({ fields, params }) => {
-    const { atomsConfig } = useSitecore();
+    const { atomsConfig, page } = useSitecore();
+    // Chrome (`<code type="text/sitecore">`) is only meaningful to Design Studio/Pages, so it
+    // must not leak into normal (non-editing) rendered output.
+    const isEditing = page?.mode?.isEditing ?? false;
+    const spec = useMemo(() => (isEditing ? withElementChromeKeys(doc) : doc), [isEditing]);
+    const renderRegistry = useMemo(
+      () => (isEditing ? withEditingChromeRegistry(registry, catalog) : registry),
+      [isEditing]
+    );
     const [store] = useState(() =>
       createStateStore({
         ...initialState,
@@ -75,12 +81,15 @@ export function createNCC(
     );
 
     return (
-      <div className={`component${params?.styles ? ` ${params.styles}` : ''}`} id={params?.RenderingIdentifier || ''}>
+      <div
+        className={`component${params?.styles ? ` ${params.styles}` : ''}`}
+        id={params?.RenderingIdentifier || ''}
+      >
         <StateProvider store={store}>
           <VisibilityProvider>
             <ActionProvider handlers={resolvedHandlers} navigate={atomsConfig?.navigate}>
               <ValidationProvider>
-                <Renderer spec={chromeDoc} registry={chromeRegistry} />
+                <Renderer spec={spec} registry={renderRegistry} />
               </ValidationProvider>
             </ActionProvider>
           </VisibilityProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/content-sdk/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Followup to the previous PR for JSS-10208 that enables the chromes only in edit mode

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
